### PR TITLE
Support Pasta curves.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,5 @@ rayon = "1.3.0"
 rand_core = { version = "0.5", default-features = false }
 itertools = "0.9.0"
 subtle = "2.4"
+pasta_curves = "0.2.1"
 
-[dev-dependencies]
-curve25519-dalek = {version = "3.0.0", features = ["simd_backend"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["zkSNARKs", "cryptography", "proofs"]
 
 [dependencies]
 merlin = "2.0.0"
-rand = "0.7.3"
+rand = "0.8.4"
 digest = "0.8.1"
 sha3 = "0.8.2"
 rayon = "1.3.0"
@@ -20,4 +20,3 @@ rand_core = { version = "0.5", default-features = false }
 itertools = "0.9.0"
 subtle = "2.4"
 pasta_curves = "0.2.1"
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(non_snake_case)]
 #![allow(clippy::type_complexity)]
 #![feature(test)]
-//#![deny(missing_docs)]
+#![deny(missing_docs)]
 
 mod commitments;
 pub mod errors;
@@ -102,7 +102,7 @@ impl<G: Group> StepSNARK<G> {
 
 /// A SNARK that holds the proof of the final step of an incremental computation
 pub struct FinalSNARK<G: Group> {
-  pub W: R1CSWitness<G>,
+  W: R1CSWitness<G>,
 }
 
 impl<G: Group> FinalSNARK<G> {
@@ -126,12 +126,11 @@ impl<G: Group> FinalSNARK<G> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::pasta::{PallasPoint, PallasScalar};
   use crate::traits::PrimeField;
   use rand::rngs::OsRng;
 
-  type S = PallasScalar;
-  type G = PallasPoint;
+  type S = pasta_curves::pallas::Scalar;
+  type G = pasta_curves::pallas::Point;
 
   #[test]
   fn test_tiny_r1cs() {

--- a/src/pasta.rs
+++ b/src/pasta.rs
@@ -1,3 +1,4 @@
+//! This module implements the Nova traits for pallas::Point and pallas::Scalar.
 use crate::traits::{ChallengeTrait, CompressedGroup, Group, PrimeField};
 use merlin::Transcript;
 use pasta_curves::arithmetic::{CurveExt, FieldExt, Group as Grp};
@@ -6,12 +7,6 @@ use pasta_curves::{self, pallas, Ep, Fq};
 use rand::{CryptoRng, RngCore};
 use std::borrow::Borrow;
 use std::ops::Mul;
-
-pub type PallasPoint = pallas::Point;
-pub type PallasScalar = pallas::Scalar;
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct PallasCompressedPoint(<pallas::Point as GroupEncoding>::Repr);
 
 impl Group for pallas::Point {
   type Scalar = pallas::Scalar;

--- a/src/pasta.rs
+++ b/src/pasta.rs
@@ -1,0 +1,269 @@
+use crate::traits::{ChallengeTrait, CompressedGroup, Group, PrimeField};
+use merlin::Transcript;
+use pasta_curves::arithmetic::{CurveExt, FieldExt, Group as Grp};
+use pasta_curves::group::GroupEncoding;
+use pasta_curves::{self, pallas, Ep, Fq};
+use rand::{CryptoRng, RngCore};
+use std::borrow::Borrow;
+use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PallasPoint(pallas::Point);
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PallasScalar(pallas::Scalar);
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PallasCompressedPoint(<pallas::Point as GroupEncoding>::Repr);
+
+impl Group for PallasPoint {
+  type Scalar = PallasScalar;
+  type CompressedGroupElement = PallasCompressedPoint;
+
+  fn vartime_multiscalar_mul<I, J>(scalars: I, points: J) -> Self
+  where
+    I: IntoIterator,
+    I::Item: Borrow<Self::Scalar>,
+    J: IntoIterator,
+    J::Item: Borrow<Self>,
+    Self: Clone,
+  {
+    // Unoptimized.
+    scalars
+      .into_iter()
+      .zip(points)
+      .map(|(scalar, point)| (*point.borrow()).mul(*scalar.borrow()))
+      .fold(PallasPoint(Ep::group_zero()), |acc, x| acc + x)
+  }
+
+  fn compress(&self) -> Self::CompressedGroupElement {
+    PallasCompressedPoint(self.0.to_bytes())
+  }
+
+  fn from_uniform_bytes(bytes: &[u8]) -> Option<Self> {
+    if bytes.len() != 64 {
+      None
+    } else {
+      let mut arr = [0; 32];
+      arr.copy_from_slice(&bytes[0..32]);
+
+      let hash = Ep::hash_to_curve("from_uniform_bytes");
+      Some(Self(hash(&arr)))
+    }
+  }
+}
+
+impl PrimeField for PallasScalar {
+  fn zero() -> Self {
+    Self(Fq::zero())
+  }
+  fn one() -> Self {
+    Self(Fq::one())
+  }
+  fn from_bytes_mod_order_wide(bytes: &[u8]) -> Option<Self> {
+    if bytes.len() != 64 {
+      None
+    } else {
+      let mut arr = [0; 64];
+      arr.copy_from_slice(&bytes[0..64]);
+      Some(Self(Fq::from_bytes_wide(&arr)))
+    }
+  }
+
+  fn random(_rng: &mut (impl RngCore + CryptoRng)) -> Self {
+    Self(Fq::rand())
+  }
+}
+
+impl From<Fq> for PallasScalar {
+  fn from(s: Fq) -> Self {
+    Self(s)
+  }
+}
+
+impl ChallengeTrait for PallasScalar {
+  fn challenge(label: &'static [u8], transcript: &mut Transcript) -> Self {
+    let mut buf = [0u8; 64];
+    transcript.challenge_bytes(label, &mut buf);
+    PallasScalar::from_bytes_mod_order_wide(&buf).unwrap()
+  }
+}
+
+impl CompressedGroup for PallasCompressedPoint {
+  type GroupElement = PallasPoint;
+  fn decompress(&self) -> Option<<Self as CompressedGroup>::GroupElement> {
+    Some(PallasPoint(Ep::from_bytes(&self.0).unwrap()))
+  }
+  fn as_bytes(&self) -> &[u8] {
+    &self.0
+  }
+}
+
+impl Add<PallasPoint> for PallasPoint {
+  type Output = PallasPoint;
+
+  fn add(self, x: PallasPoint) -> PallasPoint {
+    Self(self.0.add(x.0))
+  }
+}
+
+impl<'r> Add<&'r PallasPoint> for PallasPoint {
+  type Output = PallasPoint;
+
+  fn add(self, x: &PallasPoint) -> PallasPoint {
+    Self(self.0.add(x.0))
+  }
+}
+
+impl AddAssign<PallasPoint> for PallasPoint {
+  fn add_assign(&mut self, x: PallasPoint) {
+    self.0.add_assign(x.0);
+  }
+}
+
+impl<'r> AddAssign<&'r PallasPoint> for PallasPoint {
+  fn add_assign(&mut self, x: &PallasPoint) {
+    self.0.add_assign(x.0);
+  }
+}
+
+impl Sub<PallasPoint> for PallasPoint {
+  type Output = PallasPoint;
+
+  fn sub(self, x: PallasPoint) -> PallasPoint {
+    Self(self.0.sub(x.0))
+  }
+}
+
+impl<'r> Sub<&'r PallasPoint> for PallasPoint {
+  type Output = PallasPoint;
+
+  fn sub(self, x: &PallasPoint) -> PallasPoint {
+    Self(self.0.sub(x.0))
+  }
+}
+impl SubAssign<PallasPoint> for PallasPoint {
+  fn sub_assign(&mut self, x: PallasPoint) {
+    self.0.sub_assign(x.0);
+  }
+}
+impl<'r> SubAssign<&'r PallasPoint> for PallasPoint {
+  fn sub_assign(&mut self, x: &PallasPoint) {
+    self.0.sub_assign(x.0);
+  }
+}
+
+impl Mul<PallasScalar> for PallasPoint {
+  type Output = PallasPoint;
+
+  fn mul(self, x: PallasScalar) -> PallasPoint {
+    Self(self.0.mul(x.0))
+  }
+}
+
+impl<'r> Mul<&'r PallasScalar> for PallasPoint {
+  type Output = PallasPoint;
+
+  fn mul(self, x: &PallasScalar) -> PallasPoint {
+    Self(self.0.mul(x.0))
+  }
+}
+
+impl MulAssign<PallasScalar> for PallasPoint {
+  fn mul_assign(&mut self, x: PallasScalar) {
+    self.0.mul_assign(x.0);
+  }
+}
+impl<'r> MulAssign<&'r PallasScalar> for PallasPoint {
+  fn mul_assign(&mut self, x: &PallasScalar) {
+    self.0.mul_assign(x.0);
+  }
+}
+
+impl Add<PallasScalar> for PallasScalar {
+  type Output = PallasScalar;
+
+  fn add(self, x: PallasScalar) -> PallasScalar {
+    Self(self.0.add(x.0))
+  }
+}
+
+impl<'r> Add<&'r PallasScalar> for PallasScalar {
+  type Output = PallasScalar;
+
+  fn add(self, x: &PallasScalar) -> PallasScalar {
+    Self(self.0.add(x.0))
+  }
+}
+
+impl AddAssign<PallasScalar> for PallasScalar {
+  fn add_assign(&mut self, x: PallasScalar) {
+    self.0.add_assign(x.0);
+  }
+}
+
+impl<'r> AddAssign<&'r PallasScalar> for PallasScalar {
+  fn add_assign(&mut self, x: &PallasScalar) {
+    self.0.add_assign(x.0);
+  }
+}
+
+impl Sub<PallasScalar> for PallasScalar {
+  type Output = PallasScalar;
+
+  fn sub(self, x: PallasScalar) -> PallasScalar {
+    Self(self.0.sub(x.0))
+  }
+}
+
+impl<'r> Sub<&'r PallasScalar> for PallasScalar {
+  type Output = PallasScalar;
+
+  fn sub(self, x: &PallasScalar) -> PallasScalar {
+    Self(self.0.sub(x.0))
+  }
+}
+impl SubAssign<PallasScalar> for PallasScalar {
+  fn sub_assign(&mut self, x: PallasScalar) {
+    self.0.sub_assign(x.0)
+  }
+}
+impl<'r> SubAssign<&'r PallasScalar> for PallasScalar {
+  fn sub_assign(&mut self, x: &PallasScalar) {
+    self.0.sub_assign(x.0)
+  }
+}
+
+impl Mul<PallasScalar> for PallasScalar {
+  type Output = PallasScalar;
+
+  fn mul(self, x: PallasScalar) -> PallasScalar {
+    Self(self.0.mul(x.0))
+  }
+}
+
+impl<'r> Mul<&'r PallasScalar> for PallasScalar {
+  type Output = PallasScalar;
+
+  fn mul(self, x: &PallasScalar) -> PallasScalar {
+    Self(self.0.mul(x.0))
+  }
+}
+
+impl MulAssign<PallasScalar> for PallasScalar {
+  fn mul_assign(&mut self, x: PallasScalar) {
+    self.0.mul_assign(x.0)
+  }
+}
+impl<'r> MulAssign<&'r PallasScalar> for PallasScalar {
+  fn mul_assign(&mut self, x: &PallasScalar) {
+    self.0.mul_assign(x.0)
+  }
+}
+
+impl Neg for PallasScalar {
+  type Output = Self;
+  fn neg(self) -> Self {
+    Self(self.0.neg())
+  }
+}

--- a/src/pasta.rs
+++ b/src/pasta.rs
@@ -5,20 +5,17 @@ use pasta_curves::group::GroupEncoding;
 use pasta_curves::{self, pallas, Ep, Fq};
 use rand::{CryptoRng, RngCore};
 use std::borrow::Borrow;
-use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use std::ops::Mul;
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct PallasPoint(pallas::Point);
-
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub struct PallasScalar(pallas::Scalar);
+pub type PallasPoint = pallas::Point;
+pub type PallasScalar = pallas::Scalar;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PallasCompressedPoint(<pallas::Point as GroupEncoding>::Repr);
 
-impl Group for PallasPoint {
-  type Scalar = PallasScalar;
-  type CompressedGroupElement = PallasCompressedPoint;
+impl Group for pallas::Point {
+  type Scalar = pallas::Scalar;
+  type CompressedGroupElement = <pallas::Point as GroupEncoding>::Repr;
 
   fn vartime_multiscalar_mul<I, J>(scalars: I, points: J) -> Self
   where
@@ -33,11 +30,11 @@ impl Group for PallasPoint {
       .into_iter()
       .zip(points)
       .map(|(scalar, point)| (*point.borrow()).mul(*scalar.borrow()))
-      .fold(PallasPoint(Ep::group_zero()), |acc, x| acc + x)
+      .fold(Ep::group_zero(), |acc, x| acc + x)
   }
 
   fn compress(&self) -> Self::CompressedGroupElement {
-    PallasCompressedPoint(self.0.to_bytes())
+    self.to_bytes()
   }
 
   fn from_uniform_bytes(bytes: &[u8]) -> Option<Self> {
@@ -48,17 +45,17 @@ impl Group for PallasPoint {
       arr.copy_from_slice(&bytes[0..32]);
 
       let hash = Ep::hash_to_curve("from_uniform_bytes");
-      Some(Self(hash(&arr)))
+      Some(hash(&arr))
     }
   }
 }
 
-impl PrimeField for PallasScalar {
+impl PrimeField for pallas::Scalar {
   fn zero() -> Self {
-    Self(Fq::zero())
+    Fq::zero()
   }
   fn one() -> Self {
-    Self(Fq::one())
+    Fq::one()
   }
   fn from_bytes_mod_order_wide(bytes: &[u8]) -> Option<Self> {
     if bytes.len() != 64 {
@@ -66,204 +63,29 @@ impl PrimeField for PallasScalar {
     } else {
       let mut arr = [0; 64];
       arr.copy_from_slice(&bytes[0..64]);
-      Some(Self(Fq::from_bytes_wide(&arr)))
+      Some(Fq::from_bytes_wide(&arr))
     }
   }
 
   fn random(_rng: &mut (impl RngCore + CryptoRng)) -> Self {
-    Self(Fq::rand())
+    Fq::rand()
   }
 }
 
-impl From<Fq> for PallasScalar {
-  fn from(s: Fq) -> Self {
-    Self(s)
-  }
-}
-
-impl ChallengeTrait for PallasScalar {
+impl ChallengeTrait for pallas::Scalar {
   fn challenge(label: &'static [u8], transcript: &mut Transcript) -> Self {
     let mut buf = [0u8; 64];
     transcript.challenge_bytes(label, &mut buf);
-    PallasScalar::from_bytes_mod_order_wide(&buf).unwrap()
+    pallas::Scalar::from_bytes_mod_order_wide(&buf).unwrap()
   }
 }
 
-impl CompressedGroup for PallasCompressedPoint {
-  type GroupElement = PallasPoint;
+impl CompressedGroup for <pallas::Point as GroupEncoding>::Repr {
+  type GroupElement = pallas::Point;
   fn decompress(&self) -> Option<<Self as CompressedGroup>::GroupElement> {
-    Some(PallasPoint(Ep::from_bytes(&self.0).unwrap()))
+    Some(Ep::from_bytes(&self).unwrap())
   }
   fn as_bytes(&self) -> &[u8] {
-    &self.0
-  }
-}
-
-impl Add<PallasPoint> for PallasPoint {
-  type Output = PallasPoint;
-
-  fn add(self, x: PallasPoint) -> PallasPoint {
-    Self(self.0.add(x.0))
-  }
-}
-
-impl<'r> Add<&'r PallasPoint> for PallasPoint {
-  type Output = PallasPoint;
-
-  fn add(self, x: &PallasPoint) -> PallasPoint {
-    Self(self.0.add(x.0))
-  }
-}
-
-impl AddAssign<PallasPoint> for PallasPoint {
-  fn add_assign(&mut self, x: PallasPoint) {
-    self.0.add_assign(x.0);
-  }
-}
-
-impl<'r> AddAssign<&'r PallasPoint> for PallasPoint {
-  fn add_assign(&mut self, x: &PallasPoint) {
-    self.0.add_assign(x.0);
-  }
-}
-
-impl Sub<PallasPoint> for PallasPoint {
-  type Output = PallasPoint;
-
-  fn sub(self, x: PallasPoint) -> PallasPoint {
-    Self(self.0.sub(x.0))
-  }
-}
-
-impl<'r> Sub<&'r PallasPoint> for PallasPoint {
-  type Output = PallasPoint;
-
-  fn sub(self, x: &PallasPoint) -> PallasPoint {
-    Self(self.0.sub(x.0))
-  }
-}
-impl SubAssign<PallasPoint> for PallasPoint {
-  fn sub_assign(&mut self, x: PallasPoint) {
-    self.0.sub_assign(x.0);
-  }
-}
-impl<'r> SubAssign<&'r PallasPoint> for PallasPoint {
-  fn sub_assign(&mut self, x: &PallasPoint) {
-    self.0.sub_assign(x.0);
-  }
-}
-
-impl Mul<PallasScalar> for PallasPoint {
-  type Output = PallasPoint;
-
-  fn mul(self, x: PallasScalar) -> PallasPoint {
-    Self(self.0.mul(x.0))
-  }
-}
-
-impl<'r> Mul<&'r PallasScalar> for PallasPoint {
-  type Output = PallasPoint;
-
-  fn mul(self, x: &PallasScalar) -> PallasPoint {
-    Self(self.0.mul(x.0))
-  }
-}
-
-impl MulAssign<PallasScalar> for PallasPoint {
-  fn mul_assign(&mut self, x: PallasScalar) {
-    self.0.mul_assign(x.0);
-  }
-}
-impl<'r> MulAssign<&'r PallasScalar> for PallasPoint {
-  fn mul_assign(&mut self, x: &PallasScalar) {
-    self.0.mul_assign(x.0);
-  }
-}
-
-impl Add<PallasScalar> for PallasScalar {
-  type Output = PallasScalar;
-
-  fn add(self, x: PallasScalar) -> PallasScalar {
-    Self(self.0.add(x.0))
-  }
-}
-
-impl<'r> Add<&'r PallasScalar> for PallasScalar {
-  type Output = PallasScalar;
-
-  fn add(self, x: &PallasScalar) -> PallasScalar {
-    Self(self.0.add(x.0))
-  }
-}
-
-impl AddAssign<PallasScalar> for PallasScalar {
-  fn add_assign(&mut self, x: PallasScalar) {
-    self.0.add_assign(x.0);
-  }
-}
-
-impl<'r> AddAssign<&'r PallasScalar> for PallasScalar {
-  fn add_assign(&mut self, x: &PallasScalar) {
-    self.0.add_assign(x.0);
-  }
-}
-
-impl Sub<PallasScalar> for PallasScalar {
-  type Output = PallasScalar;
-
-  fn sub(self, x: PallasScalar) -> PallasScalar {
-    Self(self.0.sub(x.0))
-  }
-}
-
-impl<'r> Sub<&'r PallasScalar> for PallasScalar {
-  type Output = PallasScalar;
-
-  fn sub(self, x: &PallasScalar) -> PallasScalar {
-    Self(self.0.sub(x.0))
-  }
-}
-impl SubAssign<PallasScalar> for PallasScalar {
-  fn sub_assign(&mut self, x: PallasScalar) {
-    self.0.sub_assign(x.0)
-  }
-}
-impl<'r> SubAssign<&'r PallasScalar> for PallasScalar {
-  fn sub_assign(&mut self, x: &PallasScalar) {
-    self.0.sub_assign(x.0)
-  }
-}
-
-impl Mul<PallasScalar> for PallasScalar {
-  type Output = PallasScalar;
-
-  fn mul(self, x: PallasScalar) -> PallasScalar {
-    Self(self.0.mul(x.0))
-  }
-}
-
-impl<'r> Mul<&'r PallasScalar> for PallasScalar {
-  type Output = PallasScalar;
-
-  fn mul(self, x: &PallasScalar) -> PallasScalar {
-    Self(self.0.mul(x.0))
-  }
-}
-
-impl MulAssign<PallasScalar> for PallasScalar {
-  fn mul_assign(&mut self, x: PallasScalar) {
-    self.0.mul_assign(x.0)
-  }
-}
-impl<'r> MulAssign<&'r PallasScalar> for PallasScalar {
-  fn mul_assign(&mut self, x: &PallasScalar) {
-    self.0.mul_assign(x.0)
-  }
-}
-
-impl Neg for PallasScalar {
-  type Output = Self;
-  fn neg(self) -> Self {
-    Self(self.0.neg())
+    self
   }
 }


### PR DESCRIPTION
Now that https://github.com/zcash/pasta_curves is licensed under MIT/Apache, we can depend on it directly here. This simplifies trait definitions (which previously had to be wrapped, with duplicate implementations of standard operations, when providing) for pasta curves.

I removed the dev dependency on Ristretto under the assumption that it was only a placeholder whose purpose could be served by Pasta now. This allowed upgrading the rand dependency, which is useful downstream.