### PR TITLE
Add initial experimental CCS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rand_chacha = "0.3"
 itertools = "0.9.0"
 subtle = "2.4"
 pasta_curves = { version = "0.5", features = ["repr-c", "serde"] }
-neptune = { version = "10.0.0", default-features = false }
+neptune = { version = "9.0.0", default-features = false }
 generic-array = "0.14.4"
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"
@@ -50,7 +50,7 @@ name = "compressed-snark"
 harness = false
 
 [features]
-default = ["hypernova"]
+default = []
 # Compiles in portable mode, w/o ISA extensions => binary can be executed on all systems.
 portable = ["pasta-msm/portable"]
 cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,9 @@ name = "compressed-snark"
 harness = false
 
 [features]
-default = []
+default = ["hypernova"]
 # Compiles in portable mode, w/o ISA extensions => binary can be executed on all systems.
 portable = ["pasta-msm/portable"]
 cuda = ["neptune/cuda", "neptune/pasta", "neptune/arity24"]
 opencl = ["neptune/opencl", "neptune/pasta", "neptune/arity24"]
+hypernova = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rand_chacha = "0.3"
 itertools = "0.9.0"
 subtle = "2.4"
 pasta_curves = { version = "0.5", features = ["repr-c", "serde"] }
-neptune = { version = "9.0.0", default-features = false }
+neptune = { version = "10.0.0", default-features = false }
 generic-array = "0.14.4"
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
+
+### Experimental features
+
+To run early experimental work on CCS and HyperNova, use the `hypernova` feature flag:
+
+```text
+cargo test --features hypernova ccs
+```
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 

--- a/src/ccs.rs
+++ b/src/ccs.rs
@@ -2,16 +2,17 @@
 #![allow(unused_imports)]
 #![allow(dead_code)]
 #![allow(clippy::type_complexity)]
+
 use crate::{
-  constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_HASH_BITS},
+  constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_FE_FOR_RO, NUM_HASH_BITS},
   errors::NovaError,
   gadgets::{
     nonnative::{bignat::nat_to_limbs, util::f_to_nat},
     utils::scalar_as_base,
   },
-  r1cs::R1CSShape,
+  r1cs::{R1CSInstance, R1CSShape, R1CSWitness, R1CS},
   traits::{
-    commitment::CommitmentEngineTrait, AbsorbInROTrait, Group, ROTrait, TranscriptReprTrait,
+    commitment::CommitmentEngineTrait, commitment::CommitmentTrait, AbsorbInROTrait, Group, ROTrait,
   },
   utils::*,
   Commitment, CommitmentKey, CE,
@@ -30,7 +31,7 @@ use sha3::{Digest, Sha3_256};
 // x CCS basic impl
 // x CCS basic is_sat
 // - Clean up old R1CS stuff we don't need
-// - Get rid of hardcoded R1CS
+// x Get rid of hardcoded R1CS
 // - Linearized/Committed CCS
 // - R1CS to CCS
 
@@ -76,8 +77,17 @@ pub struct CCSInstance<G: Group> {
 
 // TODO: Type for other CCS types, eqv to RelaxedR1CS
 
-// TODO: Function to convert R1CS to CCS
-// Put here or in r1cs module
+// TODO: Update variables here? This is currently based on R1CS with M length, not sanity checked
+impl<G: Group> CCS<G> {
+  /// Samples public parameters for the specified number of constraints and variables in an CCS
+  pub fn commitment_key(S: &CCSShape<G>) -> CommitmentKey<G> {
+    let num_cons = S.num_cons;
+    let num_vars = S.num_vars;
+    let total_nz = S.M.iter().fold(0, |acc, m| acc + m.len());
+
+    G::CE::setup(b"ck", max(max(num_cons, num_vars), total_nz))
+  }
+}
 
 // TODO: Util fn to create new CCSShape for R1CS with following values
 // n=n, m=m, N=N, l=l, t=3, q=2, d=2
@@ -383,6 +393,9 @@ impl<G: Group> CCSShape<G> {
   //   Ok((T, comm_T))
   // }
 
+  // TODO: Compute linearized form
+  // Requires MLE
+
   /// Pads the R1CSShape so that the number of variables is a power of two
   /// Renumbers variables to accomodate padded variables
   pub fn pad(&self) -> Self {
@@ -478,5 +491,128 @@ impl<G: Group> CCSInstance<G> {
         X: X.to_owned(),
       })
     }
+  }
+}
+
+#[cfg(test)]
+pub mod test {
+  use super::*;
+  use crate::{
+    r1cs::R1CS,
+    traits::{Group, ROConstantsTrait},
+  };
+  use ::bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+  use ff::{Field, PrimeField};
+  use rand::rngs::OsRng;
+
+  type S = pasta_curves::pallas::Scalar;
+  type G = pasta_curves::pallas::Point;
+
+  #[test]
+  fn test_tiny_ccs() {
+    // 1. Generate valid R1CS Shape
+    // 2. Convert to CCS
+    // 3. Test that it is satisfiable
+
+    let one = S::one();
+    let (num_cons, num_vars, num_io, A, B, C) = {
+      let num_cons = 4;
+      let num_vars = 4;
+      let num_io = 2;
+
+      // Consider a cubic equation: `x^3 + x + 5 = y`, where `x` and `y` are respectively the input and output.
+      // The R1CS for this problem consists of the following constraints:
+      // `I0 * I0 - Z0 = 0`
+      // `Z0 * I0 - Z1 = 0`
+      // `(Z1 + I0) * 1 - Z2 = 0`
+      // `(Z2 + 5) * 1 - I1 = 0`
+
+      // Relaxed R1CS is a set of three sparse matrices (A B C), where there is a row for every
+      // constraint and a column for every entry in z = (vars, u, inputs)
+      // An R1CS instance is satisfiable iff:
+      // Az \circ Bz = u \cdot Cz + E, where z = (vars, 1, inputs)
+      let mut A: Vec<(usize, usize, S)> = Vec::new();
+      let mut B: Vec<(usize, usize, S)> = Vec::new();
+      let mut C: Vec<(usize, usize, S)> = Vec::new();
+
+      // constraint 0 entries in (A,B,C)
+      // `I0 * I0 - Z0 = 0`
+      A.push((0, num_vars + 1, one));
+      B.push((0, num_vars + 1, one));
+      C.push((0, 0, one));
+
+      // constraint 1 entries in (A,B,C)
+      // `Z0 * I0 - Z1 = 0`
+      A.push((1, 0, one));
+      B.push((1, num_vars + 1, one));
+      C.push((1, 1, one));
+
+      // constraint 2 entries in (A,B,C)
+      // `(Z1 + I0) * 1 - Z2 = 0`
+      A.push((2, 1, one));
+      A.push((2, num_vars + 1, one));
+      B.push((2, num_vars, one));
+      C.push((2, 2, one));
+
+      // constraint 3 entries in (A,B,C)
+      // `(Z2 + 5) * 1 - I1 = 0`
+      A.push((3, 2, one));
+      A.push((3, num_vars, one + one + one + one + one));
+      B.push((3, num_vars, one));
+      C.push((3, num_vars + 2, one));
+
+      (num_cons, num_vars, num_io, A, B, C)
+    };
+
+    // create a R1CS shape object
+    let S = {
+      let res = R1CSShape::new(num_cons, num_vars, num_io, &A, &B, &C);
+      assert!(res.is_ok());
+      res.unwrap()
+    };
+
+    // 2. Take R1CS and convert to CCS
+    let S = CCSShape::from_r1cs(S);
+
+    // generate generators and ro constants
+    let _ck = CCS::<G>::commitment_key(&S);
+    let _ro_consts =
+      <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::new();
+
+    // 3. Test that CCS is satisfiable
+    let _rand_inst_witness_generator =
+      |ck: &CommitmentKey<G>, I: &S| -> (S, CCSInstance<G>, CCSWitness<G>) {
+        let i0 = *I;
+
+        // compute a satisfying (vars, X) tuple
+        let (O, vars, X) = {
+          let z0 = i0 * i0; // constraint 0
+          let z1 = i0 * z0; // constraint 1
+          let z2 = z1 + i0; // constraint 2
+          let i1 = z2 + one + one + one + one + one; // constraint 3
+
+          // store the witness and IO for the instance
+          let W = vec![z0, z1, z2, S::zero()];
+          let X = vec![i0, i1];
+          (i1, W, X)
+        };
+
+        let W = {
+          let res = CCSWitness::new(&S, &vars);
+          assert!(res.is_ok());
+          res.unwrap()
+        };
+        let U = {
+          let comm_W = W.commit(ck);
+          let res = CCSInstance::new(&S, &comm_W, &X);
+          assert!(res.is_ok());
+          res.unwrap()
+        };
+
+        // check that generated instance is satisfiable
+        assert!(S.is_sat(ck, &U, &W).is_ok());
+
+        (O, U, W)
+      };
   }
 }

