### PR TITLE
[test, chore]: Fix clippy and genericize one more test

### DIFF
--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -439,8 +439,8 @@ where
 
     // we assume the first bit to be 1, so we must initialize acc to self and double it
     // we remove this assumption below
-    let mut acc = p.clone();
-    p = p.double_incomplete(cs.namespace(|| "double"))?;
+    let mut acc = p;
+    p = acc.double_incomplete(cs.namespace(|| "double"))?;
 
     // perform the double-and-add loop to compute the scalar mul using incomplete addition law
     for (i, bit) in incomplete_bits.iter().enumerate().skip(1) {


### PR DESCRIPTION
- make `test_tiny_r2cs` (will help with upcoming adaptation to other curve cycles)
- fix a [`redundant_clone`](https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_clone) clippy warning, closes #178 