### PR TITLE
Remove Zlib compression in public parameter computation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ harness = false
 name = "compressed-snark"
 harness = false
 
+[[bench]]
+name = "compute-digest"
+harness = false
+
 [features]
 default = []
 # Compiles in portable mode, w/o ISA extensions => binary can be executed on all systems.

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -1,0 +1,84 @@
+use std::{marker::PhantomData, time::Duration};
+
+use bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ff::PrimeField;
+use nova_snark::{
+  traits::{
+    circuit::{StepCircuit, TrivialTestCircuit},
+    Group,
+  },
+  PublicParams,
+};
+
+type G1 = pasta_curves::pallas::Point;
+type G2 = pasta_curves::vesta::Point;
+type C1 = NonTrivialTestCircuit<<G1 as Group>::Scalar>;
+type C2 = TrivialTestCircuit<<G2 as Group>::Scalar>;
+
+criterion_group! {
+name = compute_digest;
+config = Criterion::default().warm_up_time(Duration::from_millis(3000)).sample_size(10);
+targets = bench_compute_digest
+}
+
+criterion_main!(compute_digest);
+
+fn bench_compute_digest(c: &mut Criterion) {
+  c.bench_function("compute_digest", |b| {
+    b.iter(|| {
+      PublicParams::<G1, G2, C1, C2>::setup(black_box(C1::new(10)), black_box(C2::default()))
+    })
+  });
+}
+
+#[derive(Clone, Debug, Default)]
+struct NonTrivialTestCircuit<F: PrimeField> {
+  num_cons: usize,
+  _p: PhantomData<F>,
+}
+
+impl<F> NonTrivialTestCircuit<F>
+where
+  F: PrimeField,
+{
+  pub fn new(num_cons: usize) -> Self {
+    Self {
+      num_cons,
+      _p: Default::default(),
+    }
+  }
+}
+impl<F> StepCircuit<F> for NonTrivialTestCircuit<F>
+where
+  F: PrimeField,
+{
+  fn arity(&self) -> usize {
+    1
+  }
+
+  fn synthesize<CS: ConstraintSystem<F>>(
+    &self,
+    cs: &mut CS,
+    z: &[AllocatedNum<F>],
+  ) -> Result<Vec<AllocatedNum<F>>, SynthesisError> {
+    // Consider a an equation: `x^2 = y`, where `x` and `y` are respectively the input and output.
+    let mut x = z[0].clone();
+    let mut y = x.clone();
+    for i in 0..self.num_cons {
+      y = x.square(cs.namespace(|| format!("x_sq_{i}")))?;
+      x = y.clone();
+    }
+    Ok(vec![y])
+  }
+
+  fn output(&self, z: &[F]) -> Vec<F> {
+    let mut x = z[0];
+    let mut y = x;
+    for _i in 0..self.num_cons {
+      y = x * x;
+      x = y;
+    }
+    vec![y]
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -851,6 +851,46 @@ mod tests {
     }
   }
 
+  fn test_pp_digest_with<G1, G2, T1, T2>(circuit1: T1, circuit2: T2, expected: &str)
+  where
+    G1: Group<Base = <G2 as Group>::Scalar>,
+    G2: Group<Base = <G1 as Group>::Scalar>,
+    T1: StepCircuit<G1::Scalar>,
+    T2: StepCircuit<G2::Scalar>,
+  {
+    let pp = PublicParams::<G1, G2, T1, T2>::setup(circuit1, circuit2);
+
+    let digest_str = pp
+      .digest
+      .to_repr()
+      .as_ref()
+      .iter()
+      .map(|b| format!("{:02x}", b))
+      .collect::<String>();
+    assert_eq!(digest_str, expected);
+  }
+
+  #[test]
+  fn test_pp_digest() {
+    type G1 = pasta_curves::pallas::Point;
+    type G2 = pasta_curves::vesta::Point;
+    let trivial_circuit1 = TrivialTestCircuit::<<G1 as Group>::Scalar>::default();
+    let trivial_circuit2 = TrivialTestCircuit::<<G2 as Group>::Scalar>::default();
+    let cubic_circuit1 = CubicCircuit::<<G1 as Group>::Scalar>::default();
+
+    test_pp_digest_with::<G1, G2, _, _>(
+      trivial_circuit1,
+      trivial_circuit2.clone(),
+      "497c94323154901bc87e38f7bc978a76c346d74327b2ca371b2ede191491e901",
+    );
+
+    test_pp_digest_with::<G1, G2, _, _>(
+      cubic_circuit1,
+      trivial_circuit2,
+      "2837eae6fc977d0f1a8896f16aa73969fab9da06361969a8a4feacf23416a603",
+    );
+  }
+
   fn test_ivc_trivial_with<G1, G2>()
   where
     G1: Group<Base = <G2 as Group>::Scalar>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,6 @@ use constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_FE_WITHOUT_IO_FOR_CRHF, NUM_HASH_
 use core::marker::PhantomData;
 use errors::NovaError;
 use ff::Field;
-use flate2::{write::ZlibEncoder, Compression};
 use gadgets::utils::scalar_as_base;
 use nifs::NIFS;
 use r1cs::{R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness};
@@ -757,13 +756,10 @@ type CE<G> = <G as Group>::CE;
 
 fn compute_digest<G: Group, T: Serialize>(o: &T) -> G::Scalar {
   // obtain a vector of bytes representing public parameters
-  let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
-  bincode::serialize_into(&mut encoder, o).unwrap();
-  let pp_bytes = encoder.finish().unwrap();
-
+  let bytes = bincode::serialize(o).unwrap();
   // convert pp_bytes into a short digest
   let mut hasher = Sha3_256::new();
-  hasher.input(&pp_bytes);
+  hasher.input(&bytes);
   let digest = hasher.result();
 
   // truncate the digest to NUM_HASH_BITS bits
@@ -881,13 +877,13 @@ mod tests {
     test_pp_digest_with::<G1, G2, _, _>(
       trivial_circuit1,
       trivial_circuit2.clone(),
-      "497c94323154901bc87e38f7bc978a76c346d74327b2ca371b2ede191491e901",
+      "39a4ea9dd384346fdeb6b5857c7be56fa035153b616d55311f3191dfbceea603",
     );
 
     test_pp_digest_with::<G1, G2, _, _>(
       cubic_circuit1,
       trivial_circuit2,
-      "2837eae6fc977d0f1a8896f16aa73969fab9da06361969a8a4feacf23416a603",
+      "3f7b25f589f2da5ab26254beba98faa54f6442ebf5fa5860caf7b08b576cab00",
     );
   }
 


### PR DESCRIPTION
The Zlib compression of a byte string is not a reproducible artefact across implementations, as can be verified by taking the next-to-last commit of this PR ( c79f4f66a72fe75b59309c03ec24da094b27a8ef ), i.e. reducing the PR to just adding a test and a bench, and trying the following:
- using one of the three non-default backends for the flate2 import, as indicated [here](https://github.com/rust-lang/flate2-rs#backends)
- using gzp with [this commit](https://github.com/microsoft/Nova/commit/45e22aa9a71335b4b0115ccc92f9395bb594f651)
- using libdeflater with [this commit](https://github.com/microsoft/Nova/commit/14aabfe2984abb8b3c3027a56571a5793b5c4d55)

The 5 implementations of Zlib above will all fail to pass the test and return distinct values (not only w.r.t the test, but also w.r.t *each other*) for the digest of the test circuit.

This PR thus tries to remove compression out of the digest computation, and finds the following bench result:
```
compute_digest          time:   [1.4451 s 1.4571 s 1.4689 s]
                        change: [-29.357% -27.854% -26.573%] (p = 0.00 < 0.05)
                        Performance has improved.
```
This seems to solve both a performance and a reproducibility (canonicality) problem.