### PR TITLE
Use bellperson v0.19.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
 
 [dependencies]
-bellperson =  "0.18.0"
+bellperson =  "0.19.0"
 ff = "0.11.0"
 merlin = "2.0.0"
 rand = "0.8.4"


### PR DESCRIPTION
PR to use the latest bellperson, which supports 'instance aggregation' and is needed to allow Groth16 proofs somewhat structurally comparable to Nova proofs.