### PR TITLE
refactor: make CommitmentKeyExtTrait public

### DIFF
--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -203,7 +203,9 @@ impl<G: Group> CommitmentEngineTrait<G> for CommitmentEngine<G> {
   }
 }
 
-pub(crate) trait CommitmentKeyExtTrait<G: Group> {
+/// A trait listing properties of a commitment key that can be managed in a divide-and-conquer fashion
+pub trait CommitmentKeyExtTrait<G: Group> {
+  /// Holds the type of the commitment engine
   type CE: CommitmentEngineTrait<G>;
 
   /// Splits the commitment key into two pieces at a specified point


### PR DESCRIPTION
- Refactored the `CommitmentKeyExtTrait` from the local `src/provider/pedersen.rs` to the more centrally located `src/traits/commitment.rs`.
- Updated `src/provider/ipa_pc.rs` to import `CommitmentKeyExtTrait` directly from its new location in the `commitment` module.

The current `CommitmentKeyExtTrait` must be referred to - if not implemented - by any code base that wants to be generic in the curve cycle that's used in Nova, as #171 demonstrated. In the current state, this trait was crate-private, and could not be referred to, even by projects that would want to write code *only* for the two curve cycles the Nova code base already supports.
