### PR TITLE
Optimizations

### DIFF
--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -124,14 +124,10 @@ where
         x_i_plus_1.square(cs.namespace(|| format!("x_i_plus_1_sq_iter_{}", i)))?;
       let x_i_plus_1_quad =
         x_i_plus_1_sq.square(cs.namespace(|| format!("x_i_plus_1_quad_{}", i)))?;
-      let x_i_plus_1_pow_5 = x_i_plus_1_quad.mul(
-        cs.namespace(|| format!("x_i_plus_1_pow_5_{}", i)),
-        &x_i_plus_1,
-      )?;
       cs.enforce(
-        || format!("x_i_plus_1_pow_5 = x_i + y_i_iter_{}", i),
-        |lc| lc + x_i_plus_1_pow_5.get_variable(),
-        |lc| lc + CS::one(),
+        || format!("x_i_plus_1_quad * x_i_plus_1 = x_i + y_i_iter_{}", i),
+        |lc| lc + x_i_plus_1_quad.get_variable(),
+        |lc| lc + x_i_plus_1.get_variable(),
         |lc| lc + x_i.get_variable() + y_i.get_variable(),
       );
 
@@ -209,6 +205,15 @@ fn main() {
   println!(
     "Number of constraints per step (secondary circuit): {}",
     pp.num_constraints().1
+  );
+
+  println!(
+    "Number of variables per step (primary circuit): {}",
+    pp.num_variables().0
+  );
+  println!(
+    "Number of variables per step (secondary circuit): {}",
+    pp.num_variables().1
   );
 
   // produce non-deterministic advice

--- a/src/commitments.rs
+++ b/src/commitments.rs
@@ -134,6 +134,12 @@ impl<G: Group> Commitment<G> {
   }
 }
 
+impl<G: Group> Default for Commitment<G> {
+  fn default() -> Self {
+    Commitment { comm: G::zero() }
+  }
+}
+
 impl<C: CompressedGroup> CompressedCommitment<C> {
   pub fn decompress(&self) -> Result<Commitment<C::GroupElement>, NovaError> {
     let comm = self.comm.decompress();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,14 @@ where
       self.r1cs_shape_secondary.num_cons,
     )
   }
+
+  /// Returns the number of variables in the primary and secondary circuits
+  pub fn num_variables(&self) -> (usize, usize) {
+    (
+      self.r1cs_shape_primary.num_vars,
+      self.r1cs_shape_secondary.num_vars,
+    )
+  }
 }
 
 /// A SNARK that proves the correct execution of an incremental computation

--- a/src/pasta.rs
+++ b/src/pasta.rs
@@ -11,7 +11,7 @@ use num_traits::Num;
 use pasta_curves::{
   self,
   arithmetic::{CurveAffine, CurveExt, Group as OtherGroup},
-  group::{Curve, GroupEncoding},
+  group::{Curve, Group as AnotherGroup, GroupEncoding},
   pallas, vesta, Ep, Eq,
 };
 use rand::SeedableRng;
@@ -95,6 +95,14 @@ impl Group for pallas::Point {
       16,
     )
     .unwrap()
+  }
+
+  fn zero() -> Self {
+    pallas::Point::group_zero()
+  }
+
+  fn get_generator() -> Self {
+    pallas::Point::generator()
   }
 }
 
@@ -193,6 +201,14 @@ impl Group for vesta::Point {
       16,
     )
     .unwrap()
+  }
+
+  fn zero() -> Self {
+    vesta::Point::group_zero()
+  }
+
+  fn get_generator() -> Self {
+    vesta::Point::generator()
   }
 }
 

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -577,8 +577,8 @@ impl<G: Group> RelaxedR1CSWitness<G> {
 
 impl<G: Group> RelaxedR1CSInstance<G> {
   /// Produces a default RelaxedR1CSInstance given R1CSGens and R1CSShape
-  pub fn default(gens: &R1CSGens<G>, S: &R1CSShape<G>) -> RelaxedR1CSInstance<G> {
-    let (comm_W, comm_E) = RelaxedR1CSWitness::default(S).commit(gens);
+  pub fn default(_gens: &R1CSGens<G>, S: &R1CSShape<G>) -> RelaxedR1CSInstance<G> {
+    let (comm_W, comm_E) = (Commitment::default(), Commitment::default());
     RelaxedR1CSInstance {
       comm_W,
       comm_E,

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -64,6 +64,12 @@ pub trait Group:
 
   /// Returns the order of the group as a big integer
   fn get_order() -> BigInt;
+
+  /// Returns an element that is the additive identity of the group
+  fn zero() -> Self;
+
+  /// Returns the generator of the group
+  fn get_generator() -> Self;
 }
 
 /// Represents a compressed version of a group element


### PR DESCRIPTION
* Avoid committing to zero vectors when creating a default instance
* Make 3 constraints/iter (down from 4 constraints/iter) in the MinRoot example