--- a/src/ccs.rs
+++ b/src/ccs.rs
@@ -1,0 +1,540 @@
+//! This module defines CCS related types and functions.
+#![allow(unused_imports)]
+#![allow(dead_code)]
+#![allow(clippy::type_complexity)]
+use crate::{
+  constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_HASH_BITS},
+  errors::NovaError,
+  gadgets::{
+    nonnative::{bignat::nat_to_limbs, util::f_to_nat},
+    utils::scalar_as_base,
+  },
+  traits::{
+    commitment::CommitmentEngineTrait, AbsorbInROTrait, Group, ROTrait, TranscriptReprTrait,
+  },
+  utils::*,
+  Commitment, CommitmentKey, CE,
+};
+use bitvec::vec;
+use core::{cmp::max, marker::PhantomData};
+use ff::Field;
+use flate2::{write::ZlibEncoder, Compression};
+use itertools::concat;
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+use sha3::{Digest, Sha3_256};
+
+// TODO, based on r1cs.rs:
+// x CCS struct
+// x CCS basic impl
+// x CCS basic is_sat
+// - Clean up old R1CS stuff we don't need
+// - Get rid of hardcoded R1CS
+// - Linearized/Committed CCS
+// - R1CS to CCS
+
+/// Public parameters for a given CCS
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct CCS<G: Group> {
+  _p: PhantomData<G>,
+}
+
+// A type that holds the shape of a CCS instance
+// Unlike R1CS we have a list of matrices M instead of only A, B, C
+// We also have t, q, d constants and c (vector), S (set)
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CCSShape<G: Group> {
+  pub(crate) num_cons: usize,
+  pub(crate) num_vars: usize,
+  pub(crate) num_io: usize,
+  pub(crate) M: Vec<Vec<(usize, usize, G::Scalar)>>,
+  pub(crate) t: usize,
+  pub(crate) q: usize,
+  pub(crate) d: usize,
+  pub(crate) S: Vec<Vec<usize>>,
+  pub(crate) c: Vec<usize>,
+  digest: G::Scalar, // digest of the rest of CCSShape
+}
+
+/// A type that holds a witness for a given CCS instance
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CCSWitness<G: Group> {
+  W: Vec<G::Scalar>,
+}
+
+/// A type that holds an CCS instance
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct CCSInstance<G: Group> {
+  pub(crate) comm_W: Commitment<G>,
+  pub(crate) X: Vec<G::Scalar>,
+}
+
+// TODO: Type for other CCS types, eqv to RelaxedR1CS
+
+// TODO: Function to convert R1CS to CCS
+// Put here or in r1cs module
+
+// TODO: Util fn to create new CCSShape for R1CS with following values
+// n=n, m=m, N=N, l=l, t=3, q=2, d=2
+// M={A,B,C}, S={{0, 1}, {2}}, c={1,−1}
+
+impl<G: Group> CCSShape<G> {
+  /// Create an object of type `CCSSShape` from the explicitly specified CCS matrices
+  pub fn new(
+    num_cons: usize,
+    num_vars: usize,
+    num_io: usize,
+    M: &[Vec<(usize, usize, G::Scalar)>],
+  ) -> Result<CCSShape<G>, NovaError> {
+    // NOTE: We assume the following constants for R1CS-to-CCS
+    // TODO: Add as parameters to new once all hardcoding is removed
+    const T: usize = 3;
+    const Q: usize = 2;
+    const D: usize = 2;
+    const S1: [usize; 2] = [0, 1];
+    const S2: [usize; 1] = [2];
+    const C0: i32 = 1;
+    const C1: i32 = -1;
+
+    let is_valid = |num_cons: usize,
+                    num_vars: usize,
+                    num_io: usize,
+                    matrix: &[(usize, usize, G::Scalar)]|
+     -> Result<(), NovaError> {
+      let res = (0..matrix.len())
+        .map(|i| {
+          let (row, col, _val) = matrix[i];
+          if row >= num_cons || col > num_io + num_vars {
+            Err(NovaError::InvalidIndex)
+          } else {
+            Ok(())
+          }
+        })
+        .collect::<Result<Vec<()>, NovaError>>();
+
+      if res.is_err() {
+        Err(NovaError::InvalidIndex)
+      } else {
+        Ok(())
+      }
+    };
+
+    // Check that the row and column indexes are within the range of the number of constraints and variables
+    let res_M = M
+      .iter()
+      .map(|m| is_valid(num_cons, num_vars, num_io, m))
+      .collect::<Result<Vec<()>, NovaError>>();
+
+    // If any of the matricies are invalid, return an error
+    if res_M.is_err() {
+      return Err(NovaError::InvalidIndex);
+    }
+
+    // We require the number of public inputs/outputs to be even
+    if num_io % 2 != 0 {
+      return Err(NovaError::OddInputLength);
+    }
+
+    let digest = Self::compute_digest(num_cons, num_vars, num_io, M);
+
+    let shape = CCSShape {
+      num_cons,
+      num_vars,
+      num_io,
+      M: M.to_vec(),
+      t: T,
+      q: Q,
+      d: D,
+      S: vec![S1.to_vec(), S2.to_vec()],
+      c: vec![C0 as usize, C1 as usize],
+      digest,
+    };
+
+    Ok(shape)
+  }
+
+  // NOTE: Not currently used
+  // TODO This has to be updated for CCS to not just return Az, Bz, Cz
+  // pub fn multiply_vec(
+  //   &self,
+  //   z: &[G::Scalar],
+  // ) -> Result<Vec<Vec<G::Scalar>>, NovaError> {
+  //   if z.len() != self.num_io + self.num_vars + 1 {
+  //     return Err(NovaError::InvalidWitnessLength);
+  //   }
+
+  //   // computes a product between a sparse matrix `matrix` and a vector `z`
+  //   // This does not perform any validation of entries in M (e.g., if entries in `M` reference indexes outside the range of `z`)
+  //   // This is safe since we know that `M` is valid
+  //   let sparse_matrix_vec_product =
+  //     |matrix: &Vec<(usize, usize, G::Scalar)>, num_rows: usize, z: &[G::Scalar]| -> Vec<G::Scalar> {
+  //       (0..matrix.len())
+  //         .map(|i| {
+  //           let (row, col, val) =matrix[i];
+  //           (row, val * z[col])
+  //         })
+  //         .fold(vec![G::Scalar::ZERO; num_rows], |mut Mz, (r, v)| {
+  //           Mz[r] += v;
+  //           Mz
+  //         })
+  //     };
+
+  //     // // XXX: Hacky, assumes M is A, B, C (true for R1CS)
+  //     // let A = self.M[0].clone();
+  //     // let B = self.M[1].clone();
+  //     // let C = self.M[2].clone();
+
+  //     // let (Az, (Bz, Cz)) = rayon::join(
+  //     //   || sparse_matrix_vec_product(&A, self.num_cons, z),
+  //     //   || {
+  //     //     rayon::join(
+  //     //       || sparse_matrix_vec_product(&B, self.num_cons, z),
+  //     //       || sparse_matrix_vec_product(&C, self.num_cons, z),
+  //     //     )
+  //     //   },
+  //     // );
+
+  //   // TODO Use rayon to parallelize
+  //   let Mzs = self.M.iter().map(|m| sparse_matrix_vec_product(m, self.num_cons, z)).collect::<Vec<_>>();
+
+  //   Ok(Mzs)
+  // }
+
+  /// Checks if the Relaxed R1CS instance is satisfiable given a witness and its shape
+  // pub fn is_sat_relaxed(
+  //   &self,
+  //   ck: &CommitmentKey<G>,
+  //   U: &RelaxedR1CSInstance<G>,
+  //   W: &RelaxedR1CSWitness<G>,
+  // ) -> Result<(), NovaError> {
+  //   assert_eq!(W.W.len(), self.num_vars);
+  //   assert_eq!(W.E.len(), self.num_cons);
+  //   assert_eq!(U.X.len(), self.num_io);
+
+  //   // verify if Az * Bz = u*Cz + E
+  //   let res_eq: bool = {
+  //     let z = concat(vec![W.W.clone(), vec![U.u], U.X.clone()]);
+  //     let (Az, Bz, Cz) = self.multiply_vec(&z)?;
+  //     assert_eq!(Az.len(), self.num_cons);
+  //     assert_eq!(Bz.len(), self.num_cons);
+  //     assert_eq!(Cz.len(), self.num_cons);
+
+  //     let res: usize = (0..self.num_cons)
+  //       .map(|i| usize::from(Az[i] * Bz[i] != U.u * Cz[i] + W.E[i]))
+  //       .sum();
+
+  //     res == 0
+  //   };
+
+  //   // verify if comm_E and comm_W are commitments to E and W
+  //   let res_comm: bool = {
+  //     let (comm_W, comm_E) =
+  //       rayon::join(|| CE::<G>::commit(ck, &W.W), || CE::<G>::commit(ck, &W.E));
+  //     U.comm_W == comm_W && U.comm_E == comm_E
+  //   };
+
+  //   if res_eq && res_comm {
+  //     Ok(())
+  //   } else {
+  //     Err(NovaError::UnSat)
+  //   }
+  // }
+
+  /// Checks if the CCS instance is satisfiable given a witness and its shape
+  pub fn is_sat(
+    &self,
+    ck: &CommitmentKey<G>,
+    U: &CCSInstance<G>,
+    W: &CCSWitness<G>,
+  ) -> Result<(), NovaError> {
+    assert_eq!(W.W.len(), self.num_vars);
+    assert_eq!(U.X.len(), self.num_io);
+
+    let m = self.M[0].len();
+
+    // Sage code to check CCS relation:
+    //
+    // r = [F(0)] * m
+    // for i in range(0, q):
+    //     hadamard_output = [F(1)]*m
+    //     for j in S[i]:
+    //         hadamard_output = hadamard_product(hadamard_output,
+    //                 matrix_vector_product(M[j], z))
+    //
+    //     r = vec_add(r, vec_elem_mul(hadamard_output, c[i]))
+    // print("\nCCS relation check (∑ cᵢ ⋅ ◯ Mⱼ z == 0):", r == [0]*m)
+    //
+    // verify if ∑ cᵢ ⋅ ◯ Mⱼ z == 0
+    let res_eq: bool = {
+      let mut r = vec![G::Scalar::ZERO; m];
+      let z = concat(vec![W.W.clone(), vec![G::Scalar::ONE], U.X.clone()]);
+
+      for i in 0..self.q {
+        let mut hadamard_output = vec![G::Scalar::ONE; m];
+        for j in &self.S[i] {
+          let mvp = matrix_vector_product_sparse(&self.M[*j], &z)?;
+          hadamard_output = hadamard_product(&hadamard_output, &mvp)?;
+        }
+
+        // XXX Problem if c[i] is F?
+        let civ = G::Scalar::from(self.c[i] as u64);
+        let vep = vector_elem_product(&hadamard_output, &civ)?;
+
+        r = vector_add(&r, &vep)?;
+      }
+      r == vec![G::Scalar::ZERO; m]
+    };
+
+    // NOTE: Previous R1CS code for reference
+    // // verify if Az * Bz = u*Cz
+    // let res_eq: bool = {
+    //   let z = concat(vec![W.W.clone(), vec![G::Scalar::ONE], U.X.clone()]);
+    //   let (Az, Bz, Cz) = self.multiply_vec(&z)?;
+    //   assert_eq!(Az.len(), self.num_cons);
+    //   assert_eq!(Bz.len(), self.num_cons);
+    //   assert_eq!(Cz.len(), self.num_cons);
+
+    //   let res: usize = (0..self.num_cons)
+    //     .map(|i| usize::from(Az[i] * Bz[i] != Cz[i]))
+    //     .sum();
+
+    //   res == 0
+    // };
+
+    // verify if comm_W is a commitment to W
+    let res_comm: bool = U.comm_W == CE::<G>::commit(ck, &W.W);
+
+    if res_eq && res_comm {
+      Ok(())
+    } else {
+      Err(NovaError::UnSat)
+    }
+  }
+
+  /// A method to compute a commitment to the cross-term `T` given a
+  /// Relaxed R1CS instance-witness pair and an R1CS instance-witness pair
+  // pub fn commit_T(
+  //   &self,
+  //   ck: &CommitmentKey<G>,
+  //   U1: &RelaxedR1CSInstance<G>,
+  //   W1: &RelaxedR1CSWitness<G>,
+  //   U2: &R1CSInstance<G>,
+  //   W2: &R1CSWitness<G>,
+  // ) -> Result<(Vec<G::Scalar>, Commitment<G>), NovaError> {
+  //   let (AZ_1, BZ_1, CZ_1) = {
+  //     let Z1 = concat(vec![W1.W.clone(), vec![U1.u], U1.X.clone()]);
+  //     self.multiply_vec(&Z1)?
+  //   };
+
+  //   let (AZ_2, BZ_2, CZ_2) = {
+  //     let Z2 = concat(vec![W2.W.clone(), vec![G::Scalar::ONE], U2.X.clone()]);
+  //     self.multiply_vec(&Z2)?
+  //   };
+
+  //   let AZ_1_circ_BZ_2 = (0..AZ_1.len())
+  //     .into_par_iter()
+  //     .map(|i| AZ_1[i] * BZ_2[i])
+  //     .collect::<Vec<G::Scalar>>();
+  //   let AZ_2_circ_BZ_1 = (0..AZ_2.len())
+  //     .into_par_iter()
+  //     .map(|i| AZ_2[i] * BZ_1[i])
+  //     .collect::<Vec<G::Scalar>>();
+  //   let u_1_cdot_CZ_2 = (0..CZ_2.len())
+  //     .into_par_iter()
+  //     .map(|i| U1.u * CZ_2[i])
+  //     .collect::<Vec<G::Scalar>>();
+  //   let u_2_cdot_CZ_1 = (0..CZ_1.len())
+  //     .into_par_iter()
+  //     .map(|i| CZ_1[i])
+  //     .collect::<Vec<G::Scalar>>();
+
+  //   let T = AZ_1_circ_BZ_2
+  //     .par_iter()
+  //     .zip(&AZ_2_circ_BZ_1)
+  //     .zip(&u_1_cdot_CZ_2)
+  //     .zip(&u_2_cdot_CZ_1)
+  //     .map(|(((a, b), c), d)| *a + *b - *c - *d)
+  //     .collect::<Vec<G::Scalar>>();
+
+  //   let comm_T = CE::<G>::commit(ck, &T);
+
+  //   Ok((T, comm_T))
+  // }
+
+  /// returns the digest of R1CSShape
+  pub fn get_digest(&self) -> G::Scalar {
+    self.digest
+  }
+
+  fn compute_digest(
+    num_cons: usize,
+    num_vars: usize,
+    num_io: usize,
+    M: &[Vec<(usize, usize, G::Scalar)>],
+  ) -> G::Scalar {
+    #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+    struct CCSShapeWithoutDigest<G: Group> {
+      num_cons: usize,
+      num_vars: usize,
+      num_io: usize,
+      M: Vec<Vec<(usize, usize, G::Scalar)>>,
+    }
+
+    let shape = CCSShapeWithoutDigest::<G> {
+      num_cons,
+      num_vars,
+      num_io,
+      M: M.to_vec(),
+    };
+
+    // obtain a vector of bytes representing the CCS shape
+    let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+    bincode::serialize_into(&mut encoder, &shape).unwrap();
+    let shape_bytes = encoder.finish().unwrap();
+
+    // convert shape_bytes into a short digest
+    let mut hasher = Sha3_256::new();
+    hasher.input(&shape_bytes);
+    let digest = hasher.result();
+
+    // truncate the digest to 250 bits
+    let bv = (0..NUM_HASH_BITS).map(|i| {
+      let (byte_pos, bit_pos) = (i / 8, i % 8);
+      let bit = (digest[byte_pos] >> bit_pos) & 1;
+      bit == 1
+    });
+
+    // turn the bit vector into a scalar
+    let mut res = G::Scalar::ZERO;
+    let mut coeff = G::Scalar::ONE;
+    for bit in bv {
+      if bit {
+        res += coeff;
+      }
+      coeff += coeff;
+    }
+    res
+  }
+
+  /// Pads the R1CSShape so that the number of variables is a power of two
+  /// Renumbers variables to accomodate padded variables
+  pub fn pad(&self) -> Self {
+    // equalize the number of variables and constraints
+    let m = max(self.num_vars, self.num_cons).next_power_of_two();
+
+    // check if the provided R1CSShape is already as required
+    if self.num_vars == m && self.num_cons == m {
+      return self.clone();
+    }
+
+    // check if the number of variables are as expected, then
+    // we simply set the number of constraints to the next power of two
+    if self.num_vars == m {
+      let digest = Self::compute_digest(m, self.num_vars, self.num_io, &self.M);
+
+      // NOTE: We assume the following constants for R1CS-to-CCS
+      const T: usize = 3;
+      const Q: usize = 2;
+      const D: usize = 2;
+      const S: [[usize; 2]; 1] = [[0, 1]];
+      const S2: [usize; 1] = [2];
+      const C0: i32 = 1;
+      const C1: i32 = -1;
+
+      return CCSShape {
+        num_cons: m,
+        num_vars: m,
+        num_io: self.num_io,
+        M: self.M.clone(),
+        t: T,
+        q: Q,
+        d: D,
+        S: vec![S[0].to_vec(), S2.to_vec()],
+        c: vec![C0 as usize, C1 as usize],
+        digest,
+      };
+    }
+
+    // otherwise, we need to pad the number of variables and renumber variable accesses
+    let num_vars_padded = m;
+    let num_cons_padded = m;
+    let apply_pad = |M: &[(usize, usize, G::Scalar)]| -> Vec<(usize, usize, G::Scalar)> {
+      M.par_iter()
+        .map(|(r, c, v)| {
+          (
+            *r,
+            if c >= &self.num_vars {
+              c + num_vars_padded - self.num_vars
+            } else {
+              *c
+            },
+            *v,
+          )
+        })
+        .collect::<Vec<_>>()
+    };
+
+    // Apply pad for each matrix in M
+    let M_padded = self.M.iter().map(|m| apply_pad(m)).collect::<Vec<_>>();
+
+    let digest = Self::compute_digest(num_cons_padded, num_vars_padded, self.num_io, &M_padded);
+
+    // NOTE: We assume the following constants for R1CS-to-CCS
+    const T: usize = 3;
+    const Q: usize = 2;
+    const D: usize = 2;
+    const S: [[usize; 2]; 1] = [[0, 1]];
+    const S2: [usize; 1] = [2];
+    const C0: i32 = 1;
+    const C1: i32 = -1;
+
+    CCSShape {
+      num_cons: num_cons_padded,
+      num_vars: num_vars_padded,
+      num_io: self.num_io,
+      M: M_padded,
+      t: T,
+      q: Q,
+      d: D,
+      S: vec![S[0].to_vec(), S2.to_vec()],
+      c: vec![C0 as usize, C1 as usize],
+      digest,
+    }
+  }
+}
+
+impl<G: Group> CCSWitness<G> {
+  /// A method to create a witness object using a vector of scalars
+  pub fn new(S: &CCSShape<G>, W: &[G::Scalar]) -> Result<CCSWitness<G>, NovaError> {
+    if S.num_vars != W.len() {
+      Err(NovaError::InvalidWitnessLength)
+    } else {
+      Ok(CCSWitness { W: W.to_owned() })
+    }
+  }
+
+  /// Commits to the witness using the supplied generators
+  pub fn commit(&self, ck: &CommitmentKey<G>) -> Commitment<G> {
+    CE::<G>::commit(ck, &self.W)
+  }
+}
+
+impl<G: Group> CCSInstance<G> {
+  /// A method to create an instance object using consitituent elements
+  pub fn new(
+    S: &CCSShape<G>,
+    comm_W: &Commitment<G>,
+    X: &[G::Scalar],
+  ) -> Result<CCSInstance<G>, NovaError> {
+    if S.num_io != X.len() {
+      Err(NovaError::InvalidInputLength)
+    } else {
+      Ok(CCSInstance {
+        comm_W: *comm_W,
+        X: X.to_owned(),
+      })
+    }
+  }
+}

