### PR TITLE
making index for tracking progress optional

### DIFF
--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -9,7 +9,7 @@ use nova_snark::{
     circuit::{StepCircuit, TrivialTestCircuit},
     Group,
   },
-  CompressedSNARK, PublicParams, RecursiveSNARK,
+  CompressedSNARK, PublicParams, RecursiveSNARK, StepCounter,
 };
 use std::time::Duration;
 
@@ -66,7 +66,7 @@ fn bench_compressed_snark(c: &mut Criterion) {
       // verify the recursive snark at each step of recursion
       let res = recursive_snark_unwrapped.verify(
         &pp,
-        i + 1,
+        StepCounter::Standard(i + 1),
         vec![<G1 as Group>::Scalar::from(2u64)],
         vec![<G2 as Group>::Scalar::from(2u64)],
       );
@@ -97,7 +97,7 @@ fn bench_compressed_snark(c: &mut Criterion) {
         assert!(black_box(&compressed_snark)
           .verify(
             black_box(&pp),
-            black_box(num_steps),
+            black_box(StepCounter::Standard(num_steps)),
             black_box(vec![<G1 as Group>::Scalar::from(2u64)]),
             black_box(vec![<G2 as Group>::Scalar::from(2u64)]),
           )

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -9,7 +9,7 @@ use nova_snark::{
     circuit::{StepCircuit, TrivialTestCircuit},
     Group,
   },
-  PublicParams, RecursiveSNARK,
+  PublicParams, RecursiveSNARK, StepCounter,
 };
 use std::time::Duration;
 
@@ -66,7 +66,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
       // verify the recursive snark at each step of recursion
       let res = recursive_snark_unwrapped.verify(
         &pp,
-        i + 1,
+        StepCounter::Standard(i + 1),
         vec![<G1 as Group>::Scalar::from(2u64)],
         vec![<G2 as Group>::Scalar::from(2u64)],
       );
@@ -99,7 +99,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
         assert!(black_box(&recursive_snark)
           .verify(
             black_box(&pp),
-            black_box(num_warmup_steps),
+            black_box(StepCounter::Standard(num_warmup_steps)),
             black_box(vec![<G1 as Group>::Scalar::from(2u64)]),
             black_box(vec![<G2 as Group>::Scalar::from(2u64)]),
           )

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -10,7 +10,7 @@ use nova_snark::{
     circuit::{StepCircuit, TrivialTestCircuit},
     Group,
   },
-  CompressedSNARK, PublicParams, RecursiveSNARK,
+  CompressedSNARK, PublicParams, RecursiveSNARK, StepCounter,
 };
 use num_bigint::BigUint;
 use std::time::Instant;
@@ -145,7 +145,7 @@ fn main() {
   println!("Nova-based VDF with MinRoot delay function");
   println!("=========================================================");
 
-  let num_steps = 10;
+  let num_steps = StepCounter::Standard(10);
   for num_iters_per_step in [1024, 2048, 4096, 8192, 16384, 32768, 65535] {
     // number of iterations of MinRoot per Nova's recursive step
     let circuit_primary = MinRootCircuit {
@@ -195,11 +195,11 @@ fn main() {
 
     // produce non-deterministic advice
     let (z0_primary, minroot_iterations) = MinRootIteration::new(
-      num_iters_per_step * num_steps,
+      num_iters_per_step * num_steps.value(),
       &<G1 as Group>::Scalar::zero(),
       &<G1 as Group>::Scalar::one(),
     );
-    let minroot_circuits = (0..num_steps)
+    let minroot_circuits = (0..num_steps.value())
       .map(|i| MinRootCircuit {
         seq: (0..num_iters_per_step)
           .map(|j| MinRootIteration {
@@ -220,7 +220,7 @@ fn main() {
     println!("Generating a RecursiveSNARK...");
     let mut recursive_snark: Option<RecursiveSNARK<G1, G2, C1, C2>> = None;
 
-    for (i, circuit_primary) in minroot_circuits.iter().take(num_steps).enumerate() {
+    for (i, circuit_primary) in minroot_circuits.iter().take(num_steps.value()).enumerate() {
       let start = Instant::now();
       let res = RecursiveSNARK::prove_step(
         &pp,


### PR DESCRIPTION
This PR adds a more generic Step Counter that can be used for recursive functions that are not defined with respect to a counter \ell. With the more generic counter how one determines that the prover performed all the steps is application-specific.