### PR TITLE
minor typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ To run tests (we recommend the release mode to drastically shorten run times):
 cargo test --release
 ```
 
+To run example:
+```text
+cargo run --example minroot
+```
+
 ## References
 [Nova: Recursive Zero-Knowledge Arguments from Folding Schemes](https://eprint.iacr.org/2021/370) \
 Abhiram Kothapalli, Srinath Setty, and Ioanna Tzialla \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1076,7 +1076,7 @@ mod tests {
       ) -> Result<Vec<AllocatedNum<F>>, SynthesisError> {
         let x = &z[0];
 
-        // we allocate a variable and set it to the provided non-derministic advice.
+        // we allocate a variable and set it to the provided non-deterministic advice.
         let y = AllocatedNum::alloc(cs.namespace(|| "y"), || Ok(self.y))?;
 
         // We now check if y = x^{1/5} by checking if y^5 = x

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,7 @@ where
         let zi_primary = c_primary.output(&z0_primary);
         let zi_secondary = c_secondary.output(&z0_secondary);
 
-        if z0_primary.len() != pp.F_arity_primary || z0_secondary.len() != pp.F_arity_secondary {
+        if zi_primary.len() != pp.F_arity_primary || zi_secondary.len() != pp.F_arity_secondary {
           return Err(NovaError::InvalidStepOutputLength);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ where
     let F_arity_primary = c_primary.arity();
     let F_arity_secondary = c_secondary.arity();
 
-    // ro_consts_circuit_primart are parameterized by G2 because the type alias uses G2::Base = G1::Scalar
+    // ro_consts_circuit_primary are parameterized by G2 because the type alias uses G2::Base = G1::Scalar
     let ro_consts_circuit_primary: ROConstantsCircuit<G2> = ROConstantsCircuit::<G2>::new();
     let ro_consts_circuit_secondary: ROConstantsCircuit<G1> = ROConstantsCircuit::<G1>::new();
 

--- a/src/traits/circuit.rs
+++ b/src/traits/circuit.rs
@@ -19,7 +19,7 @@ pub trait StepCircuit<F: PrimeField>: Send + Sync + Clone {
     z: &[AllocatedNum<F>],
   ) -> Result<Vec<AllocatedNum<F>>, SynthesisError>;
 
-  /// return the output of the step when provided with with the step's input
+  /// return the output of the step when provided with the step's input
   fn output(&self, z: &[F]) -> Vec<F>;
 }
 


### PR DESCRIPTION
Fixed a minor typo I think.
The length check of z0 is done twice.

(Note: This is my first pull request in my life. I'm sincerely sorry if I missed a practice that should be followed in git and caused any inconvenience.)