### PR TITLE
Clippy formatting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["zkSNARKs", "cryptography", "proofs"]
 
 [dependencies]
 bellperson = { version = "0.24", default-features = false }
-ff = { version = "0.12.0", features = ["derive"]}
+ff = { version = "0.12.0", features = ["derive"] }
 merlin = "2.0.0"
 digest = "0.8.1"
 sha3 = "0.8.2"
@@ -49,4 +49,4 @@ name = "compressed-snark"
 harness = false
 
 [features]
-default = [ "bellperson/default", "neptune/default" ]
+default = []

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -38,7 +38,7 @@ fn bench_compressed_snark(c: &mut Criterion) {
     // number of constraints in the step circuit
     let num_cons = num_cons_in_augmented_circuit - num_cons_verifier_circuit_primary;
 
-    let mut group = c.benchmark_group(format!("CompressedSNARK-StepCircuitSize-{}", num_cons));
+    let mut group = c.benchmark_group(format!("CompressedSNARK-StepCircuitSize-{num_cons}"));
     group.sample_size(num_samples);
 
     // Produce public parameters
@@ -143,7 +143,7 @@ where
     let mut x = z[0].clone();
     let mut y = x.clone();
     for i in 0..self.num_cons {
-      y = x.square(cs.namespace(|| format!("x_sq_{}", i)))?;
+      y = x.square(cs.namespace(|| format!("x_sq_{i}")))?;
       x = y.clone();
     }
     Ok(vec![y])

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -35,7 +35,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     // number of constraints in the step circuit
     let num_cons = num_cons_in_augmented_circuit - num_cons_verifier_circuit_primary;
 
-    let mut group = c.benchmark_group(format!("RecursiveSNARK-StepCircuitSize-{}", num_cons));
+    let mut group = c.benchmark_group(format!("RecursiveSNARK-StepCircuitSize-{num_cons}"));
     group.sample_size(10);
 
     // Produce public parameters
@@ -144,7 +144,7 @@ where
     let mut x = z[0].clone();
     let mut y = x.clone();
     for i in 0..self.num_cons {
-      y = x.square(cs.namespace(|| format!("x_sq_{}", i)))?;
+      y = x.square(cs.namespace(|| format!("x_sq_{i}")))?;
       x = y.clone();
     }
     Ok(vec![y])

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -96,7 +96,7 @@ where
     for i in 0..self.seq.len() {
       // non deterministic advice
       let x_i_plus_1 =
-        AllocatedNum::alloc(cs.namespace(|| format!("x_i_plus_1_iter_{}", i)), || {
+        AllocatedNum::alloc(cs.namespace(|| format!("x_i_plus_1_iter_{i}")), || {
           Ok(self.seq[i].x_i_plus_1)
         })?;
 
@@ -106,11 +106,11 @@ where
       // (1) constraints for condition (i) are below
       // (2) constraints for condition (ii) is avoided because we just used x_i wherever y_i_plus_1 is used
       let x_i_plus_1_sq =
-        x_i_plus_1.square(cs.namespace(|| format!("x_i_plus_1_sq_iter_{}", i)))?;
+        x_i_plus_1.square(cs.namespace(|| format!("x_i_plus_1_sq_iter_{i}")))?;
       let x_i_plus_1_quad =
-        x_i_plus_1_sq.square(cs.namespace(|| format!("x_i_plus_1_quad_{}", i)))?;
+        x_i_plus_1_sq.square(cs.namespace(|| format!("x_i_plus_1_quad_{i}")))?;
       cs.enforce(
-        || format!("x_i_plus_1_quad * x_i_plus_1 = x_i + y_i_iter_{}", i),
+        || format!("x_i_plus_1_quad * x_i_plus_1 = x_i + y_i_iter_{i}"),
         |lc| lc + x_i_plus_1_quad.get_variable(),
         |lc| lc + x_i_plus_1.get_variable(),
         |lc| lc + x_i.get_variable() + y_i.get_variable(),
@@ -163,8 +163,7 @@ fn main() {
     let circuit_secondary = TrivialTestCircuit::default();
 
     println!(
-      "Proving {} iterations of MinRoot per step",
-      num_iters_per_step
+      "Proving {num_iters_per_step} iterations of MinRoot per step"
     );
 
     // produce public parameters

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -105,8 +105,7 @@ where
       // (ii) y_i_plus_1 = x_i
       // (1) constraints for condition (i) are below
       // (2) constraints for condition (ii) is avoided because we just used x_i wherever y_i_plus_1 is used
-      let x_i_plus_1_sq =
-        x_i_plus_1.square(cs.namespace(|| format!("x_i_plus_1_sq_iter_{i}")))?;
+      let x_i_plus_1_sq = x_i_plus_1.square(cs.namespace(|| format!("x_i_plus_1_sq_iter_{i}")))?;
       let x_i_plus_1_quad =
         x_i_plus_1_sq.square(cs.namespace(|| format!("x_i_plus_1_quad_{i}")))?;
       cs.enforce(
@@ -162,9 +161,7 @@ fn main() {
 
     let circuit_secondary = TrivialTestCircuit::default();
 
-    println!(
-      "Proving {num_iters_per_step} iterations of MinRoot per step"
-    );
+    println!("Proving {num_iters_per_step} iterations of MinRoot per step");
 
     // produce public parameters
     println!("Producing public parameters...");

--- a/examples/signature.rs
+++ b/examples/signature.rs
@@ -185,7 +185,7 @@ pub fn synthesize_bits<F: PrimeField, CS: ConstraintSystem<F>>(
     .into_iter()
     .map(|i| {
       AllocatedBit::alloc(
-        cs.namespace(|| format!("bit {}", i)),
+        cs.namespace(|| format!("bit {i}")),
         Some(bits.as_ref().unwrap()[i as usize]),
       )
     })

--- a/src/bellperson/shape_cs.rs
+++ b/src/bellperson/shape_cs.rs
@@ -122,13 +122,13 @@ where
     let mut result = Vec::new();
 
     for input in &self.inputs {
-      result.push(format!("INPUT {}", input));
+      result.push(format!("INPUT {input}"));
     }
     for aux in &self.aux {
-      result.push(format!("AUX {}", aux));
+      result.push(format!("AUX {aux}"));
     }
 
-    for &(ref _a, ref _b, ref _c, ref name) in &self.constraints {
+    for (_a, _b, _c, name) in &self.constraints {
       result.push(name.to_string());
     }
 
@@ -164,12 +164,12 @@ where
         if coeff != <G::Scalar>::one() && coeff != negone {
           for (i, x) in powers_of_two.iter().enumerate() {
             if x == &coeff {
-              write!(s, "2^{} . ", i).unwrap();
+              write!(s, "2^{i} . ").unwrap();
               break;
             }
           }
 
-          write!(s, "{:?} . ", coeff).unwrap()
+          write!(s, "{coeff:?} . ").unwrap()
         }
 
         match var.0.get_unchecked() {
@@ -188,10 +188,10 @@ where
       s.push(')');
     };
 
-    for &(ref a, ref b, ref c, ref name) in &self.constraints {
+    for (a, b, c, name) in &self.constraints {
       s.push('\n');
 
-      write!(s, "{}: ", name).unwrap();
+      write!(s, "{name}: ").unwrap();
       pp(&mut s, a);
       write!(s, " * ").unwrap();
       pp(&mut s, b);
@@ -209,8 +209,7 @@ where
   fn set_named_obj(&mut self, path: String, to: NamedObject) {
     assert!(
       !self.named_objects.contains_key(&path),
-      "tried to create object at existing path: {}",
-      path
+      "tried to create object at existing path: {path}"
     );
 
     self.named_objects.insert(path, to);

--- a/src/bellperson/solver.rs
+++ b/src/bellperson/solver.rs
@@ -43,7 +43,7 @@ where
         &self
           .a
           .iter()
-          .map(|v| format!("Fr({:?})", v))
+          .map(|v| format!("Fr({v:?})"))
           .collect::<Vec<_>>(),
       )
       .field(
@@ -51,7 +51,7 @@ where
         &self
           .b
           .iter()
-          .map(|v| format!("Fr({:?})", v))
+          .map(|v| format!("Fr({v:?})"))
           .collect::<Vec<_>>(),
       )
       .field(
@@ -59,7 +59,7 @@ where
         &self
           .c
           .iter()
-          .map(|v| format!("Fr({:?})", v))
+          .map(|v| format!("Fr({v:?})"))
           .collect::<Vec<_>>(),
       )
       .field("input_assignment", &self.input_assignment)

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -146,7 +146,7 @@ where
     // Allocate z0
     let z_0 = (0..arity)
       .map(|i| {
-        AllocatedNum::alloc(cs.namespace(|| format!("z0_{}", i)), || {
+        AllocatedNum::alloc(cs.namespace(|| format!("z0_{i}")), || {
           Ok(self.inputs.get()?.z0[i])
         })
       })
@@ -156,7 +156,7 @@ where
     let zero = vec![G::Base::zero(); arity];
     let z_i = (0..arity)
       .map(|i| {
-        AllocatedNum::alloc(cs.namespace(|| format!("zi_{}", i)), || {
+        AllocatedNum::alloc(cs.namespace(|| format!("zi_{i}")), || {
           Ok(self.inputs.get()?.zi.as_ref().unwrap_or(&zero)[i])
         })
       })

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -444,15 +444,15 @@ where
 
     // perform the double-and-add loop to compute the scalar mul using incomplete addition law
     for (i, bit) in incomplete_bits.iter().enumerate().skip(1) {
-      let temp = acc.add_incomplete(cs.namespace(|| format!("add {}", i)), &p)?;
+      let temp = acc.add_incomplete(cs.namespace(|| format!("add {i}")), &p)?;
       acc = AllocatedPointNonInfinity::conditionally_select(
-        cs.namespace(|| format!("acc_iteration_{}", i)),
+        cs.namespace(|| format!("acc_iteration_{i}")),
         &temp,
         &acc,
         &Boolean::from(bit.clone()),
       )?;
 
-      p = p.double_incomplete(cs.namespace(|| format!("double {}", i)))?;
+      p = p.double_incomplete(cs.namespace(|| format!("double {i}")))?;
     }
 
     // convert back to AllocatedPoint
@@ -500,15 +500,15 @@ where
     let mut p_complete = p.to_allocated_point(&self.is_infinity)?;
 
     for (i, bit) in complete_bits.iter().enumerate() {
-      let temp = acc.add(cs.namespace(|| format!("add_complete {}", i)), &p_complete)?;
+      let temp = acc.add(cs.namespace(|| format!("add_complete {i}")), &p_complete)?;
       acc = AllocatedPoint::conditionally_select(
-        cs.namespace(|| format!("acc_complete_iteration_{}", i)),
+        cs.namespace(|| format!("acc_complete_iteration_{i}")),
         &temp,
         &acc,
         &Boolean::from(bit.clone()),
       )?;
 
-      p_complete = p_complete.double(cs.namespace(|| format!("double_complete {}", i)))?;
+      p_complete = p_complete.double(cs.namespace(|| format!("double_complete {i}")))?;
     }
 
     Ok(acc)
@@ -961,7 +961,7 @@ mod tests {
       .to_le_bits()
       .into_iter()
       .enumerate()
-      .map(|(i, bit)| AllocatedBit::alloc(cs.namespace(|| format!("bit {}", i)), Some(bit)))
+      .map(|(i, bit)| AllocatedBit::alloc(cs.namespace(|| format!("bit {i}")), Some(bit)))
       .collect::<Result<Vec<AllocatedBit>, SynthesisError>>()
       .unwrap();
     let e = a.scalar_mul(cs.namespace(|| "Scalar Mul"), bits).unwrap();

--- a/src/gadgets/nonnative/bignat.rs
+++ b/src/gadgets/nonnative/bignat.rs
@@ -52,9 +52,7 @@ pub fn nat_to_limbs<Scalar: PrimeField>(
         .collect(),
     )
   } else {
-    eprintln!(
-      "nat {nat} does not fit in {n_limbs} limbs of width {limb_width}"
-    );
+    eprintln!("nat {nat} does not fit in {n_limbs} limbs of width {limb_width}");
     Err(SynthesisError::Unsatisfiable)
   }
 }
@@ -706,10 +704,7 @@ impl<Scalar: PrimeField> Polynomial<Scalar> {
     });
     let coefficients = (0..n_product_coeffs)
       .map(|i| {
-        Ok(
-          LinearCombination::zero()
-            + cs.alloc(|| format!("prod {i}"), || Ok(values.grab()?[i]))?,
-        )
+        Ok(LinearCombination::zero() + cs.alloc(|| format!("prod {i}"), || Ok(values.grab()?[i]))?)
       })
       .collect::<Result<Vec<LinearCombination<Scalar>>, SynthesisError>>()?;
     let product = Polynomial {

--- a/src/gadgets/nonnative/util.rs
+++ b/src/gadgets/nonnative/util.rs
@@ -106,7 +106,7 @@ impl<Scalar: PrimeField> Num<Scalar> {
     let bits: Vec<Variable> = (1..n_bits)
       .map(|i| {
         cs.alloc(
-          || format!("bit {}", i),
+          || format!("bit {i}"),
           || {
             let r = if *v.grab()?.get_bit(i).grab()? {
               Scalar::one()
@@ -121,7 +121,7 @@ impl<Scalar: PrimeField> Num<Scalar> {
 
     for (i, v) in bits.iter().enumerate() {
       cs.enforce(
-        || format!("{} is bit", i),
+        || format!("{i} is bit"),
         |lc| lc + *v,
         |lc| lc + CS::one() - *v,
         |lc| lc,
@@ -191,7 +191,7 @@ impl<Scalar: PrimeField> Num<Scalar> {
     let allocations: Vec<Bit<Scalar>> = (0..n_bits)
       .map(|bit_i| {
         Bit::alloc(
-          cs.namespace(|| format!("bit{}", bit_i)),
+          cs.namespace(|| format!("bit{bit_i}")),
           values.as_ref().map(|vs| vs[bit_i]),
         )
       })
@@ -257,5 +257,5 @@ pub fn f_to_nat<Scalar: PrimeField>(f: &Scalar) -> BigInt {
 /// Convert a natural number to a field element.
 /// Returns `None` if the number is too big for the field.
 pub fn nat_to_f<Scalar: PrimeField>(n: &BigInt) -> Option<Scalar> {
-  Scalar::from_str_vartime(&format!("{}", n))
+  Scalar::from_str_vartime(&format!("{n}"))
 }

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -225,7 +225,7 @@ where
       .iter()
       .enumerate()
       .map(|(i, limb)| {
-        limb.as_allocated_num(cs.namespace(|| format!("convert limb {} of X_r[0] to num", i)))
+        limb.as_allocated_num(cs.namespace(|| format!("convert limb {i} of X_r[0] to num")))
       })
       .collect::<Result<Vec<AllocatedNum<G::Base>>, _>>()?;
 
@@ -241,7 +241,7 @@ where
       .iter()
       .enumerate()
       .map(|(i, limb)| {
-        limb.as_allocated_num(cs.namespace(|| format!("convert limb {} of X_r[1] to num", i)))
+        limb.as_allocated_num(cs.namespace(|| format!("convert limb {i} of X_r[1] to num")))
       })
       .collect::<Result<Vec<AllocatedNum<G::Base>>, _>>()?;
 

--- a/src/gadgets/utils.rs
+++ b/src/gadgets/utils.rs
@@ -131,7 +131,7 @@ pub fn alloc_bignat_constant<F: PrimeField, CS: ConstraintSystem<F>>(
   #[allow(clippy::needless_range_loop)]
   for i in 0..n_limbs {
     cs.enforce(
-      || format!("check limb {}", i),
+      || format!("check limb {i}"),
       |lc| lc + &bignat.limbs[i],
       |lc| lc + CS::one(),
       |lc| lc + (limbs[i], CS::one()),
@@ -222,7 +222,7 @@ pub fn conditionally_select_vec<F: PrimeField, CS: ConstraintSystem<F>>(
     .zip(b.iter())
     .enumerate()
     .map(|(i, (a, b))| {
-      conditionally_select(cs.namespace(|| format!("select_{}", i)), a, b, condition)
+      conditionally_select(cs.namespace(|| format!("select_{i}")), a, b, condition)
     })
     .collect::<Result<Vec<AllocatedNum<F>>, SynthesisError>>()
 }
@@ -252,7 +252,7 @@ pub fn conditionally_select_bignat<F: PrimeField, CS: ConstraintSystem<F>>(
   // a * condition - b*condition = c - b
   for i in 0..c.limbs.len() {
     cs.enforce(
-      || format!("conditional select constraint {}", i),
+      || format!("conditional select constraint {i}"),
       |lc| lc + &a.limbs[i] - &b.limbs[i],
       |_| condition.lc(CS::one(), F::one()),
       |lc| lc + &c.limbs[i] - &b.limbs[i],

--- a/src/poseidon.rs
+++ b/src/poseidon.rs
@@ -221,9 +221,9 @@ mod tests {
       let num = S::random(&mut csprng);
       ro.absorb(num);
       let num_gadget =
-        AllocatedNum::alloc(cs.namespace(|| format!("data {}", i)), || Ok(num)).unwrap();
+        AllocatedNum::alloc(cs.namespace(|| format!("data {i}")), || Ok(num)).unwrap();
       num_gadget
-        .inputize(&mut cs.namespace(|| format!("input {}", i)))
+        .inputize(&mut cs.namespace(|| format!("input {i}")))
         .unwrap();
       ro_gadget.absorb(num_gadget);
     }


### PR DESCRIPTION
- Uses captured string identifiers as introduced in [Rust 1.58](https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html#captured-identifiers-in-format-strings)
- Removes default features for bellperson and neptune, as they only pull in groth16