### PR TITLE
refactor: Refactor Keccak256Transcript and update tests

### DIFF
--- a/src/provider/keccak.rs
+++ b/src/provider/keccak.rs
@@ -23,14 +23,17 @@ pub struct Keccak256Transcript<G: Group> {
 }
 
 fn compute_updated_state(keccak_instance: Keccak256, input: &[u8]) -> [u8; KECCAK256_STATE_SIZE] {
-  let input_lo = [input, &[KECCAK256_PREFIX_CHALLENGE_LO]].concat();
-  let input_hi = [input, &[KECCAK256_PREFIX_CHALLENGE_HI]].concat();
+  let mut updated_instance = keccak_instance;
+  updated_instance.input(input);
 
-  let mut hasher_lo = keccak_instance.clone();
-  let mut hasher_hi = keccak_instance;
+  let input_lo = &[KECCAK256_PREFIX_CHALLENGE_LO];
+  let input_hi = &[KECCAK256_PREFIX_CHALLENGE_HI];
 
-  hasher_lo.input(&input_lo);
-  hasher_hi.input(&input_hi);
+  let mut hasher_lo = updated_instance.clone();
+  let mut hasher_hi = updated_instance;
+
+  hasher_lo.input(input_lo);
+  hasher_hi.input(input_hi);
 
   let output_lo = hasher_lo.result();
   let output_hi = hasher_hi.result();

--- a/src/provider/keccak.rs
+++ b/src/provider/keccak.rs
@@ -57,10 +57,10 @@ impl<G: Group> TranscriptEngineTrait<G> for Keccak256Transcript<G> {
 
   fn squeeze(&mut self, label: &'static [u8]) -> Result<G::Scalar, NovaError> {
     let input = [
+      self.transcript.as_ref(),
       DOM_SEP_TAG,
       self.round.to_le_bytes().as_ref(),
       self.state.as_ref(),
-      self.transcript.as_ref(),
       label,
     ]
     .concat();
@@ -131,13 +131,13 @@ mod tests {
   #[test]
   fn test_keccak_transcript() {
     test_keccak_transcript_with::<pasta_curves::pallas::Point>(
-      "432d5811c8be3d44d47f52108a8749ae18482efd1a37b830f966456b5d75340c",
-      "65f7908d53abcd18f3b1d767456ef9009b91c7566a635e9ca7be26e21d4d7a10",
+      "5ddffa8dc091862132788b8976af88b9a2c70594727e611c7217ba4c30c8c70a",
+      "4d4bf42c065870395749fa1c4fb641df1e0d53f05309b03d5b1db7f0be3aa13d",
     );
 
     test_keccak_transcript_with::<bn256::Point>(
-      "93f9160d5501865b399ee4ff0ffe17b697a4023e33e931e2597d36e6cc4ac602",
-      "bca8bdb96608a8277a7cb34bd493dfbc5baf2a080d1d6c9d32d7ab4f238eb803",
+      "9fb71e3b74bfd0b60d97349849b895595779a240b92a6fae86bd2812692b6b0e",
+      "bfd4c50b7d6317e9267d5d65c985eb455a3561129c0b3beef79bfc8461a84f18",
     );
   }
 


### PR DESCRIPTION
## Problem

The Keccak transcript implementation can allocate a potentially very long vector by storing a full copy of the transcript and hashing it only on a state update. This computation can instead be performed incrementally at the cost of putting the transcript at the start of `squeeze`'s input, only storing the (bounded) state of the hasher.

This improves the memory usage, and has no significant effect on benchmarks:
https://gist.github.com/huitseeker/b5bc1df2e012dcca1356b4c1ad251eee

## Solution
- Replaced the transcript vector with a `Keccak256` instance, improving data handling and memory usage.
- Refactored `compute_updated_state` to work directly on a given `Keccak256` instance, reducing unnecessary object creation.
- this change ~~roughly~~ amounts to putting the transcript at the start of squeeze's input array
- Updated test cases to validate and reflect changes in the keccak transcript implementation.