### PR TITLE
Make ecc tests generic wrt curves

### DIFF
--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -155,8 +155,8 @@ macro_rules! impl_traits {
       }
 
       fn get_curve_params() -> (Self::Base, Self::Base, BigInt) {
-        let A = Self::Base::zero();
-        let B = Self::Base::from(5);
+        let A = $name::Point::a();
+        let B = $name::Point::b();
         let order = BigInt::from_str_radix($order_str, 16).unwrap();
 
         (A, B, order)


### PR DESCRIPTION
This PR makes the ECC tests generic wrt to the curves, as long as a curve implements `nova::traits::Group`, `pasta_curves::arithmetic::CurveAffine` (which is the case for the curves in `halo2curves`, eg), and the `Base` and `Scalar` fields are shared between the traits.

After https://github.com/microsoft/Nova/pull/162 is merged, we can implement other curve cycles and use them directly in the tests such as in https://github.com/microsoft/Nova/commit/8e70bfca67f77bcfd6de5261d76a52fefdcfa951.