### PR TITLE
Feature to enable Neptune GPU Poseidon

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,5 +30,5 @@ jobs:
     - name: Check Rustfmt Code Style
       run: cargo fmt --all -- --check
     - name: Check clippy warnings
-      run: cargo clippy --all-targets --all-features -- -D warnings
+      run: cargo clippy --all-targets -- -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,5 @@ harness = false
 
 [features]
 default = []
+cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24"]
+opencl = ["neptune/opencl", "neptune/pasta", "neptune/arity24"]


### PR DESCRIPTION
Adds features `cuda` and `opencl` to toggle Neptune to compile and use GPU kernels. On https://github.com/nalinbhardwaj/Nova-Scotia/pull/6 this is a ~10% speedup on a larger circuit on my 2018 MacBook (so likely significant on better machines/GPU as well).