--- a/src/ccs.rs
+++ b/src/ccs.rs
@@ -26,14 +26,9 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 
-// TODO, based on r1cs.rs:
-// x CCS struct
-// x CCS basic impl
-// x CCS basic is_sat
-// - Clean up old R1CS stuff we don't need
-// x Get rid of hardcoded R1CS
-// - Linearized/Committed CCS
-// - R1CS to CCS
+// TODO: Create a SparseMatrix type? Vec<(usize, usize, G::Scalar)>
+// TODO: Committed CCS using MLE (see src/spartan/pp.rs)
+// TODO: Linearized CCS struct and methods, separate struct similar to RelaxedR1CS
 
 /// Public parameters for a given CCS
 #[derive(Clone, Serialize, Deserialize)]
@@ -42,12 +37,10 @@ pub struct CCS<G: Group> {
   _p: PhantomData<G>,
 }
 
-// TODO Pull out matrix type?
-
-// A type that holds the shape of a CCS instance
-// Unlike R1CS we have a list of matrices M instead of only A, B, C
-// We also have t, q, d constants and c (vector), S (set)
-// TODO Add m, n, or infer from M?
+// NOTE: Currently m, n are implicit, could possibly infer from M
+/// A type that holds the shape of a CCS instance
+/// Unlike R1CS we have a list of matrices M instead of only A, B, C
+/// We also have t, q, d constants and c (vector), S (set)
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CCSShape<G: Group> {
   pub(crate) num_cons: usize,
@@ -67,6 +60,7 @@ pub struct CCSWitness<G: Group> {
   W: Vec<G::Scalar>,
 }
 
+// TODO: Make sure this is in the right form for committed CCS using MLE, possibly a separate type?
 /// A type that holds an CCS instance
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound = "")]
@@ -75,10 +69,8 @@ pub struct CCSInstance<G: Group> {
   pub(crate) X: Vec<G::Scalar>,
 }
 
