### PR TITLE
chore: Update neptune dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rand_chacha = "0.3"
 itertools = "0.9.0"
 subtle = "2.4"
 pasta_curves = { version = "0.5", features = ["repr-c", "serde"] }
-neptune = { version = "9.0.0", default-features = false }
+neptune = { version = "10.0.0", default-features = false }
 generic-array = "0.14.4"
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"


### PR DESCRIPTION
- Update neptune dependency to version 10.0.0

This imports a bug-fix for the serializer of `PoseidonConstants`, which is used in Lurk to cache Nova's public parameters.