### PR TITLE
Add InputOutputMismatch error.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,6 +12,8 @@ pub enum NovaError {
   InvalidInputLength,
   /// returned if the supplied witness is not of the right length
   InvalidWitnessLength,
+  /// returned if the supplied instance input does not match the previous instance output
+  InputOutputMismatch,
   /// returned if the supplied witness is not a satisfying witness to a given shape and instance
   UnSat,
   /// returned when the supplied compressed commitment cannot be decompressed

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -399,7 +399,7 @@ impl<G: Group> RelaxedR1CSInstance<G> {
       }
       for i in 0..self.Y_last.len() {
         if self.Y_last[i] != U2.X[i] {
-          return Err(NovaError::InvalidInputLength);
+          return Err(NovaError::InputOutputMismatch);
         }
       }
     }


### PR DESCRIPTION
Add a new error, `InputOutputMismatch` for the case in which the current input and previous output do not match, when folding instances.