-// TODO: Type for other CCS types, eqv to RelaxedR1CS
-
-// TODO: Update variables here? This is currently based on R1CS with M length, not sanity checked
 impl<G: Group> CCS<G> {
+  // TODO: Update commitment_key variables here? This is currently based on R1CS with M length
   /// Samples public parameters for the specified number of constraints and variables in an CCS
   pub fn commitment_key(S: &CCSShape<G>) -> CommitmentKey<G> {
     let num_cons = S.num_cons;
@@ -88,10 +80,6 @@ impl<G: Group> CCS<G> {
     G::CE::setup(b"ck", max(max(num_cons, num_vars), total_nz))
   }
 }
-
-// TODO: Util fn to create new CCSShape for R1CS with following values
-// n=n, m=m, N=N, l=l, t=3, q=2, d=2
-// M={A,B,C}, S={{0, 1}, {2}}, c={1,−1}
 
 impl<G: Group> CCSShape<G> {
   /// Create an object of type `CCSSShape` from the explicitly specified CCS matrices
@@ -155,99 +143,15 @@ impl<G: Group> CCSShape<G> {
       d,
       S,
       c,
-      //     S: vec![S1.to_vec(), S2.to_vec()],
-      //     c: vec![C0 as usize, C1 as usize],
     };
 
     Ok(shape)
   }
 
-  // NOTE: Not currently used
-  // TODO This has to be updated for CCS to not just return Az, Bz, Cz
-  // pub fn multiply_vec(
-  //   &self,
-  //   z: &[G::Scalar],
-  // ) -> Result<Vec<Vec<G::Scalar>>, NovaError> {
-  //   if z.len() != self.num_io + self.num_vars + 1 {
-  //     return Err(NovaError::InvalidWitnessLength);
-  //   }
+  // NOTE: Not using previous used multiply_vec (r1cs.rs), see utils.rs
 
-  //   // computes a product between a sparse matrix `matrix` and a vector `z`
-  //   // This does not perform any validation of entries in M (e.g., if entries in `M` reference indexes outside the range of `z`)
-  //   // This is safe since we know that `M` is valid
-  //   let sparse_matrix_vec_product =
-  //     |matrix: &Vec<(usize, usize, G::Scalar)>, num_rows: usize, z: &[G::Scalar]| -> Vec<G::Scalar> {
-  //       (0..matrix.len())
-  //         .map(|i| {
-  //           let (row, col, val) =matrix[i];
-  //           (row, val * z[col])
-  //         })
-  //         .fold(vec![G::Scalar::ZERO; num_rows], |mut Mz, (r, v)| {
-  //           Mz[r] += v;
-  //           Mz
-  //         })
-  //     };
-
-  //     // // XXX: Hacky, assumes M is A, B, C (true for R1CS)
-  //     // let A = self.M[0].clone();
-  //     // let B = self.M[1].clone();
-  //     // let C = self.M[2].clone();
-
-  //     // let (Az, (Bz, Cz)) = rayon::join(
-  //     //   || sparse_matrix_vec_product(&A, self.num_cons, z),
-  //     //   || {
-  //     //     rayon::join(
-  //     //       || sparse_matrix_vec_product(&B, self.num_cons, z),
-  //     //       || sparse_matrix_vec_product(&C, self.num_cons, z),
-  //     //     )
-  //     //   },
-  //     // );
-
-  //   // TODO Use rayon to parallelize
-  //   let Mzs = self.M.iter().map(|m| sparse_matrix_vec_product(m, self.num_cons, z)).collect::<Vec<_>>();
-
-  //   Ok(Mzs)
-  // }
-
-  /// Checks if the Relaxed R1CS instance is satisfiable given a witness and its shape
-  // pub fn is_sat_relaxed(
-  //   &self,
-  //   ck: &CommitmentKey<G>,
-  //   U: &RelaxedR1CSInstance<G>,
-  //   W: &RelaxedR1CSWitness<G>,
-  // ) -> Result<(), NovaError> {
-  //   assert_eq!(W.W.len(), self.num_vars);
-  //   assert_eq!(W.E.len(), self.num_cons);
-  //   assert_eq!(U.X.len(), self.num_io);
-
-  //   // verify if Az * Bz = u*Cz + E
-  //   let res_eq: bool = {
-  //     let z = concat(vec![W.W.clone(), vec![U.u], U.X.clone()]);
-  //     let (Az, Bz, Cz) = self.multiply_vec(&z)?;
-  //     assert_eq!(Az.len(), self.num_cons);
-  //     assert_eq!(Bz.len(), self.num_cons);
-  //     assert_eq!(Cz.len(), self.num_cons);
-
-  //     let res: usize = (0..self.num_cons)
-  //       .map(|i| usize::from(Az[i] * Bz[i] != U.u * Cz[i] + W.E[i]))
-  //       .sum();
-
-  //     res == 0
-  //   };
-
-  //   // verify if comm_E and comm_W are commitments to E and W
-  //   let res_comm: bool = {
-  //     let (comm_W, comm_E) =
-  //       rayon::join(|| CE::<G>::commit(ck, &W.W), || CE::<G>::commit(ck, &W.E));
-  //     U.comm_W == comm_W && U.comm_E == comm_E
-  //   };
-
-  //   if res_eq && res_comm {
-  //     Ok(())
-  //   } else {
-  //     Err(NovaError::UnSat)
-  //   }
-  // }
+  // NOTE: Equivalent to is_sat_relaxed (r1cs.rs) but for CCCSS/LCCCS?
+  // Either here or as a separate method on LCCCS struct
 
   /// Checks if the CCS instance is satisfiable given a witness and its shape
   pub fn is_sat(
@@ -285,7 +189,7 @@ impl<G: Group> CCSShape<G> {
           hadamard_output = hadamard_product(&hadamard_output, &mvp)?;
         }
 
-        // XXX Problem if c[i] is F?
+        // XXX: Problem if c[i] is F?
         let civ = G::Scalar::from(self.c[i] as u64);
         let vep = vector_elem_product(&hadamard_output, &civ)?;
 
@@ -293,22 +197,6 @@ impl<G: Group> CCSShape<G> {
       }
       r == vec![G::Scalar::ZERO; m]
     };
-
-    // NOTE: Previous R1CS code for reference
-    // // verify if Az * Bz = u*Cz
-    // let res_eq: bool = {
-    //   let z = concat(vec![W.W.clone(), vec![G::Scalar::ONE], U.X.clone()]);
-    //   let (Az, Bz, Cz) = self.multiply_vec(&z)?;
-    //   assert_eq!(Az.len(), self.num_cons);
-    //   assert_eq!(Bz.len(), self.num_cons);
-    //   assert_eq!(Cz.len(), self.num_cons);
-
-    //   let res: usize = (0..self.num_cons)
-    //     .map(|i| usize::from(Az[i] * Bz[i] != Cz[i]))
-    //     .sum();
-
-    //   res == 0
-    // };
 
     // verify if comm_W is a commitment to W
     let res_comm: bool = U.comm_W == CE::<G>::commit(ck, &W.W);
@@ -342,59 +230,6 @@ impl<G: Group> CCSShape<G> {
       c: vec![C0 as usize, C1 as usize],
     }
   }
