### PR TITLE
Add Grumpkin cycle implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ flate2 = "1.0"
 bitvec = "1.0"
 byteorder = "1.4.3"
 thiserror = "1.0" 
+halo2curves = { git = "https://github.com/leonardoalt/halo2curves", branch = "nova", features = [ "derive_serde" ] }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { version = "0.1.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ halo2curves = { version="0.1.0", features = [ "derive_serde" ] }
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { version = "0.1.4" }
 
+[target.wasm32-unknown-unknown.dependencies]
+# see https://github.com/rust-random/rand/pull/948
+getrandom = { version = "0.2.0", default-features = false, features = ["js"]}
+
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
 rand = "0.8.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ flate2 = "1.0"
 bitvec = "1.0"
 byteorder = "1.4.3"
 thiserror = "1.0" 
-halo2curves = { git = "https://github.com/leonardoalt/halo2curves", branch = "nova", features = [ "derive_serde" ] }
+halo2curves = { git = "https://github.com/han0110/halo2curves", branch = "feature/hash-to-curve", features = [ "derive_serde" ] }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { version = "0.1.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ flate2 = "1.0"
 bitvec = "1.0"
 byteorder = "1.4.3"
 thiserror = "1.0" 
-halo2curves = { git = "https://github.com/han0110/halo2curves", branch = "feature/hash-to-curve", features = [ "derive_serde" ] }
+halo2curves = { version="0.1.0", features = [ "derive_serde" ] }
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { version = "0.1.4" }

--- a/src/bellperson/mod.rs
+++ b/src/bellperson/mod.rs
@@ -62,7 +62,7 @@ mod tests {
 
   #[test]
   fn test_alloc_bit() {
-    type G = pasta_curves::pallas::Point;
-    test_alloc_bit_with::<G>();
+    test_alloc_bit_with::<pasta_curves::pallas::Point>();
+    test_alloc_bit_with::<crate::provider::bn254_grumpkin::bn256::Point>();
   }
 }

--- a/src/bellperson/mod.rs
+++ b/src/bellperson/mod.rs
@@ -63,6 +63,6 @@ mod tests {
   #[test]
   fn test_alloc_bit() {
     test_alloc_bit_with::<pasta_curves::pallas::Point>();
-    test_alloc_bit_with::<crate::provider::bn254_grumpkin::bn256::Point>();
+    test_alloc_bit_with::<crate::provider::bn256_grumpkin::bn256::Point>();
   }
 }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -372,8 +372,10 @@ impl<G: Group, SC: StepCircuit<G::Base>> Circuit<<G as Group>::Base>
 mod tests {
   use super::*;
   use crate::bellperson::{shape_cs::ShapeCS, solver::SatisfyingAssignment};
-  type PastaG1 = pasta_curves::pallas::Point;
-  type PastaG2 = pasta_curves::vesta::Point;
+  //type PastaG1 = pasta_curves::pallas::Point;
+  //type PastaG2 = pasta_curves::vesta::Point;
+  type PastaG1 = halo2curves::bn256::Point;
+  type PastaG2 = halo2curves::grumpkin::Point;
 
   use crate::constants::{BN_LIMB_WIDTH, BN_N_LIMBS};
   use crate::{

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -372,12 +372,11 @@ impl<G: Group, SC: StepCircuit<G::Base>> Circuit<<G as Group>::Base>
 mod tests {
   use super::*;
   use crate::bellperson::{shape_cs::ShapeCS, solver::SatisfyingAssignment};
-  //type PastaG1 = pasta_curves::pallas::Point;
-  //type PastaG2 = pasta_curves::vesta::Point;
-  type PastaG1 = halo2curves::bn256::Point;
-  type PastaG2 = halo2curves::grumpkin::Point;
+  type PastaG1 = pasta_curves::pallas::Point;
+  type PastaG2 = pasta_curves::vesta::Point;
 
   use crate::constants::{BN_LIMB_WIDTH, BN_N_LIMBS};
+  use crate::provider;
   use crate::{
     bellperson::r1cs::{NovaShape, NovaWitness},
     gadgets::utils::scalar_as_base,
@@ -473,7 +472,7 @@ mod tests {
   }
 
   #[test]
-  fn test_recursive_circuit() {
+  fn test_recursive_circuit_pasta() {
     let params1 = NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
     let params2 = NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, false);
     let ro_consts1: ROConstantsCircuit<PastaG2> = PoseidonConstantsCircuit::new();
@@ -482,5 +481,20 @@ mod tests {
     test_recursive_circuit_with::<PastaG1, PastaG2>(
       params1, params2, ro_consts1, ro_consts2, 9815, 10347,
     );
+  }
+
+  #[test]
+  fn test_recursive_circuit_grumpkin() {
+    let params1 = NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
+    let params2 = NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, false);
+    let ro_consts1: ROConstantsCircuit<provider::bn254_grumpkin::grumpkin::Point> =
+      PoseidonConstantsCircuit::new();
+    let ro_consts2: ROConstantsCircuit<provider::bn254_grumpkin::bn256::Point> =
+      PoseidonConstantsCircuit::new();
+
+    test_recursive_circuit_with::<
+      provider::bn254_grumpkin::bn256::Point,
+      provider::bn254_grumpkin::grumpkin::Point,
+    >(params1, params2, ro_consts1, ro_consts2, 9983, 10536);
   }
 }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -487,14 +487,14 @@ mod tests {
   fn test_recursive_circuit_grumpkin() {
     let params1 = NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
     let params2 = NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, false);
-    let ro_consts1: ROConstantsCircuit<provider::bn254_grumpkin::grumpkin::Point> =
+    let ro_consts1: ROConstantsCircuit<provider::bn256_grumpkin::grumpkin::Point> =
       PoseidonConstantsCircuit::new();
-    let ro_consts2: ROConstantsCircuit<provider::bn254_grumpkin::bn256::Point> =
+    let ro_consts2: ROConstantsCircuit<provider::bn256_grumpkin::bn256::Point> =
       PoseidonConstantsCircuit::new();
 
     test_recursive_circuit_with::<
-      provider::bn254_grumpkin::bn256::Point,
-      provider::bn254_grumpkin::grumpkin::Point,
+      provider::bn256_grumpkin::bn256::Point,
+      provider::bn256_grumpkin::grumpkin::Point,
     >(params1, params2, ro_consts1, ro_consts2, 9983, 10536);
   }
 }

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -754,7 +754,7 @@ mod tests {
     r1cs::{NovaShape, NovaWitness},
     {shape_cs::ShapeCS, solver::SatisfyingAssignment},
   };
-  use crate::provider::bn254_grumpkin::{bn256, grumpkin};
+  use crate::provider::bn256_grumpkin::{bn256, grumpkin};
   use ff::{Field, PrimeFieldBits};
   use pasta_curves::{arithmetic::CurveAffine, group::Curve, pallas, vesta};
   use rand::rngs::OsRng;

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -754,6 +754,7 @@ mod tests {
     r1cs::{NovaShape, NovaWitness},
     {shape_cs::ShapeCS, solver::SatisfyingAssignment},
   };
+  use crate::provider::bn254_grumpkin::{bn256, grumpkin};
   use ff::{Field, PrimeFieldBits};
   use pasta_curves::{arithmetic::CurveAffine, group::Curve, pallas, vesta};
   use rand::rngs::OsRng;
@@ -768,7 +769,6 @@ mod tests {
     is_infinity: bool,
   }
 
-  #[cfg(test)]
   impl<G> Point<G>
   where
     G: Group,
@@ -896,6 +896,9 @@ mod tests {
   fn test_ecc_ops() {
     test_ecc_ops_with::<pallas::Affine, pallas::Point>();
     test_ecc_ops_with::<vesta::Affine, vesta::Point>();
+
+    test_ecc_ops_with::<bn256::Affine, bn256::Point>();
+    test_ecc_ops_with::<grumpkin::Affine, grumpkin::Point>();
   }
 
   fn test_ecc_ops_with<C, G>()
@@ -977,6 +980,9 @@ mod tests {
   fn test_ecc_circuit_ops() {
     test_ecc_circuit_ops_with::<pallas::Point, vesta::Point>();
     test_ecc_circuit_ops_with::<vesta::Point, pallas::Point>();
+
+    test_ecc_circuit_ops_with::<bn256::Point, grumpkin::Point>();
+    test_ecc_circuit_ops_with::<grumpkin::Point, bn256::Point>();
   }
 
   fn test_ecc_circuit_ops_with<G1, G2>()
@@ -1027,6 +1033,9 @@ mod tests {
   fn test_ecc_circuit_add_equal() {
     test_ecc_circuit_add_equal_with::<pallas::Point, vesta::Point>();
     test_ecc_circuit_add_equal_with::<vesta::Point, pallas::Point>();
+
+    test_ecc_circuit_add_equal_with::<bn256::Point, grumpkin::Point>();
+    test_ecc_circuit_add_equal_with::<grumpkin::Point, bn256::Point>();
   }
 
   fn test_ecc_circuit_add_equal_with<G1, G2>()
@@ -1081,6 +1090,9 @@ mod tests {
   fn test_ecc_circuit_add_negation() {
     test_ecc_circuit_add_negation_with::<pallas::Point, vesta::Point>();
     test_ecc_circuit_add_negation_with::<vesta::Point, pallas::Point>();
+
+    test_ecc_circuit_add_negation_with::<bn256::Point, grumpkin::Point>();
+    test_ecc_circuit_add_negation_with::<grumpkin::Point, bn256::Point>();
   }
 
   fn test_ecc_circuit_add_negation_with<G1, G2>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -793,6 +793,7 @@ fn compute_digest<G: Group, T: Serialize>(o: &T) -> G::Scalar {
 
 #[cfg(test)]
 mod tests {
+  use crate::provider::bn254_grumpkin::{bn256, grumpkin};
   use crate::provider::pedersen::CommitmentKeyExtTrait;
 
   use super::*;
@@ -946,11 +947,11 @@ mod tests {
 
   #[test]
   fn test_ivc_trivial() {
-    //type G1 = pasta_curves::pallas::Point;
-    //type G2 = pasta_curves::vesta::Point;
-    type G1 = halo2curves::bn256::Point;
-    type G2 = halo2curves::grumpkin::Point;
+    type G1 = pasta_curves::pallas::Point;
+    type G2 = pasta_curves::vesta::Point;
     test_ivc_trivial_with::<G1, G2>();
+
+    test_ivc_trivial_with::<bn256::Point, grumpkin::Point>();
   }
 
   fn test_ivc_nontrivial_with<G1, G2>()
@@ -1030,8 +1031,8 @@ mod tests {
   fn test_ivc_nontrivial() {
     //type G1 = pasta_curves::pallas::Point;
     //type G2 = pasta_curves::vesta::Point;
-    type G1 = halo2curves::bn256::Point;
-    type G2 = halo2curves::grumpkin::Point;
+    type G1 = bn256::Point;
+    type G2 = grumpkin::Point;
 
     test_ivc_nontrivial_with::<G1, G2>();
   }
@@ -1126,8 +1127,8 @@ mod tests {
   fn test_ivc_nontrivial_with_compression() {
     //type G1 = pasta_curves::pallas::Point;
     //type G2 = pasta_curves::vesta::Point;
-    type G1 = halo2curves::bn256::Point;
-    type G2 = halo2curves::grumpkin::Point;
+    type G1 = bn256::Point;
+    type G2 = grumpkin::Point;
 
     test_ivc_nontrivial_with_compression_with::<G1, G2>();
   }
@@ -1225,8 +1226,8 @@ mod tests {
   fn test_ivc_nontrivial_with_spark_compression() {
     //type G1 = pasta_curves::pallas::Point;
     //type G2 = pasta_curves::vesta::Point;
-    type G1 = halo2curves::bn256::Point;
-    type G2 = halo2curves::grumpkin::Point;
+    type G1 = bn256::Point;
+    type G2 = grumpkin::Point;
 
     test_ivc_nontrivial_with_spark_compression_with::<G1, G2>();
   }
@@ -1383,8 +1384,8 @@ mod tests {
   fn test_ivc_nondet_with_compression() {
     //type G1 = pasta_curves::pallas::Point;
     //type G2 = pasta_curves::vesta::Point;
-    type G1 = halo2curves::bn256::Point;
-    type G2 = halo2curves::grumpkin::Point;
+    type G1 = bn256::Point;
+    type G2 = grumpkin::Point;
 
     test_ivc_nondet_with_compression_with::<G1, G2>();
   }
@@ -1449,11 +1450,10 @@ mod tests {
 
   #[test]
   fn test_ivc_base() {
-    //type G1 = pasta_curves::pallas::Point;
-    //type G2 = pasta_curves::vesta::Point;
-    type G1 = halo2curves::bn256::Point;
-    type G2 = halo2curves::grumpkin::Point;
+    type G1 = pasta_curves::pallas::Point;
+    type G2 = pasta_curves::vesta::Point;
 
     test_ivc_base_with::<G1, G2>();
+    test_ivc_base_with::<bn256::Point, grumpkin::Point>();
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -896,6 +896,23 @@ mod tests {
       trivial_circuit2,
       "3f7b25f589f2da5ab26254beba98faa54f6442ebf5fa5860caf7b08b576cab00",
     );
+
+    let trivial_circuit1_grumpkin =
+      TrivialTestCircuit::<<bn256::Point as Group>::Scalar>::default();
+    let trivial_circuit2_grumpkin =
+      TrivialTestCircuit::<<grumpkin::Point as Group>::Scalar>::default();
+    let cubic_circuit1_grumpkin = CubicCircuit::<<bn256::Point as Group>::Scalar>::default();
+
+    test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _>(
+      trivial_circuit1_grumpkin,
+      trivial_circuit2_grumpkin.clone(),
+      "967acca1d6b4731cd65d4072c12bbaca9648f24d7bcc2877aee720e4265d4302",
+    );
+    test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _>(
+      cubic_circuit1_grumpkin,
+      trivial_circuit2_grumpkin,
+      "44629f26a78bf6c4e3077f940232050d1793d304fdba5e221d0cf66f76a37903",
+    );
   }
 
   fn test_ivc_trivial_with<G1, G2>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1029,12 +1029,11 @@ mod tests {
 
   #[test]
   fn test_ivc_nontrivial() {
-    //type G1 = pasta_curves::pallas::Point;
-    //type G2 = pasta_curves::vesta::Point;
-    type G1 = bn256::Point;
-    type G2 = grumpkin::Point;
+    type G1 = pasta_curves::pallas::Point;
+    type G2 = pasta_curves::vesta::Point;
 
     test_ivc_nontrivial_with::<G1, G2>();
+    test_ivc_nontrivial_with::<bn256::Point, grumpkin::Point>();
   }
 
   fn test_ivc_nontrivial_with_compression_with<G1, G2>()
@@ -1125,12 +1124,11 @@ mod tests {
 
   #[test]
   fn test_ivc_nontrivial_with_compression() {
-    //type G1 = pasta_curves::pallas::Point;
-    //type G2 = pasta_curves::vesta::Point;
-    type G1 = bn256::Point;
-    type G2 = grumpkin::Point;
+    type G1 = pasta_curves::pallas::Point;
+    type G2 = pasta_curves::vesta::Point;
 
     test_ivc_nontrivial_with_compression_with::<G1, G2>();
+    test_ivc_nontrivial_with_compression_with::<bn256::Point, grumpkin::Point>();
   }
 
   fn test_ivc_nontrivial_with_spark_compression_with<G1, G2>()
@@ -1224,12 +1222,11 @@ mod tests {
 
   #[test]
   fn test_ivc_nontrivial_with_spark_compression() {
-    //type G1 = pasta_curves::pallas::Point;
-    //type G2 = pasta_curves::vesta::Point;
-    type G1 = bn256::Point;
-    type G2 = grumpkin::Point;
+    type G1 = pasta_curves::pallas::Point;
+    type G2 = pasta_curves::vesta::Point;
 
     test_ivc_nontrivial_with_spark_compression_with::<G1, G2>();
+    test_ivc_nontrivial_with_spark_compression_with::<bn256::Point, grumpkin::Point>();
   }
 
   fn test_ivc_nondet_with_compression_with<G1, G2>()
@@ -1382,12 +1379,11 @@ mod tests {
 
   #[test]
   fn test_ivc_nondet_with_compression() {
-    //type G1 = pasta_curves::pallas::Point;
-    //type G2 = pasta_curves::vesta::Point;
-    type G1 = bn256::Point;
-    type G2 = grumpkin::Point;
+    type G1 = pasta_curves::pallas::Point;
+    type G2 = pasta_curves::vesta::Point;
 
     test_ivc_nondet_with_compression_with::<G1, G2>();
+    test_ivc_nondet_with_compression_with::<bn256::Point, grumpkin::Point>();
   }
 
   fn test_ivc_base_with<G1, G2>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -946,8 +946,10 @@ mod tests {
 
   #[test]
   fn test_ivc_trivial() {
-    type G1 = pasta_curves::pallas::Point;
-    type G2 = pasta_curves::vesta::Point;
+    //type G1 = pasta_curves::pallas::Point;
+    //type G2 = pasta_curves::vesta::Point;
+    type G1 = halo2curves::bn256::Point;
+    type G2 = halo2curves::grumpkin::Point;
     test_ivc_trivial_with::<G1, G2>();
   }
 
@@ -1026,8 +1028,10 @@ mod tests {
 
   #[test]
   fn test_ivc_nontrivial() {
-    type G1 = pasta_curves::pallas::Point;
-    type G2 = pasta_curves::vesta::Point;
+    //type G1 = pasta_curves::pallas::Point;
+    //type G2 = pasta_curves::vesta::Point;
+    type G1 = halo2curves::bn256::Point;
+    type G2 = halo2curves::grumpkin::Point;
 
     test_ivc_nontrivial_with::<G1, G2>();
   }
@@ -1120,8 +1124,10 @@ mod tests {
 
   #[test]
   fn test_ivc_nontrivial_with_compression() {
-    type G1 = pasta_curves::pallas::Point;
-    type G2 = pasta_curves::vesta::Point;
+    //type G1 = pasta_curves::pallas::Point;
+    //type G2 = pasta_curves::vesta::Point;
+    type G1 = halo2curves::bn256::Point;
+    type G2 = halo2curves::grumpkin::Point;
 
     test_ivc_nontrivial_with_compression_with::<G1, G2>();
   }
@@ -1217,8 +1223,10 @@ mod tests {
 
   #[test]
   fn test_ivc_nontrivial_with_spark_compression() {
-    type G1 = pasta_curves::pallas::Point;
-    type G2 = pasta_curves::vesta::Point;
+    //type G1 = pasta_curves::pallas::Point;
+    //type G2 = pasta_curves::vesta::Point;
+    type G1 = halo2curves::bn256::Point;
+    type G2 = halo2curves::grumpkin::Point;
 
     test_ivc_nontrivial_with_spark_compression_with::<G1, G2>();
   }
@@ -1373,8 +1381,10 @@ mod tests {
 
   #[test]
   fn test_ivc_nondet_with_compression() {
-    type G1 = pasta_curves::pallas::Point;
-    type G2 = pasta_curves::vesta::Point;
+    //type G1 = pasta_curves::pallas::Point;
+    //type G2 = pasta_curves::vesta::Point;
+    type G1 = halo2curves::bn256::Point;
+    type G2 = halo2curves::grumpkin::Point;
 
     test_ivc_nondet_with_compression_with::<G1, G2>();
   }
@@ -1439,8 +1449,10 @@ mod tests {
 
   #[test]
   fn test_ivc_base() {
-    type G1 = pasta_curves::pallas::Point;
-    type G2 = pasta_curves::vesta::Point;
+    //type G1 = pasta_curves::pallas::Point;
+    //type G2 = pasta_curves::vesta::Point;
+    type G1 = halo2curves::bn256::Point;
+    type G2 = halo2curves::grumpkin::Point;
 
     test_ivc_base_with::<G1, G2>();
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -793,7 +793,7 @@ fn compute_digest<G: Group, T: Serialize>(o: &T) -> G::Scalar {
 
 #[cfg(test)]
 mod tests {
-  use crate::provider::bn254_grumpkin::{bn256, grumpkin};
+  use crate::provider::bn256_grumpkin::{bn256, grumpkin};
   use crate::provider::pedersen::CommitmentKeyExtTrait;
 
   use super::*;

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -210,6 +210,8 @@ mod tests {
   #[test]
   fn test_tiny_r1cs_bellperson() {
     test_tiny_r1cs_bellperson_with::<G>();
+
+    test_tiny_r1cs_bellperson_with::<crate::provider::bn254_grumpkin::bn256::Point>();
   }
 
   #[allow(clippy::too_many_arguments)]
@@ -384,5 +386,6 @@ mod tests {
   #[test]
   fn test_tiny_r1cs() {
     test_tiny_r1cs_with::<pasta_curves::pallas::Point>();
+    test_tiny_r1cs_with::<crate::provider::bn254_grumpkin::bn256::Point>();
   }
 }

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -211,7 +211,7 @@ mod tests {
   fn test_tiny_r1cs_bellperson() {
     test_tiny_r1cs_bellperson_with::<G>();
 
-    test_tiny_r1cs_bellperson_with::<crate::provider::bn254_grumpkin::bn256::Point>();
+    test_tiny_r1cs_bellperson_with::<crate::provider::bn256_grumpkin::bn256::Point>();
   }
 
   #[allow(clippy::too_many_arguments)]
@@ -386,6 +386,6 @@ mod tests {
   #[test]
   fn test_tiny_r1cs() {
     test_tiny_r1cs_with::<pasta_curves::pallas::Point>();
-    test_tiny_r1cs_with::<crate::provider::bn254_grumpkin::bn256::Point>();
+    test_tiny_r1cs_with::<crate::provider::bn256_grumpkin::bn256::Point>();
   }
 }

--- a/src/provider/bn254_grumpkin.rs
+++ b/src/provider/bn254_grumpkin.rs
@@ -1,0 +1,338 @@
+//! This module implements the Nova traits for bn256::Point, bn256::Scalar, grumpkin::Point, grumpkin::Scalar.
+use crate::{
+  provider::{
+    keccak::Keccak256Transcript,
+    pedersen::CommitmentEngine,
+    poseidon::{PoseidonRO, PoseidonROCircuit},
+  },
+  traits::{CompressedGroup, Group, PrimeFieldExt, TranscriptReprTrait},
+};
+use digest::{ExtendableOutput, Input};
+use ff::{FromUniformBytes, PrimeField};
+use num_bigint::BigInt;
+use num_traits::Num;
+use pasta_curves::{
+  self,
+  arithmetic::{CurveAffine, CurveExt},
+  group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup, GroupEncoding},
+};
+use rayon::prelude::*;
+use sha3::Shake256;
+use std::io::Read;
+
+use halo2curves::bn256::{
+  self, Affine as Bn256Affine, Compressed as Bn256Compressed, Point as Bn256,
+};
+use halo2curves::grumpkin::{
+  self, Affine as GrumpkinAffine, Compressed as GrumpkinCompressed, Point as GrumpkinPoint,
+};
+
+macro_rules! impl_traits {
+  (
+    $name:ident,
+    $name_compressed:ident,
+    $name_curve:ident,
+    $name_curve_affine:ident,
+    $order_str:literal
+  ) => {
+    impl Group for $name::Point {
+      type Base = $name::Base;
+      type Scalar = $name::Scalar;
+      type CompressedGroupElement = $name_compressed;
+      type PreprocessedGroupElement = $name::Affine;
+      type RO = PoseidonRO<Self::Base, Self::Scalar>;
+      type ROCircuit = PoseidonROCircuit<Self::Base>;
+      type TE = Keccak256Transcript<Self>;
+      type CE = CommitmentEngine<Self>;
+
+      #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+      fn vartime_multiscalar_mul(
+        scalars: &[Self::Scalar],
+        bases: &[Self::PreprocessedGroupElement],
+      ) -> Self {
+        cpu_best_multiexp(scalars, bases)
+      }
+
+      #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+      fn vartime_multiscalar_mul(
+        scalars: &[Self::Scalar],
+        bases: &[Self::PreprocessedGroupElement],
+      ) -> Self {
+        cpu_best_multiexp(scalars, bases)
+      }
+
+      fn preprocessed(&self) -> Self::PreprocessedGroupElement {
+        self.to_affine()
+      }
+
+      fn compress(&self) -> Self::CompressedGroupElement {
+        self.to_bytes()
+      }
+
+      fn from_label(label: &'static [u8], n: usize) -> Vec<Self::PreprocessedGroupElement> {
+        let mut shake = Shake256::default();
+        shake.input(label);
+        let mut reader = shake.xof_result();
+        let mut uniform_bytes_vec = Vec::new();
+        for _ in 0..n {
+          let mut uniform_bytes = [0u8; 32];
+          reader.read_exact(&mut uniform_bytes).unwrap();
+          uniform_bytes_vec.push(uniform_bytes);
+        }
+        let gens_proj: Vec<$name_curve> = (0..n)
+          .collect::<Vec<usize>>()
+          .into_par_iter()
+          .map(|i| {
+            let hash = $name_curve::hash_to_curve("from_uniform_bytes");
+            hash(&uniform_bytes_vec[i])
+          })
+          .collect();
+
+        let num_threads = rayon::current_num_threads();
+        if gens_proj.len() > num_threads {
+          let chunk = (gens_proj.len() as f64 / num_threads as f64).ceil() as usize;
+          (0..num_threads)
+            .collect::<Vec<usize>>()
+            .into_par_iter()
+            .map(|i| {
+              let start = i * chunk;
+              let end = if i == num_threads - 1 {
+                gens_proj.len()
+              } else {
+                core::cmp::min((i + 1) * chunk, gens_proj.len())
+              };
+              if end > start {
+                let mut gens = vec![$name_curve_affine::identity(); end - start];
+                <Self as Curve>::batch_normalize(&gens_proj[start..end], &mut gens);
+                gens
+              } else {
+                vec![]
+              }
+            })
+            .collect::<Vec<Vec<$name_curve_affine>>>()
+            .into_par_iter()
+            .flatten()
+            .collect()
+        } else {
+          let mut gens = vec![$name_curve_affine::identity(); n];
+          <Self as Curve>::batch_normalize(&gens_proj, &mut gens);
+          gens
+        }
+      }
+
+      fn to_coordinates(&self) -> (Self::Base, Self::Base, bool) {
+        let coordinates = self.to_affine().coordinates();
+        if coordinates.is_some().unwrap_u8() == 1
+          && (coordinates.unwrap().x() != &Self::Base::zero()
+            || coordinates.unwrap().y() != &Self::Base::zero())
+        {
+          (*coordinates.unwrap().x(), *coordinates.unwrap().y(), false)
+        } else {
+          (Self::Base::zero(), Self::Base::zero(), true)
+        }
+      }
+
+      fn get_curve_params() -> (Self::Base, Self::Base, BigInt) {
+        let A = $name::Point::a();
+        let B = $name::Point::b();
+        let order = BigInt::from_str_radix($order_str, 16).unwrap();
+
+        (A, B, order)
+      }
+
+      fn zero() -> Self {
+        $name::Point::identity()
+      }
+
+      fn get_generator() -> Self {
+        $name::Point::generator()
+      }
+    }
+
+    impl PrimeFieldExt for $name::Scalar {
+      fn from_uniform(bytes: &[u8]) -> Self {
+        let bytes_arr: [u8; 64] = bytes.try_into().unwrap();
+        $name::Scalar::from_uniform_bytes(&bytes_arr)
+      }
+
+      /*
+      fn to_bytes(&self) -> Vec<u8> {
+        self.to_repr().as_ref().to_vec()
+      }
+      */
+    }
+
+    impl<G: Group> TranscriptReprTrait<G> for $name_compressed {
+      fn to_transcript_bytes(&self) -> Vec<u8> {
+        self.as_ref().to_vec()
+      }
+    }
+
+    impl CompressedGroup for $name_compressed {
+      type GroupElement = $name::Point;
+
+      fn decompress(&self) -> Option<$name::Point> {
+        Some($name_curve::from_bytes(&self).unwrap())
+      }
+
+      /*
+      fn as_bytes(&self) -> &[u8] {
+        &self.0
+      }
+      */
+    }
+  };
+}
+
+impl<G: Group> TranscriptReprTrait<G> for grumpkin::Base {
+  fn to_transcript_bytes(&self) -> Vec<u8> {
+    self.to_repr().to_vec()
+  }
+}
+
+impl<G: Group> TranscriptReprTrait<G> for grumpkin::Scalar {
+  fn to_transcript_bytes(&self) -> Vec<u8> {
+    self.to_repr().to_vec()
+  }
+}
+
+impl_traits!(
+  grumpkin,
+  GrumpkinCompressed,
+  GrumpkinPoint,
+  GrumpkinAffine,
+  "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001"
+);
+
+impl_traits!(
+  bn256,
+  Bn256Compressed,
+  Bn256,
+  Bn256Affine,
+  "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
+);
+
+/// Native implementation of fast multiexp for platforms that do not support pasta_msm/semolina
+/// Adapted from zcash/halo2
+fn cpu_multiexp_serial<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C], acc: &mut C::Curve) {
+  let coeffs: Vec<_> = coeffs.iter().map(|a| a.to_repr()).collect();
+
+  let c = if bases.len() < 4 {
+    1
+  } else if bases.len() < 32 {
+    3
+  } else {
+    (f64::from(bases.len() as u32)).ln().ceil() as usize
+  };
+
+  fn get_at<F: PrimeField>(segment: usize, c: usize, bytes: &F::Repr) -> usize {
+    let skip_bits = segment * c;
+    let skip_bytes = skip_bits / 8;
+
+    if skip_bytes >= 32 {
+      return 0;
+    }
+
+    let mut v = [0; 8];
+    for (v, o) in v.iter_mut().zip(bytes.as_ref()[skip_bytes..].iter()) {
+      *v = *o;
+    }
+
+    let mut tmp = u64::from_le_bytes(v);
+    tmp >>= skip_bits - (skip_bytes * 8);
+    tmp %= 1 << c;
+
+    tmp as usize
+  }
+
+  let segments = (256 / c) + 1;
+
+  for current_segment in (0..segments).rev() {
+    for _ in 0..c {
+      *acc = acc.double();
+    }
+
+    #[derive(Clone, Copy)]
+    enum Bucket<C: CurveAffine> {
+      None,
+      Affine(C),
+      Projective(C::Curve),
+    }
+
+    impl<C: CurveAffine> Bucket<C> {
+      fn add_assign(&mut self, other: &C) {
+        *self = match *self {
+          Bucket::None => Bucket::Affine(*other),
+          Bucket::Affine(a) => Bucket::Projective(a + *other),
+          Bucket::Projective(mut a) => {
+            a += *other;
+            Bucket::Projective(a)
+          }
+        }
+      }
+
+      fn add(self, mut other: C::Curve) -> C::Curve {
+        match self {
+          Bucket::None => other,
+          Bucket::Affine(a) => {
+            other += a;
+            other
+          }
+          Bucket::Projective(a) => other + a,
+        }
+      }
+    }
+
+    let mut buckets: Vec<Bucket<C>> = vec![Bucket::None; (1 << c) - 1];
+
+    for (coeff, base) in coeffs.iter().zip(bases.iter()) {
+      let coeff = get_at::<C::Scalar>(current_segment, c, coeff);
+      if coeff != 0 {
+        buckets[coeff - 1].add_assign(base);
+      }
+    }
+
+    // Summation by parts
+    // e.g. 3a + 2b + 1c = a +
+    //                    (a) + b +
+    //                    ((a) + b) + c
+    let mut running_sum = C::Curve::identity();
+    for exp in buckets.into_iter().rev() {
+      running_sum = exp.add(running_sum);
+      *acc += &running_sum;
+    }
+  }
+}
+
+/// Performs a multi-exponentiation operation without GPU acceleration.
+///
+/// This function will panic if coeffs and bases have a different length.
+///
+/// This will use multithreading if beneficial.
+/// Adapted from zcash/halo2
+fn cpu_best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve {
+  assert_eq!(coeffs.len(), bases.len());
+
+  let num_threads = rayon::current_num_threads();
+  if coeffs.len() > num_threads {
+    let chunk = coeffs.len() / num_threads;
+    let num_chunks = coeffs.chunks(chunk).len();
+    let mut results = vec![C::Curve::identity(); num_chunks];
+    rayon::scope(|scope| {
+      for ((coeffs, bases), acc) in coeffs
+        .chunks(chunk)
+        .zip(bases.chunks(chunk))
+        .zip(results.iter_mut())
+      {
+        scope.spawn(move |_| {
+          cpu_multiexp_serial(coeffs, bases, acc);
+        });
+      }
+    });
+    results.iter().fold(C::Curve::identity(), |a, b| a + b)
+  } else {
+    let mut acc = C::Curve::identity();
+    cpu_multiexp_serial(coeffs, bases, &mut acc);
+    acc
+  }
+}

--- a/src/provider/bn254_grumpkin.rs
+++ b/src/provider/bn254_grumpkin.rs
@@ -41,6 +41,9 @@ pub mod grumpkin {
   };
 }
 
+// This implementation behaves in ways specific to the bn256/grumpkin curves in:
+// - to_coordinates,
+// - vartime_multiscalar_mul, where it does not call into accelerated implementations.
 macro_rules! impl_traits {
   (
     $name:ident,
@@ -128,8 +131,8 @@ macro_rules! impl_traits {
       fn to_coordinates(&self) -> (Self::Base, Self::Base, bool) {
         let coordinates = self.to_affine().coordinates();
         if coordinates.is_some().unwrap_u8() == 1
-          && (coordinates.unwrap().x() != &Self::Base::zero()
-            || coordinates.unwrap().y() != &Self::Base::zero())
+          // The bn256/grumpkin convention is to define and return the identity point's affine encoding (not None)
+          && (Self::PreprocessedGroupElement::identity() != self.to_affine())
         {
           (*coordinates.unwrap().x(), *coordinates.unwrap().y(), false)
         } else {

--- a/src/provider/bn254_grumpkin.rs
+++ b/src/provider/bn254_grumpkin.rs
@@ -21,11 +21,25 @@ use sha3::Shake256;
 use std::io::Read;
 
 use halo2curves::bn256::{
-  self, Affine as Bn256Affine, Compressed as Bn256Compressed, Point as Bn256,
+  G1Affine as Bn256Affine, G1Compressed as Bn256Compressed, G1 as Bn256Point,
 };
 use halo2curves::grumpkin::{
-  self, Affine as GrumpkinAffine, Compressed as GrumpkinCompressed, Point as GrumpkinPoint,
+  G1Affine as GrumpkinAffine, G1Compressed as GrumpkinCompressed, G1 as GrumpkinPoint,
 };
+
+/// Re-exports that give access to the standard aliases used in the code base, for bn256
+pub mod bn256 {
+  pub use halo2curves::bn256::{
+    Fq as Base, Fr as Scalar, G1Affine as Affine, G1Compressed as Compressed, G1 as Point,
+  };
+}
+
+/// Re-exports that give access to the standard aliases used in the code base, for grumpkin
+pub mod grumpkin {
+  pub use halo2curves::grumpkin::{
+    Fq as Base, Fr as Scalar, G1Affine as Affine, G1Compressed as Compressed, G1 as Point,
+  };
+}
 
 macro_rules! impl_traits {
   (
@@ -197,19 +211,19 @@ impl<G: Group> TranscriptReprTrait<G> for grumpkin::Scalar {
 }
 
 impl_traits!(
+  bn256,
+  Bn256Compressed,
+  Bn256Point,
+  Bn256Affine,
+  "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
+);
+
+impl_traits!(
   grumpkin,
   GrumpkinCompressed,
   GrumpkinPoint,
   GrumpkinAffine,
   "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001"
-);
-
-impl_traits!(
-  bn256,
-  Bn256Compressed,
-  Bn256,
-  Bn256Affine,
-  "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
 );
 
 /// Native implementation of fast multiexp for platforms that do not support pasta_msm/semolina

--- a/src/provider/bn254_grumpkin.rs
+++ b/src/provider/bn254_grumpkin.rs
@@ -59,15 +59,6 @@ macro_rules! impl_traits {
       type TE = Keccak256Transcript<Self>;
       type CE = CommitmentEngine<Self>;
 
-      #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-      fn vartime_multiscalar_mul(
-        scalars: &[Self::Scalar],
-        bases: &[Self::PreprocessedGroupElement],
-      ) -> Self {
-        cpu_best_multiexp(scalars, bases)
-      }
-
-      #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
       fn vartime_multiscalar_mul(
         scalars: &[Self::Scalar],
         bases: &[Self::PreprocessedGroupElement],
@@ -168,12 +159,6 @@ macro_rules! impl_traits {
         let bytes_arr: [u8; 64] = bytes.try_into().unwrap();
         $name::Scalar::from_uniform_bytes(&bytes_arr)
       }
-
-      /*
-      fn to_bytes(&self) -> Vec<u8> {
-        self.to_repr().as_ref().to_vec()
-      }
-      */
     }
 
     impl<G: Group> TranscriptReprTrait<G> for $name_compressed {
@@ -188,12 +173,6 @@ macro_rules! impl_traits {
       fn decompress(&self) -> Option<$name::Point> {
         Some($name_curve::from_bytes(&self).unwrap())
       }
-
-      /*
-      fn as_bytes(&self) -> &[u8] {
-        &self.0
-      }
-      */
     }
   };
 }

--- a/src/provider/bn254_grumpkin.rs
+++ b/src/provider/bn254_grumpkin.rs
@@ -215,7 +215,7 @@ impl_traits!(
   Bn256Compressed,
   Bn256Point,
   Bn256Affine,
-  "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
+  "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001"
 );
 
 impl_traits!(
@@ -223,7 +223,7 @@ impl_traits!(
   GrumpkinCompressed,
   GrumpkinPoint,
   GrumpkinAffine,
-  "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001"
+  "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
 );
 
 /// Native implementation of fast multiexp for platforms that do not support pasta_msm/semolina

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -208,98 +208,6 @@ impl_traits!(
   "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
 );
 
-/// Native implementation of fast multiexp for platforms that do not support pasta_msm/semolina
-/// Adapted from zcash/halo2
-fn cpu_multiexp_serial<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C], acc: &mut C::Curve) {
-  let coeffs: Vec<_> = coeffs.iter().map(|a| a.to_repr()).collect();
-
-  let c = if bases.len() < 4 {
-    1
-  } else if bases.len() < 32 {
-    3
-  } else {
-    (f64::from(bases.len() as u32)).ln().ceil() as usize
-  };
-
-  fn get_at<F: PrimeField>(segment: usize, c: usize, bytes: &F::Repr) -> usize {
-    let skip_bits = segment * c;
-    let skip_bytes = skip_bits / 8;
-
-    if skip_bytes >= 32 {
-      return 0;
-    }
-
-    let mut v = [0; 8];
-    for (v, o) in v.iter_mut().zip(bytes.as_ref()[skip_bytes..].iter()) {
-      *v = *o;
-    }
-
-    let mut tmp = u64::from_le_bytes(v);
-    tmp >>= skip_bits - (skip_bytes * 8);
-    tmp %= 1 << c;
-
-    tmp as usize
-  }
-
-  let segments = (256 / c) + 1;
-
-  for current_segment in (0..segments).rev() {
-    for _ in 0..c {
-      *acc = acc.double();
-    }
-
-    #[derive(Clone, Copy)]
-    enum Bucket<C: CurveAffine> {
-      None,
-      Affine(C),
-      Projective(C::Curve),
-    }
-
-    impl<C: CurveAffine> Bucket<C> {
-      fn add_assign(&mut self, other: &C) {
-        *self = match *self {
-          Bucket::None => Bucket::Affine(*other),
-          Bucket::Affine(a) => Bucket::Projective(a + *other),
-          Bucket::Projective(mut a) => {
-            a += *other;
-            Bucket::Projective(a)
-          }
-        }
-      }
-
-      fn add(self, mut other: C::Curve) -> C::Curve {
-        match self {
-          Bucket::None => other,
-          Bucket::Affine(a) => {
-            other += a;
-            other
-          }
-          Bucket::Projective(a) => other + a,
-        }
-      }
-    }
-
-    let mut buckets: Vec<Bucket<C>> = vec![Bucket::None; (1 << c) - 1];
-
-    for (coeff, base) in coeffs.iter().zip(bases.iter()) {
-      let coeff = get_at::<C::Scalar>(current_segment, c, coeff);
-      if coeff != 0 {
-        buckets[coeff - 1].add_assign(base);
-      }
-    }
-
-    // Summation by parts
-    // e.g. 3a + 2b + 1c = a +
-    //                    (a) + b +
-    //                    ((a) + b) + c
-    let mut running_sum = C::Curve::identity();
-    for exp in buckets.into_iter().rev() {
-      running_sum = exp.add(running_sum);
-      *acc += &running_sum;
-    }
-  }
-}
-
 /// Performs a multi-exponentiation operation without GPU acceleration.
 ///
 /// This function will panic if coeffs and bases have a different length.
@@ -309,31 +217,9 @@ fn cpu_multiexp_serial<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C], acc: &
 // TODO: update once https://github.com/privacy-scaling-explorations/halo2curves/pull/29
 // (or a successor thereof) is merged
 fn cpu_best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve {
-  assert_eq!(coeffs.len(), bases.len());
-
-  let num_threads = rayon::current_num_threads();
-  if coeffs.len() > num_threads {
-    let chunk = coeffs.len() / num_threads;
-    let num_chunks = coeffs.chunks(chunk).len();
-    let mut results = vec![C::Curve::identity(); num_chunks];
-    rayon::scope(|scope| {
-      for ((coeffs, bases), acc) in coeffs
-        .chunks(chunk)
-        .zip(bases.chunks(chunk))
-        .zip(results.iter_mut())
-      {
-        scope.spawn(move |_| {
-          cpu_multiexp_serial(coeffs, bases, acc);
-        });
-      }
-    });
-    results.iter().fold(C::Curve::identity(), |a, b| a + b)
-  } else {
-    let mut acc = C::Curve::identity();
-    cpu_multiexp_serial(coeffs, bases, &mut acc);
-    acc
-  }
+  crate::provider::pasta::cpu_best_multiexp(coeffs, bases)
 }
+
 #[cfg(test)]
 mod tests {
   use super::*;

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -306,6 +306,8 @@ fn cpu_multiexp_serial<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C], acc: &
 ///
 /// This will use multithreading if beneficial.
 /// Adapted from zcash/halo2
+// TODO: update once https://github.com/privacy-scaling-explorations/halo2curves/pull/29
+// (or a successor thereof) is merged
 fn cpu_best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve {
   assert_eq!(coeffs.len(), bases.len());
 

--- a/src/provider/keccak.rs
+++ b/src/provider/keccak.rs
@@ -95,7 +95,7 @@ impl<G: Group> TranscriptEngineTrait<G> for Keccak256Transcript<G> {
 #[cfg(test)]
 mod tests {
   use crate::{
-    provider::bn254_grumpkin::bn256,
+    provider::bn256_grumpkin::bn256,
     provider::keccak::Keccak256Transcript,
     traits::{Group, TranscriptEngineTrait},
   };

--- a/src/provider/keccak.rs
+++ b/src/provider/keccak.rs
@@ -95,13 +95,14 @@ impl<G: Group> TranscriptEngineTrait<G> for Keccak256Transcript<G> {
 #[cfg(test)]
 mod tests {
   use crate::{
+    provider::bn254_grumpkin::bn256,
     provider::keccak::Keccak256Transcript,
     traits::{Group, TranscriptEngineTrait},
   };
   use ff::PrimeField;
   use sha3::{Digest, Keccak256};
 
-  fn test_keccak_transcript_with<G: Group>() {
+  fn test_keccak_transcript_with<G: Group>(expected_h1: &'static str, expected_h2: &'static str) {
     let mut transcript: Keccak256Transcript<G> = Keccak256Transcript::new(b"test");
 
     // two scalars
@@ -114,10 +115,7 @@ mod tests {
 
     // make a challenge
     let c1: <G as Group>::Scalar = transcript.squeeze(b"c1").unwrap();
-    assert_eq!(
-      hex::encode(c1.to_repr().as_ref()),
-      "432d5811c8be3d44d47f52108a8749ae18482efd1a37b830f966456b5d75340c"
-    );
+    assert_eq!(hex::encode(c1.to_repr().as_ref()), expected_h1);
 
     // a scalar
     let s3 = <G as Group>::Scalar::from(128u64);
@@ -127,16 +125,20 @@ mod tests {
 
     // make a challenge
     let c2: <G as Group>::Scalar = transcript.squeeze(b"c2").unwrap();
-    assert_eq!(
-      hex::encode(c2.to_repr().as_ref()),
-      "65f7908d53abcd18f3b1d767456ef9009b91c7566a635e9ca7be26e21d4d7a10"
-    );
+    assert_eq!(hex::encode(c2.to_repr().as_ref()), expected_h2);
   }
 
   #[test]
   fn test_keccak_transcript() {
-    type G = pasta_curves::pallas::Point;
-    test_keccak_transcript_with::<G>()
+    test_keccak_transcript_with::<pasta_curves::pallas::Point>(
+      "432d5811c8be3d44d47f52108a8749ae18482efd1a37b830f966456b5d75340c",
+      "65f7908d53abcd18f3b1d767456ef9009b91c7566a635e9ca7be26e21d4d7a10",
+    );
+
+    test_keccak_transcript_with::<bn256::Point>(
+      "93f9160d5501865b399ee4ff0ffe17b697a4023e33e931e2597d36e6cc4ac602",
+      "bca8bdb96608a8277a7cb34bd493dfbc5baf2a080d1d6c9d32d7ab4f238eb803",
+    );
   }
 
   #[test]

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -4,6 +4,7 @@
 //! `RO` traits with Poseidon
 //! `EvaluationEngine` with an IPA-based polynomial evaluation argument
 
+pub mod bn254_grumpkin;
 pub mod ipa_pc;
 pub mod keccak;
 pub mod pasta;

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -4,7 +4,7 @@
 //! `RO` traits with Poseidon
 //! `EvaluationEngine` with an IPA-based polynomial evaluation argument
 
-pub mod bn254_grumpkin;
+pub mod bn256_grumpkin;
 pub mod ipa_pc;
 pub mod keccak;
 pub mod pasta;

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -320,7 +320,7 @@ fn cpu_multiexp_serial<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C], acc: &
 ///
 /// This will use multithreading if beneficial.
 /// Adapted from zcash/halo2
-fn cpu_best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve {
+pub(crate) fn cpu_best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve {
   assert_eq!(coeffs.len(), bases.len());
 
   let num_threads = rayon::current_num_threads();

--- a/src/provider/poseidon.rs
+++ b/src/provider/poseidon.rs
@@ -201,7 +201,7 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::provider::bn254_grumpkin::bn256;
+  use crate::provider::bn256_grumpkin::bn256;
   use crate::{
     bellperson::solver::SatisfyingAssignment, constants::NUM_CHALLENGE_BITS,
     gadgets::utils::le_bits_to_num, traits::Group,

--- a/src/provider/poseidon.rs
+++ b/src/provider/poseidon.rs
@@ -201,6 +201,7 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::provider::bn254_grumpkin::bn256;
   use crate::{
     bellperson::solver::SatisfyingAssignment, constants::NUM_CHALLENGE_BITS,
     gadgets::utils::le_bits_to_num, traits::Group,
@@ -242,8 +243,7 @@ mod tests {
 
   #[test]
   fn test_poseidon_ro() {
-    type G = pasta_curves::pallas::Point;
-
-    test_poseidon_ro_with::<G>()
+    test_poseidon_ro_with::<pasta_curves::pallas::Point>();
+    test_poseidon_ro_with::<bn256::Point>();
   }
 }

--- a/src/spartan/pp.rs
+++ b/src/spartan/pp.rs
@@ -2185,7 +2185,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>, C: StepCircuit<G::Scala
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::provider::bn254_grumpkin::bn256;
+  use crate::provider::bn256_grumpkin::bn256;
   use ::bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
   use core::marker::PhantomData;
   use ff::PrimeField;

--- a/src/spartan/pp.rs
+++ b/src/spartan/pp.rs
@@ -2185,6 +2185,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>, C: StepCircuit<G::Scala
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::provider::bn254_grumpkin::bn256;
   use ::bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
   use core::marker::PhantomData;
   use ff::PrimeField;
@@ -2244,6 +2245,7 @@ mod tests {
     type EE = crate::provider::ipa_pc::EvaluationEngine<G>;
 
     test_spartan_snark_with::<G, EE>();
+    test_spartan_snark_with::<_, crate::provider::ipa_pc::EvaluationEngine<bn256::Point>>();
   }
 
   fn test_spartan_snark_with<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>>() {


### PR DESCRIPTION
This is joint work with @leonardoalt !

This PR pulls in an implementation of, and runs all Nova tests on the [Ethereum-friendly Grumpkin curve cycle](https://hackmd.io/@aztec-network/ByzgNxBfd#2-Grumpkin---A-curve-on-top-of-BN-254-for-SNARK-efficient-group-operations). 

The implementation ~~is~~ was  from the halo2curves repo with the following pending PR thrown in:
https://github.com/privacy-scaling-explorations/halo2curves/pull/47 - ~~I'll update the present PR when that resolves.~~