### PR TITLE
Speed up MSMs for non-GPU accelerated MSMs and architectures that don't support GPU/semolina

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,5 +49,5 @@ harness = false
 [features]
 default = [ "bellperson/default", "neptune/default" ]
 
-[target.'cfg(not(target_family = "wasm"))'.dependencies]
+[target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ bincode = "1.2.1"
 flate2 = "1.0"
 bitvec = "1.0"
 byteorder = "1.4.3"
-cfg-if = "1.0.0"
 
 [dev-dependencies]
 criterion = "0.3.1"
@@ -47,7 +46,7 @@ name = "compressed-snark"
 harness = false
 
 [features]
-default = [ "bellperson/default", "neptune/default" ]
+default = ["bellperson/default", "neptune/default"]
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ rand_chacha = "0.3"
 itertools = "0.9.0"
 subtle = "2.4"
 pasta_curves = { version = "0.4.0", features = ["repr-c"] }
-pasta-msm = "0.1.3"
 neptune = { version = "8.1.0", default-features = false }
 generic-array = "0.14.4"
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
@@ -34,6 +33,7 @@ bincode = "1.2.1"
 flate2 = "1.0"
 bitvec = "1.0"
 byteorder = "1.4.3"
+cfg-if = "1.0.0"
 
 [dev-dependencies]
 criterion = "0.3.1"
@@ -48,3 +48,6 @@ harness = false
 
 [features]
 default = [ "bellperson/default", "neptune/default" ]
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+pasta-msm = "0.1.3"


### PR DESCRIPTION
Adds fast, parallelisable MSM for compile targets that aren't supported by pasta_msm/semolina. Also uses fast MSM on small MSMs (smaller than 128 size) for _all_ architecture since I'm on my laptop a size 128 MSM is ~3x faster with this code vs. the old non Pippengers code.

The multiexp code is taken from https://github.com/zcash/halo2/blob/main/halo2_proofs/src/arithmetic.rs, all credits to authors there!

Tested end to end with this branch of Nova Scotia: https://github.com/nalinbhardwaj/Nova-Scotia/tree/browser

Follow up from discussion here: https://github.com/microsoft/Nova/pull/125#discussion_r1087001908