-
-  /// A method to compute a commitment to the cross-term `T` given a
-  /// Relaxed R1CS instance-witness pair and an R1CS instance-witness pair
-  // pub fn commit_T(
-  //   &self,
-  //   ck: &CommitmentKey<G>,
-  //   U1: &RelaxedR1CSInstance<G>,
-  //   W1: &RelaxedR1CSWitness<G>,
-  //   U2: &R1CSInstance<G>,
-  //   W2: &R1CSWitness<G>,
-  // ) -> Result<(Vec<G::Scalar>, Commitment<G>), NovaError> {
-  //   let (AZ_1, BZ_1, CZ_1) = {
-  //     let Z1 = concat(vec![W1.W.clone(), vec![U1.u], U1.X.clone()]);
-  //     self.multiply_vec(&Z1)?
-  //   };
-
-  //   let (AZ_2, BZ_2, CZ_2) = {
-  //     let Z2 = concat(vec![W2.W.clone(), vec![G::Scalar::ONE], U2.X.clone()]);
-  //     self.multiply_vec(&Z2)?
-  //   };
-
-  //   let AZ_1_circ_BZ_2 = (0..AZ_1.len())
-  //     .into_par_iter()
-  //     .map(|i| AZ_1[i] * BZ_2[i])
-  //     .collect::<Vec<G::Scalar>>();
-  //   let AZ_2_circ_BZ_1 = (0..AZ_2.len())
-  //     .into_par_iter()
-  //     .map(|i| AZ_2[i] * BZ_1[i])
-  //     .collect::<Vec<G::Scalar>>();
-  //   let u_1_cdot_CZ_2 = (0..CZ_2.len())
-  //     .into_par_iter()
-  //     .map(|i| U1.u * CZ_2[i])
-  //     .collect::<Vec<G::Scalar>>();
-  //   let u_2_cdot_CZ_1 = (0..CZ_1.len())
-  //     .into_par_iter()
-  //     .map(|i| CZ_1[i])
-  //     .collect::<Vec<G::Scalar>>();
-
-  //   let T = AZ_1_circ_BZ_2
-  //     .par_iter()
-  //     .zip(&AZ_2_circ_BZ_1)
-  //     .zip(&u_1_cdot_CZ_2)
-  //     .zip(&u_2_cdot_CZ_1)
-  //     .map(|(((a, b), c), d)| *a + *b - *c - *d)
-  //     .collect::<Vec<G::Scalar>>();
-
-  //   let comm_T = CE::<G>::commit(ck, &T);
-
-  //   Ok((T, comm_T))
-  // }
-
-  // TODO: Compute linearized form
-  // Requires MLE
 
   /// Pads the R1CSShape so that the number of variables is a power of two
   /// Renumbers variables to accomodate padded variables
