### PR TITLE
Refactor to allow non-determinisim.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ itertools = "0.9.0"
 subtle = "2.4"
 pasta_curves = { version = "^0.3.1", features = ["repr-c"] }
 pasta-msm = "0.1.1"
-neptune = { version = "6.1", default-features = false }
+neptune = { version = "6.1.1", default-features = false }
 generic-array = "0.14.4"
 bellperson-nonnative = { version = "0.3.0", default-features = false, features = ["wasm"] }
 num-bigint = { version = "0.4", features = ["serde", "rand"] }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -383,8 +383,8 @@ mod tests {
   where
     F: PrimeField,
   {
-    fn compute(&self, z: &F) -> (Self, F) {
-      (self.clone(), *z)
+    fn compute(&self, z: &F) -> Option<(Self, F)> {
+      Some((self.clone(), *z))
     }
   }
 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -326,7 +326,7 @@ where
 
     let z_next = self
       .step_circuit
-      .synthesize(&mut cs.namespace(|| "F"), z_input)?;
+      .synthesize_step(&mut cs.namespace(|| "F"), z_input)?;
 
     // Compute the new hash H(params, Unew, i+1, z0, z_{i+1})
     let mut ro: PoseidonROGadget<G::Base> = PoseidonROGadget::new(self.ro_consts);
@@ -357,11 +357,12 @@ mod tests {
   use crate::constants::{BN_LIMB_WIDTH, BN_N_LIMBS};
   use crate::{
     bellperson::r1cs::{NovaShape, NovaWitness},
-    traits::HashFuncConstantsTrait,
+    traits::{ComputeStep, HashFuncConstantsTrait},
   };
   use ff::PrimeField;
   use std::marker::PhantomData;
 
+  #[derive(Clone)]
   struct TestCircuit<F: PrimeField> {
     _p: PhantomData<F>,
   }
@@ -370,16 +371,20 @@ mod tests {
   where
     F: PrimeField,
   {
-    fn synthesize<CS: ConstraintSystem<F>>(
+    fn synthesize_step<CS: ConstraintSystem<F>>(
       &self,
       _cs: &mut CS,
       z: AllocatedNum<F>,
     ) -> Result<AllocatedNum<F>, SynthesisError> {
       Ok(z)
     }
-
-    fn compute(&self, z: &F) -> F {
-      *z
+  }
+  impl<F> ComputeStep<F> for TestCircuit<F>
+  where
+    F: PrimeField,
+  {
+    fn compute(&self, z: &F) -> (Self, F) {
+      (self.clone(), *z)
     }
   }
 

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -357,7 +357,7 @@ mod tests {
   use crate::constants::{BN_LIMB_WIDTH, BN_N_LIMBS};
   use crate::{
     bellperson::r1cs::{NovaShape, NovaWitness},
-    traits::{ComputeStep, HashFuncConstantsTrait},
+    traits::{HashFuncConstantsTrait, StepCompute},
   };
   use ff::PrimeField;
   use std::marker::PhantomData;
@@ -379,7 +379,7 @@ mod tests {
       Ok(z)
     }
   }
-  impl<F> ComputeStep<F> for TestCircuit<F>
+  impl<F> StepCompute<F> for TestCircuit<F>
   where
     F: PrimeField,
   {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use r1cs::{
   R1CSGens, R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness,
 };
 use traits::{
-  AbsorbInROTrait, ComputeStep, Group, HashFuncConstantsTrait, HashFuncTrait, StepCircuit,
+  AbsorbInROTrait, StepCompute, Group, HashFuncConstantsTrait, HashFuncTrait, StepCircuit,
 };
 
 type ROConstants<G> =
@@ -120,12 +120,12 @@ where
 }
 
 /// State of iteration over ComputeStep
-pub struct ComputeState<S: ComputeStep<F> + StepCircuit<F>, F: PrimeField> {
+pub struct ComputeState<S: StepCompute<F> + StepCircuit<F>, F: PrimeField> {
   circuit: S,
   val: F,
 }
 
-impl<F: PrimeField, S: ComputeStep<F> + StepCircuit<F> + Clone> Iterator for ComputeState<S, F> {
+impl<F: PrimeField, S: StepCompute<F> + StepCircuit<F> + Clone> Iterator for ComputeState<S, F> {
   type Item = (S, F);
 
   fn next(&mut self) -> Option<Self::Item> {
@@ -248,7 +248,7 @@ where
     Ok(state)
   }
 
-  /// create a new `RecursiveSNARK` for circuits implementing ComputeStep
+  /// create a new `RecursiveSNARK` for circuits implementing StepCompute
   pub fn prove(
     pp: &PublicParams<G1, G2, C1, C2>,
     num_steps: Option<usize>,
@@ -256,8 +256,8 @@ where
     z0_secondary: G2::Scalar,
   ) -> Result<Self, NovaError>
   where
-    C1: ComputeStep<G1::Scalar>,
-    C2: ComputeStep<G2::Scalar>,
+    C1: StepCompute<G1::Scalar>,
+    C2: StepCompute<G2::Scalar>,
   {
     if let Some(num_steps) = num_steps {
       let mut primary_iterator = ComputeState {
@@ -576,7 +576,7 @@ mod tests {
     }
   }
 
-  impl<F> ComputeStep<F> for TrivialTestCircuit<F>
+  impl<F> StepCompute<F> for TrivialTestCircuit<F>
   where
     F: PrimeField,
   {
@@ -626,7 +626,7 @@ mod tests {
     }
   }
 
-  impl<F> ComputeStep<F> for CubicCircuit<F>
+  impl<F> StepCompute<F> for CubicCircuit<F>
   where
     F: PrimeField,
   {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,6 +485,9 @@ where
     if num_steps == 0 {
       return Err(NovaError::ProofVerifyError);
     }
+    if num_steps != self.num_steps {
+      return Err(NovaError::ProofVerifyError);
+    }
 
     // check if the (relaxed) R1CS instances have two public outputs
     if self.l_u_primary.X.len() != 2
@@ -667,6 +670,15 @@ mod tests {
       <G2 as Group>::Scalar::zero(),
     );
     assert!(res.is_ok());
+
+    // verification fails when num_steps is incorrect
+    let bad_res = recursive_snark.verify(
+      &pp,
+      2,
+      <G1 as Group>::Scalar::zero(),
+      <G2 as Group>::Scalar::zero(),
+    );
+    assert!(!bad_res.is_ok());
   }
 
   #[test]
@@ -698,8 +710,6 @@ mod tests {
     assert!(res.is_ok());
     let recursive_snark = res.unwrap();
 
-    assert_eq!(num_steps, recursive_snark.num_steps);
-
     // verify the recursive SNARK
     let res = recursive_snark.verify(
       &pp,
@@ -708,6 +718,15 @@ mod tests {
       <G2 as Group>::Scalar::zero(),
     );
     assert!(res.is_ok());
+
+    // verification fails when num_steps is incorrect
+    let bad_res = recursive_snark.verify(
+      &pp,
+      num_steps + 1,
+      <G1 as Group>::Scalar::zero(),
+      <G2 as Group>::Scalar::zero(),
+    );
+    assert!(!bad_res.is_ok());
 
     let (zn_primary, zn_secondary) = res.unwrap();
 
@@ -754,8 +773,6 @@ mod tests {
     assert!(res.is_ok());
     let recursive_snark = res.unwrap();
 
-    assert_eq!(num_steps, recursive_snark.num_steps);
-
     // verify the recursive SNARK
     let res = recursive_snark.verify(
       &pp,
@@ -764,6 +781,15 @@ mod tests {
       <G2 as Group>::Scalar::zero(),
     );
     assert!(res.is_ok());
+
+    // verification fails when num_steps is incorrect
+    let bad_res = recursive_snark.verify(
+      &pp,
+      0,
+      <G1 as Group>::Scalar::zero(),
+      <G2 as Group>::Scalar::zero(),
+    );
+    assert!(!bad_res.is_ok());
 
     let (zn_primary, zn_secondary) = res.unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -678,7 +678,7 @@ mod tests {
       <G1 as Group>::Scalar::zero(),
       <G2 as Group>::Scalar::zero(),
     );
-    assert!(!bad_res.is_ok());
+    assert!(bad_res.is_err());
   }
 
   #[test]
@@ -726,7 +726,7 @@ mod tests {
       <G1 as Group>::Scalar::zero(),
       <G2 as Group>::Scalar::zero(),
     );
-    assert!(!bad_res.is_ok());
+    assert!(bad_res.is_err());
 
     let (zn_primary, zn_secondary) = res.unwrap();
 
@@ -789,7 +789,7 @@ mod tests {
       <G1 as Group>::Scalar::zero(),
       <G2 as Group>::Scalar::zero(),
     );
-    assert!(!bad_res.is_ok());
+    assert!(bad_res.is_err());
 
     let (zn_primary, zn_secondary) = res.unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,7 +385,7 @@ where
     let circuit_primary: NIFSVerifierCircuit<G2, C1> = NIFSVerifierCircuit::new(
       pp.params_primary.clone(),
       Some(inputs_primary),
-      new_primary_circuit.clone(),
+      new_primary_circuit,
       pp.ro_consts_circuit_primary.clone(),
     );
     let _ = circuit_primary.synthesize(&mut cs_primary);
@@ -419,7 +419,7 @@ where
     let circuit_secondary: NIFSVerifierCircuit<G1, C2> = NIFSVerifierCircuit::new(
       pp.params_secondary.clone(),
       Some(inputs_secondary),
-      new_secondary_circuit.clone(),
+      new_secondary_circuit,
       pp.ro_consts_circuit_secondary.clone(),
     );
     let _ = circuit_secondary.synthesize(&mut cs_secondary);
@@ -684,12 +684,9 @@ mod tests {
       // Rather, we take advantage of the hint precomputed in self.roots.
       let x = AllocatedNum::alloc(cs.namespace(|| "x"), || Ok(self.roots[0]))?;
 
-      match (z.get_value(), x.get_value()) {
-        (Some(z), Some(x)) => {
-          // Sanity check
-          assert_eq!(z, x * x)
-        }
-        _ => (),
+      if let (Some(z), Some(x)) = (z.get_value(), x.get_value()) {
+        // Sanity check
+        assert_eq!(z, x * x)
       };
 
       cs.enforce(
@@ -715,11 +712,11 @@ mod tests {
         assert_eq!(*z, square);
 
         let next = Self {
-          roots: self.roots[1..].to_vec().clone(),
+          roots: self.roots[1..].to_vec(),
           _p: Default::default(),
         };
 
-        let root = self.roots[1].clone();
+        let root = self.roots[1];
         assert_eq!(square, root * root);
 
         Some((next, root))
@@ -900,7 +897,7 @@ mod tests {
 
     // Create the nondeterministic circuit
     let ndc = NondeterministicCircuit::<<G2 as Group>::Scalar>::create(output, num_steps);
-    let input = ndc.roots[0].clone();
+    let input = ndc.roots[0];
 
     // produce public parameters
     let pp = PublicParams::<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ use r1cs::{
   R1CSGens, R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness,
 };
 use traits::{
-  AbsorbInROTrait, StepCompute, Group, HashFuncConstantsTrait, HashFuncTrait, StepCircuit,
+  AbsorbInROTrait, Group, HashFuncConstantsTrait, HashFuncTrait, StepCircuit, StepCompute,
 };
 
 type ROConstants<G> =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,7 +384,7 @@ where
   }
 
   /// create a new `RecursiveSNARK` from primary and secondary iterators
-  fn prove_with_iterators(
+  pub fn prove_with_iterators(
     pp: &PublicParams<G1, G2, C1, C2, A1, A2>,
     z0_primary: &IO<G1::Scalar, A1>,
     z0_secondary: &IO<G2::Scalar, A2>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,7 +384,7 @@ where
   }
 
   /// create a new `RecursiveSNARK` from primary and secondary iterators
-  pub fn prove_with_iterators(
+  fn prove_with_iterators(
     pp: &PublicParams<G1, G2, C1, C2, A1, A2>,
     z0_primary: &IO<G1::Scalar, A1>,
     z0_secondary: &IO<G2::Scalar, A2>,
@@ -430,7 +430,7 @@ where
   }
 
   /// Prove one step of an iterative computation, mutating the RecursiveSNARK
-  pub fn prove_step(
+  fn prove_step(
     &mut self,
     pp: &PublicParams<G1, G2, C1, C2, A1, A2>,
     i: usize,
@@ -524,7 +524,7 @@ where
   }
 
   /// Prove one step of an iterative computation, mutating the RecursiveSNARK
-  pub fn prove_step_with_iterators(
+  fn prove_step_with_iterators(
     &mut self,
     pp: &PublicParams<G1, G2, C1, C2, A1, A2>,
     i: usize,

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -12,14 +12,14 @@ use bellperson::{
 };
 use core::marker::PhantomData;
 use ff::{PrimeField, PrimeFieldBits};
-use generic_array::typenum::{U27, U32};
+use generic_array::typenum::{U2, U27, U32};
 use neptune::{
   circuit::poseidon_hash,
   poseidon::{Poseidon, PoseidonConstants},
   Strength,
 };
 
-/// All Poseidon Constants that are used in Nova
+/// All Poseidon Constants that are used in Nova random oracle
 #[derive(Clone)]
 pub struct ROConstantsCircuit<Scalar>
 where
@@ -36,12 +36,32 @@ where
   /// Generate Poseidon constants for the arities that Nova uses
   #[allow(clippy::new_without_default)]
   fn new() -> Self {
-    let constants27 = PoseidonConstants::<Scalar, U27>::new_with_strength(Strength::Strengthened);
-    let constants32 = PoseidonConstants::<Scalar, U32>::new_with_strength(Strength::Strengthened);
+    let constants27 = PoseidonConstants::<Scalar, U27>::new_with_strength(Strength::Standard);
+    let constants32 = PoseidonConstants::<Scalar, U32>::new_with_strength(Strength::Standard);
     Self {
       constants27,
       constants32,
     }
+  }
+}
+
+#[derive(Clone)]
+pub struct ArityConstants<Scalar>
+where
+  Scalar: PrimeField,
+{
+  pub arity_2: PoseidonConstants<Scalar, U2>,
+}
+
+impl<Scalar> HashFuncConstantsTrait<Scalar> for ArityConstants<Scalar>
+where
+  Scalar: PrimeField,
+{
+  /// Generate Poseidon constants for the arities that Nova uses
+  #[allow(clippy::new_without_default)]
+  fn new() -> Self {
+    let arity_2 = PoseidonConstants::<Scalar, U2>::new_with_strength(Strength::Standard);
+    Self { arity_2 }
   }
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -146,7 +146,7 @@ pub trait StepCircuit<F: PrimeField>: Sized {
 }
 
 /// A helper trait for computing a step of the incremental computation (i.e., F itself)
-pub trait ComputeStep<F: PrimeField>: Sized {
+pub trait StepCompute<F: PrimeField>: Sized {
   /// Execute the circuit for a computation, returning a new circuit and output
   fn compute(&self, z: &F) -> (Self, F);
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -148,7 +148,7 @@ pub trait StepCircuit<F: PrimeField>: Sized {
 /// A helper trait for computing a step of the incremental computation (i.e., F itself)
 pub trait StepCompute<F: PrimeField>: Sized {
   /// Execute the circuit for a computation, returning a new circuit and output
-  fn compute(&self, z: &F) -> (Self, F);
+  fn compute(&self, z: &F) -> Option<(Self, F)>;
 }
 
 impl<F: PrimeField> AppendToTranscriptTrait for F {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -134,18 +134,21 @@ impl<T, Rhs, Output> ScalarMul<Rhs, Output> for T where T: Mul<Rhs, Output = Out
 pub trait ScalarMulOwned<Rhs, Output = Self>: for<'r> ScalarMul<&'r Rhs, Output> {}
 impl<T, Rhs, Output> ScalarMulOwned<Rhs, Output> for T where T: for<'r> ScalarMul<&'r Rhs, Output> {}
 
-/// A helper trait for a step of the incremental computation (i.e., circuit for F)
-pub trait StepCircuit<F: PrimeField> {
+/// A helper trait for synthesizing a step of the incremental computation (i.e., circuit for F)
+pub trait StepCircuit<F: PrimeField>: Sized {
   /// Sythesize the circuit for a computation step and return variable
   /// that corresponds to the output of the step z_{i+1}
-  fn synthesize<CS: ConstraintSystem<F>>(
+  fn synthesize_step<CS: ConstraintSystem<F>>(
     &self,
     cs: &mut CS,
     z: AllocatedNum<F>,
   ) -> Result<AllocatedNum<F>, SynthesisError>;
+}
 
-  /// Execute the circuit for a computation step and return output
-  fn compute(&self, z: &F) -> F;
+/// A helper trait for computing a step of the incremental computation (i.e., F itself)
+pub trait ComputeStep<F: PrimeField>: Sized {
+  /// Execute the circuit for a computation, returning a new circuit and output
+  fn compute(&self, z: &F) -> (Self, F);
 }
 
 impl<F: PrimeField> AppendToTranscriptTrait for F {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -247,7 +247,7 @@ pub trait StepCircuit<F: PrimeField, A: Arity<F>>: Sized {
 }
 
 /// Enum for holding the computation F's input/output value(s).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum IO<'a, F: PrimeField, A: Arity<F>> {
   /// Unary input/output value
   Val(F),

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -156,7 +156,7 @@ pub trait StepCircuit<F: PrimeField, A: Arity<F>>: Sized {
           z_vec.push(allocated);
         }
 
-        let hash = poseidon_hash(&mut cs.namespace(|| "hash"), z_vec.clone(), &p)?;
+        let hash = poseidon_hash(&mut cs.namespace(|| "hash"), z_vec.clone(), p)?;
 
         cs.enforce(
           || "hash = z",
@@ -167,7 +167,7 @@ pub trait StepCircuit<F: PrimeField, A: Arity<F>>: Sized {
 
         let inner_output = self.synthesize_step_inner(&mut cs.namespace(|| "inner"), z_vec)?;
 
-        let output_hash = poseidon_hash(&mut cs.namespace(|| "output"), inner_output, &p)?;
+        let output_hash = poseidon_hash(&mut cs.namespace(|| "output"), inner_output, p)?;
 
         Ok(output_hash)
       }
@@ -182,7 +182,7 @@ pub trait StepCircuit<F: PrimeField, A: Arity<F>>: Sized {
           z_vec.push(allocated);
         }
 
-        let hash = poseidon_hash(&mut cs.namespace(|| "hash"), z_vec.clone(), &p)?;
+        let hash = poseidon_hash(&mut cs.namespace(|| "hash"), z_vec.clone(), p)?;
 
         cs.enforce(
           || "hash = z",
@@ -193,7 +193,7 @@ pub trait StepCircuit<F: PrimeField, A: Arity<F>>: Sized {
 
         let inner_output = self.synthesize_step_inner(&mut cs.namespace(|| "inner"), z_vec)?;
 
-        let output_hash = poseidon_hash(&mut cs.namespace(|| "output"), inner_output, &p)?;
+        let output_hash = poseidon_hash(&mut cs.namespace(|| "output"), inner_output, p)?;
 
         Ok(output_hash)
       }
@@ -233,7 +233,7 @@ impl<'a, F: PrimeField, A: Arity<F>> IO<'a, F, A> {
     match self {
       Self::Val(val) => *val,
       Self::Vals(vals, p) => {
-        let mut hasher = Poseidon::<F, A>::new_with_preimage(&vals, &p);
+        let mut hasher = Poseidon::<F, A>::new_with_preimage(vals, p);
         hasher.hash()
       }
       Self::Empty(_) => unreachable!(),
@@ -278,7 +278,7 @@ pub trait StepCompute<'a, F: PrimeField, A: Arity<F>>: Sized {
 
   /// Compute F for a non-unary computation, returning a new circuit and output
   /// This method must be implemented for non-unary F
-  fn compute_inner(&self, _z: &Vec<F>, _p: &'a PoseidonConstants<F, A>) -> Option<(Self, Vec<F>)> {
+  fn compute_inner(&self, _z: &[F], _p: &'a PoseidonConstants<F, A>) -> Option<(Self, Vec<F>)> {
     unimplemented!();
   }
 }


### PR DESCRIPTION
This PR refactors proving in a number of ways. At least some of these changes are necessary to support determinism in the computation of F. The existing code didn't allow this, since `compute` was always called on the same circuit prototype contained in the public parameters.

- separate circuit/output computation and synthesis into two traits
- at the lowest level, support caller-controlled stepping of the proof
- for convenience, allow caller to provide iterators yielding successive outputs and (un-synthesized) circuits
- most simply, and consistent with current implementation, automatically create such iterators when ComputeStep is implemented

This change also makes `num_steps` optional, and the state accumulated in a `RecursiveSNARK` tracks the actual number of steps used. This allows for applications where the number of steps is not known in advance.

It's likely that further small changes may be needed when integrating downstream consumers who will need this functionality, but until integration happens, it is difficult to anticipate what that may entail beyond my best guesses here.

NOTE: in the future, we should support a recursive proof which does not expose the number of steps. This will be important for applications in which knowing the number of steps required to compute a final result leaks information. Having the option to generate proofs without revealing the number of steps will eliminate effective  'timing attacks' on such applications.

---

UPDATE: I added support for non-unary functions, building on the first part. I know that makes this a fairly large PR, but I had to rework a fair amount of the foundation to get here.

The basic idea is that for higher-arity functions, the implementer should implement methods (`compute_inner` and `synthesize_step_inner`, which operate on and return a vector of scalars. The goal was to make the actual mechanism as hidden from the caller/user as possible, but some leakage was unavoidable so far.

Under the hood, at each step, the inputs are hashed to get the true unary input for the step function, F — and the outputs are again hashed to produce the unary output. Both hashes are proved in the circuit.

Because we need to avoid storing the initial input (Z0) in the public parameters, it's necessary to first create an 'empty' input used to generate the R1CS shape. That means the caller *does* (unfortunately) have to create the poseidon constants for the relevant scalar and arity. This is not especially difficult, but it would be nicer if it could have been avoided. This wart means that the constants are generated twice in this case. With more machinery, the public parameters and IO enum could be more symbiotic, but for now I think this is a reasonable tradeoff.