@@ -445,7 +280,7 @@ impl<G: Group> CCSShape<G> {
     // Apply pad for each matrix in M
     let M_padded = self.M.iter().map(|m| apply_pad(m)).collect::<Vec<_>>();
 
-    // XXX: Check if CCS padding is correct here
+    // TODO: Sanity check if CCS padding is correct here
     CCSShape {
       num_cons: num_cons_padded,
       num_vars: num_vars_padded,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,19 +13,22 @@
 
 // private modules
 mod bellperson;
-mod ccs;
 mod circuit;
 mod constants;
 mod nifs;
 mod r1cs;
-mod utils;
-
 // public modules
 pub mod errors;
 pub mod gadgets;
 pub mod provider;
 pub mod spartan;
 pub mod traits;
+
+// experimental modules
+#[cfg(feature = "hypernova")]
+mod ccs;
+#[cfg(feature = "hypernova")]
+mod utils;
 
 use crate::bellperson::{
   r1cs::{NovaShape, NovaWitness},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ mod circuit;
 mod constants;
 mod nifs;
 mod r1cs;
-
+mod utils;
 // public modules
 pub mod errors;
 pub mod gadgets;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,13 @@
 
 // private modules
 mod bellperson;
+mod ccs;
 mod circuit;
 mod constants;
 mod nifs;
 mod r1cs;
 mod utils;
+
 // public modules
 pub mod errors;
 pub mod gadgets;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,6 @@
 use crate::errors::NovaError;
 use ff::PrimeField;
 
-#[allow(dead_code)]
 pub fn vector_add<F: PrimeField>(a: &Vec<F>, b: &Vec<F>) -> Result<Vec<F>, NovaError> {
   if a.len() != b.len() {
     return Err(NovaError::InvalidIndex);
@@ -16,7 +15,6 @@ pub fn vector_add<F: PrimeField>(a: &Vec<F>, b: &Vec<F>) -> Result<Vec<F>, NovaE
   Ok(res)
 }
 
-#[allow(dead_code)]
 pub fn vector_elem_product<F: PrimeField>(a: &Vec<F>, e: &F) -> Result<Vec<F>, NovaError> {
   let mut res = Vec::with_capacity(a.len());
   for i in 0..a.len() {
@@ -53,7 +51,6 @@ pub fn matrix_vector_product<F: PrimeField>(
 
 // Matrix vector product where matrix is sparse
 // First element is row index, second column, third value stored
-#[allow(dead_code)]
 pub fn matrix_vector_product_sparse<F: PrimeField>(
   matrix: &Vec<(usize, usize, F)>,
   vector: &Vec<F>,
@@ -76,7 +73,6 @@ pub fn matrix_vector_product_sparse<F: PrimeField>(
   Ok(res)
 }
 
-#[allow(dead_code)]
 pub fn hadamard_product<F: PrimeField>(a: &Vec<F>, b: &Vec<F>) -> Result<Vec<F>, NovaError> {
   if a.len() != b.len() {
     return Err(NovaError::InvalidIndex);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,81 @@
+//! Basic utils
+use crate::{
+    errors::NovaError
+};
+use ff::PrimeField;
+
+#[allow(dead_code)]
+pub fn matrix_vector_product<F: PrimeField>(
+  matrix: &Vec<Vec<F>>,
+  vector: &Vec<F>,
+) -> Result<Vec<F>, NovaError> {
+  if matrix.len() == 0 || matrix[0].len() == 0 {
+    return Err(NovaError::InvalidIndex);
+  }
+
+  if matrix[0].len() != vector.len() {
+    return Err(NovaError::InvalidIndex);
+  }
+
+  let mut res = Vec::with_capacity(matrix.len());
+  for i in 0..matrix.len() {
+    let mut sum = F::ZERO;
+    for j in 0..matrix[i].len() {
+      sum += matrix[i][j] * vector[j];
+    }
+    res.push(sum);
+  }
+
+  Ok(res)
+}
+
+#[allow(dead_code)]
+pub fn hadamard_product<F: PrimeField>(a: &Vec<F>, b: &Vec<F>) -> Result<Vec<F>, NovaError> {
+  if a.len() != b.len() {
+    return Err(NovaError::InvalidIndex);
+  }
+
+  let mut res = Vec::with_capacity(a.len());
+  for i in 0..a.len() {
+    res.push(a[i] * b[i]);
+  }
+
+  Ok(res)
+}
+
+#[allow(dead_code)]
+pub fn to_F_vec<F: PrimeField>(v: Vec<u64>) -> Vec<F> {
+  v.iter().map(|x| F::from(*x)).collect()
+}
+
+#[allow(dead_code)]
+pub fn to_F_matrix<F: PrimeField>(m: Vec<Vec<u64>>) -> Vec<Vec<F>> {
+  m.iter().map(|x| to_F_vec(x.clone())).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pasta_curves::Fq;
+
+    #[test]
+    fn test_matrix_vector_product() {
+
+      let matrix = vec![vec![1, 2, 3], vec![4, 5, 6]];
+      let vector = vec![1, 2, 3];
+      let A = to_F_matrix::<Fq>(matrix);
+      let z = to_F_vec::<Fq>(vector);
+      let res = matrix_vector_product(&A, &z).unwrap();
+
+      assert_eq!(res, to_F_vec::<Fq>(vec![14, 32]));
+  }
+
+  #[test]
+  fn test_hadamard_product() {
+      let a = to_F_vec::<Fq>(vec![1, 2, 3]);
+      let b = to_F_vec::<Fq>(vec![4, 5, 6]);
+      let res = hadamard_product(&a, &b).unwrap();
+      assert_eq!(res, to_F_vec::<Fq>(vec![4, 10, 18]));
+  }
+
+}


### PR DESCRIPTION
First initial cut of experimental CCS support. Still a lot of WIP with CCCS/LCCS and using MLE, but a start. Probably has bugs.

Main issue: https://github.com/privacy-scaling-explorations/Nova/issues/13

`cargo test --features hypernova ccs` converts R1CS to CCS and checks `is_sat`.

Code is written to be merged as-is if there's interest. Alternatively, we can keep this PR open until it is more complete. All code is feature flagged under a `hypernova` flag that is off by default, so it has no impact on other parts of the code or users of the Nova library.

Logic follows the structure set out in r1cs.rs and only changing the parts that are different for CCS.

Work will continue in the PSE Nova fork (hypernova branch: https://github.com/privacy-scaling-explorations/nova/tree/hypernova). We're also doing some experimental work in arkworks in a separate repo (https://github.com/privacy-scaling-explorations/multifolding-poc), with the goal of eventually integrating it into the Nova code base.

Opening PR mostly as a FYI and sanity check of direction w.r.t. getting it integrated into the Nova code base.

Leaving PR as draft for now but comments are welcome.