### PR TITLE
feat: Make commitment key generation configurable with an optional parameter

### DIFF
--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -7,6 +7,7 @@ use ff::PrimeField;
 use nova_snark::{
   traits::{
     circuit::{StepCircuit, TrivialCircuit},
+    snark::RelaxedR1CSSNARKTrait,
     Group,
   },
   CompressedSNARK, PublicParams, RecursiveSNARK,
@@ -65,7 +66,12 @@ fn bench_compressed_snark(c: &mut Criterion) {
     let c_secondary = TrivialCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary);
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(
+      &c_primary,
+      &c_secondary,
+      Some(S1::commitment_key_floor()),
+      Some(S2::commitment_key_floor()),
+    );
 
     // Produce prover and verifier keys for CompressedSNARK
     let (pk, vk) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
@@ -147,8 +153,12 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
     let c_secondary = TrivialCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary);
-
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(
+      &c_primary,
+      &c_secondary,
+      Some(SS1::commitment_key_floor()),
+      Some(SS2::commitment_key_floor()),
+    );
     // Produce prover and verifier keys for CompressedSNARK
     let (pk, vk) = CompressedSNARK::<_, _, _, _, SS1, SS2>::setup(&pp).unwrap();
 

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -69,8 +69,8 @@ fn bench_compressed_snark(c: &mut Criterion) {
     let pp = PublicParams::<G1, G2, C1, C2>::setup(
       &c_primary,
       &c_secondary,
-      Some(S1::commitment_key_floor()),
-      Some(S2::commitment_key_floor()),
+      &*S1::commitment_key_floor(),
+      &*S2::commitment_key_floor(),
     );
 
     // Produce prover and verifier keys for CompressedSNARK
@@ -156,8 +156,8 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
     let pp = PublicParams::<G1, G2, C1, C2>::setup(
       &c_primary,
       &c_secondary,
-      Some(SS1::commitment_key_floor()),
-      Some(SS2::commitment_key_floor()),
+      &*SS1::commitment_key_floor(),
+      &*SS2::commitment_key_floor(),
     );
     // Produce prover and verifier keys for CompressedSNARK
     let (pk, vk) = CompressedSNARK::<_, _, _, _, SS1, SS2>::setup(&pp).unwrap();

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -27,7 +27,12 @@ criterion_main!(compute_digest);
 fn bench_compute_digest(c: &mut Criterion) {
   c.bench_function("compute_digest", |b| {
     b.iter(|| {
-      PublicParams::<G1, G2, C1, C2>::setup(black_box(&C1::new(10)), black_box(&C2::default()))
+      PublicParams::<G1, G2, C1, C2>::setup(
+        black_box(&C1::new(10)),
+        black_box(&C2::default()),
+        black_box(None),
+        black_box(None),
+      )
     })
   });
 }

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -6,6 +6,7 @@ use ff::PrimeField;
 use nova_snark::{
   traits::{
     circuit::{StepCircuit, TrivialCircuit},
+    snark::default_commitment_key_hint,
     Group,
   },
   PublicParams,
@@ -30,8 +31,8 @@ fn bench_compute_digest(c: &mut Criterion) {
       PublicParams::<G1, G2, C1, C2>::setup(
         black_box(&C1::new(10)),
         black_box(&C2::default()),
-        black_box(&(|_| 0)),
-        black_box(&(|_| 0)),
+        black_box(&*default_commitment_key_hint()),
+        black_box(&*default_commitment_key_hint()),
       )
     })
   });

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -30,8 +30,8 @@ fn bench_compute_digest(c: &mut Criterion) {
       PublicParams::<G1, G2, C1, C2>::setup(
         black_box(&C1::new(10)),
         black_box(&C2::default()),
-        black_box(None),
-        black_box(None),
+        black_box(&(|_| 0)),
+        black_box(&(|_| 0)),
       )
     })
   });

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -56,7 +56,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     let c_secondary = TrivialCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary);
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary, None, None);
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -56,7 +56,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     let c_secondary = TrivialCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary, None, None);
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary, &(|_| 0), &(|_| 0));
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -7,6 +7,7 @@ use ff::PrimeField;
 use nova_snark::{
   traits::{
     circuit::{StepCircuit, TrivialCircuit},
+    snark::default_commitment_key_hint,
     Group,
   },
   PublicParams, RecursiveSNARK,
@@ -56,7 +57,12 @@ fn bench_recursive_snark(c: &mut Criterion) {
     let c_secondary = TrivialCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary, &(|_| 0), &(|_| 0));
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(
+      &c_primary,
+      &c_secondary,
+      &*default_commitment_key_hint(),
+      &*default_commitment_key_hint(),
+    );
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -155,7 +155,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
 
     // Produce public parameters
     let ttc = TrivialCircuit::default();
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc, None, None);
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc, &(|_| 0), &(|_| 0));
 
     let circuit_secondary = TrivialCircuit::default();
     let z0_primary = vec![<G1 as Group>::Scalar::from(2u64)];

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -17,6 +17,7 @@ use ff::{PrimeField, PrimeFieldBits};
 use nova_snark::{
   traits::{
     circuit::{StepCircuit, TrivialCircuit},
+    snark::default_commitment_key_hint,
     Group,
   },
   PublicParams, RecursiveSNARK,
@@ -155,7 +156,12 @@ fn bench_recursive_snark(c: &mut Criterion) {
 
     // Produce public parameters
     let ttc = TrivialCircuit::default();
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc, &(|_| 0), &(|_| 0));
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(
+      &circuit_primary,
+      &ttc,
+      &*default_commitment_key_hint(),
+      &*default_commitment_key_hint(),
+    );
 
     let circuit_secondary = TrivialCircuit::default();
     let z0_primary = vec![<G1 as Group>::Scalar::from(2u64)];

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -155,7 +155,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
 
     // Produce public parameters
     let ttc = TrivialCircuit::default();
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc);
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc, None, None);
 
     let circuit_secondary = TrivialCircuit::default();
     let z0_primary = vec![<G1 as Group>::Scalar::from(2u64)];

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -161,7 +161,7 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, &(|_| 0), &(|_| 0));
     println!("PublicParams::setup, took {:?} ", start.elapsed());
 
     println!(

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -161,7 +161,7 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary);
+    >::setup(&circuit_primary, &circuit_secondary, None, None);
     println!("PublicParams::setup, took {:?} ", start.elapsed());
 
     println!(

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -9,6 +9,7 @@ use flate2::{write::ZlibEncoder, Compression};
 use nova_snark::{
   traits::{
     circuit::{StepCircuit, TrivialCircuit},
+    snark::default_commitment_key_hint,
     Group,
   },
   CompressedSNARK, PublicParams, RecursiveSNARK,
@@ -161,7 +162,12 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, &(|_| 0), &(|_| 0));
+    >::setup(
+      &circuit_primary,
+      &circuit_secondary,
+      &*default_commitment_key_hint(),
+      &*default_commitment_key_hint(),
+    );
     println!("PublicParams::setup, took {:?} ", start.elapsed());
 
     println!(

--- a/src/bellpepper/mod.rs
+++ b/src/bellpepper/mod.rs
@@ -15,7 +15,7 @@ mod tests {
       shape_cs::ShapeCS,
       solver::SatisfyingAssignment,
     },
-    traits::Group,
+    traits::{snark::default_commitment_key_hint, Group},
   };
   use bellpepper_core::{num::AllocatedNum, ConstraintSystem};
   use ff::PrimeField;
@@ -47,7 +47,7 @@ mod tests {
     // First create the shape
     let mut cs: ShapeCS<G> = ShapeCS::new();
     synthesize_alloc_bit(&mut cs);
-    let (shape, ck) = cs.r1cs_shape(&(|_| 0));
+    let (shape, ck) = cs.r1cs_shape(&*default_commitment_key_hint());
 
     // Now get the assignment
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();

--- a/src/bellpepper/mod.rs
+++ b/src/bellpepper/mod.rs
@@ -47,7 +47,7 @@ mod tests {
     // First create the shape
     let mut cs: ShapeCS<G> = ShapeCS::new();
     synthesize_alloc_bit(&mut cs);
-    let (shape, ck) = cs.r1cs_shape();
+    let (shape, ck) = cs.r1cs_shape(None);
 
     // Now get the assignment
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();

--- a/src/bellpepper/mod.rs
+++ b/src/bellpepper/mod.rs
@@ -47,7 +47,7 @@ mod tests {
     // First create the shape
     let mut cs: ShapeCS<G> = ShapeCS::new();
     synthesize_alloc_bit(&mut cs);
-    let (shape, ck) = cs.r1cs_shape(None);
+    let (shape, ck) = cs.r1cs_shape(&(|_| 0));
 
     // Now get the assignment
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();

--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -25,9 +25,9 @@ pub trait NovaWitness<G: Group> {
 /// `NovaShape` provides methods for acquiring `R1CSShape` and `CommitmentKey` from implementers.
 pub trait NovaShape<G: Group> {
   /// Return an appropriate `R1CSShape` and `CommitmentKey` structs.
-  /// Optionally, a `CommitmentKeyHint` can be provided to help guide the
-  /// construction of the `CommitmentKey`. This parameter is documented in `r1cs::R1CS::commitment_key`.
-  fn r1cs_shape(&self, optfn: Option<CommitmentKeyHint<G>>) -> (R1CSShape<G>, CommitmentKey<G>);
+  /// A `CommitmentKeyHint` should be provided to help guide the construction of the `CommitmentKey`.
+  /// This parameter is documented in `r1cs::R1CS::commitment_key`.
+  fn r1cs_shape(&self, ck_hint: &CommitmentKeyHint<G>) -> (R1CSShape<G>, CommitmentKey<G>);
 }
 
 impl<G: Group> NovaWitness<G> for SatisfyingAssignment<G> {
@@ -53,10 +53,7 @@ macro_rules! impl_nova_shape {
     where
       G::Scalar: PrimeField,
     {
-      fn r1cs_shape(
-        &self,
-        optfn: Option<CommitmentKeyHint<G>>,
-      ) -> (R1CSShape<G>, CommitmentKey<G>) {
+      fn r1cs_shape(&self, ck_hint: &CommitmentKeyHint<G>) -> (R1CSShape<G>, CommitmentKey<G>) {
         let mut A = SparseMatrix::<G::Scalar>::empty();
         let mut B = SparseMatrix::<G::Scalar>::empty();
         let mut C = SparseMatrix::<G::Scalar>::empty();
@@ -84,7 +81,7 @@ macro_rules! impl_nova_shape {
 
         // Don't count One as an input for shape's purposes.
         let S = R1CSShape::new(num_constraints, num_vars, num_inputs - 1, A, B, C).unwrap();
-        let ck = R1CS::<G>::commitment_key(&S, optfn);
+        let ck = R1CS::<G>::commitment_key(&S, ck_hint);
 
         (S, ck)
       }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -392,7 +392,7 @@ mod tests {
       NovaAugmentedCircuit::new(primary_params, None, &tc1, ro_consts1.clone());
     let mut cs: TestShapeCS<G1> = TestShapeCS::new();
     let _ = circuit1.synthesize(&mut cs);
-    let (shape1, ck1) = cs.r1cs_shape();
+    let (shape1, ck1) = cs.r1cs_shape(None);
     assert_eq!(cs.num_constraints(), num_constraints_primary);
 
     let tc2 = TrivialCircuit::default();
@@ -401,7 +401,7 @@ mod tests {
       NovaAugmentedCircuit::new(secondary_params, None, &tc2, ro_consts2.clone());
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = circuit2.synthesize(&mut cs);
-    let (shape2, ck2) = cs.r1cs_shape();
+    let (shape2, ck2) = cs.r1cs_shape(None);
     assert_eq!(cs.num_constraints(), num_constraints_secondary);
 
     // Execute the base case for the primary

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -392,7 +392,7 @@ mod tests {
       NovaAugmentedCircuit::new(primary_params, None, &tc1, ro_consts1.clone());
     let mut cs: TestShapeCS<G1> = TestShapeCS::new();
     let _ = circuit1.synthesize(&mut cs);
-    let (shape1, ck1) = cs.r1cs_shape(None);
+    let (shape1, ck1) = cs.r1cs_shape(&(|_| 0));
     assert_eq!(cs.num_constraints(), num_constraints_primary);
 
     let tc2 = TrivialCircuit::default();
@@ -401,7 +401,7 @@ mod tests {
       NovaAugmentedCircuit::new(secondary_params, None, &tc2, ro_consts2.clone());
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = circuit2.synthesize(&mut cs);
-    let (shape2, ck2) = cs.r1cs_shape(None);
+    let (shape2, ck2) = cs.r1cs_shape(&(|_| 0));
     assert_eq!(cs.num_constraints(), num_constraints_secondary);
 
     // Execute the base case for the primary

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -367,6 +367,7 @@ mod tests {
 
   use crate::constants::{BN_LIMB_WIDTH, BN_N_LIMBS};
   use crate::provider;
+  use crate::traits::snark::default_commitment_key_hint;
   use crate::{
     bellpepper::r1cs::{NovaShape, NovaWitness},
     gadgets::utils::scalar_as_base,
@@ -392,7 +393,7 @@ mod tests {
       NovaAugmentedCircuit::new(primary_params, None, &tc1, ro_consts1.clone());
     let mut cs: TestShapeCS<G1> = TestShapeCS::new();
     let _ = circuit1.synthesize(&mut cs);
-    let (shape1, ck1) = cs.r1cs_shape(&(|_| 0));
+    let (shape1, ck1) = cs.r1cs_shape(&*default_commitment_key_hint());
     assert_eq!(cs.num_constraints(), num_constraints_primary);
 
     let tc2 = TrivialCircuit::default();
@@ -401,7 +402,7 @@ mod tests {
       NovaAugmentedCircuit::new(secondary_params, None, &tc2, ro_consts2.clone());
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = circuit2.synthesize(&mut cs);
-    let (shape2, ck2) = cs.r1cs_shape(&(|_| 0));
+    let (shape2, ck2) = cs.r1cs_shape(&*default_commitment_key_hint());
     assert_eq!(cs.num_constraints(), num_constraints_secondary);
 
     // Execute the base case for the primary

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 
 /// Errors returned by Nova
 #[derive(Clone, Debug, Eq, PartialEq, Error)]
+#[non_exhaustive]
 pub enum NovaError {
   /// returned if the supplied row or col in (row,col,val) tuple is out of range
   #[error("InvalidIndex")]
@@ -26,6 +27,9 @@ pub enum NovaError {
   /// returned if proof verification fails
   #[error("ProofVerifyError")]
   ProofVerifyError,
+  /// returned if the provided commitment key is not of sufficient length
+  #[error("InvalidCommitmentKeyLength")]
+  InvalidCommitmentKeyLength,
   /// returned if the provided number of steps is zero
   #[error("InvalidNumSteps")]
   InvalidNumSteps,

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -1000,7 +1000,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_smul::<G1, _>(cs.namespace(|| "synthesize"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape();
+    let (shape, ck) = cs.r1cs_shape(None);
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();
@@ -1056,7 +1056,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_add_equal::<G1, _>(cs.namespace(|| "synthesize add equal"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape();
+    let (shape, ck) = cs.r1cs_shape(None);
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();
@@ -1116,7 +1116,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_add_negation::<G1, _>(cs.namespace(|| "synthesize add equal"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape();
+    let (shape, ck) = cs.r1cs_shape(None);
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -1000,7 +1000,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_smul::<G1, _>(cs.namespace(|| "synthesize"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape(None);
+    let (shape, ck) = cs.r1cs_shape(&(|_| 0));
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();
@@ -1056,7 +1056,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_add_equal::<G1, _>(cs.namespace(|| "synthesize add equal"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape(None);
+    let (shape, ck) = cs.r1cs_shape(&(|_| 0));
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();
@@ -1116,7 +1116,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_add_negation::<G1, _>(cs.namespace(|| "synthesize add equal"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape(None);
+    let (shape, ck) = cs.r1cs_shape(&(|_| 0));
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -748,13 +748,16 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::bellpepper::{
-    r1cs::{NovaShape, NovaWitness},
-    {solver::SatisfyingAssignment, test_shape_cs::TestShapeCS},
-  };
   use crate::provider::{
     bn256_grumpkin::{bn256, grumpkin},
     secp_secq::{secp256k1, secq256k1},
+  };
+  use crate::{
+    bellpepper::{
+      r1cs::{NovaShape, NovaWitness},
+      {solver::SatisfyingAssignment, test_shape_cs::TestShapeCS},
+    },
+    traits::snark::default_commitment_key_hint,
   };
   use ff::{Field, PrimeFieldBits};
   use pasta_curves::{arithmetic::CurveAffine, group::Curve, pallas, vesta};
@@ -1000,7 +1003,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_smul::<G1, _>(cs.namespace(|| "synthesize"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape(&(|_| 0));
+    let (shape, ck) = cs.r1cs_shape(&*default_commitment_key_hint());
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();
@@ -1056,7 +1059,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_add_equal::<G1, _>(cs.namespace(|| "synthesize add equal"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape(&(|_| 0));
+    let (shape, ck) = cs.r1cs_shape(&*default_commitment_key_hint());
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();
@@ -1116,7 +1119,7 @@ mod tests {
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = synthesize_add_negation::<G1, _>(cs.namespace(|| "synthesize add equal"));
     println!("Number of constraints: {}", cs.num_constraints());
-    let (shape, ck) = cs.r1cs_shape(&(|_| 0));
+    let (shape, ck) = cs.r1cs_shape(&*default_commitment_key_hint());
 
     // Then the satisfying assignment
     let mut cs: SatisfyingAssignment<G2> = SatisfyingAssignment::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,11 +131,12 @@ where
   ///
   /// let circuit1 = TrivialCircuit::<<G1 as Group>::Scalar>::default();
   /// let circuit2 = TrivialCircuit::<<G2 as Group>::Scalar>::default();
-  /// // Only relevant for a SNARK using computational commitments, pass &(|_| 0) otherwise.
-  /// let pp_hint1 = &*SPrime::<G1>::commitment_key_floor();
-  /// let pp_hint2 = &*SPrime::<G2>::commitment_key_floor();
+  /// // Only relevant for a SNARK using computational commitments, pass &(|_| 0)
+  /// // or &*nova_snark::traits::snark::default_commitment_key_hint() otherwise.
+  /// let ck_hint1 = &*SPrime::<G1>::commitment_key_floor();
+  /// let ck_hint2 = &*SPrime::<G2>::commitment_key_floor();
   ///
-  /// let pp = PublicParams::setup(&circuit1, &circuit2, pp_hint1, pp_hint2);
+  /// let pp = PublicParams::setup(&circuit1, &circuit2, ck_hint1, ck_hint2);
   /// ```
   pub fn setup(
     c_primary: &C1,
@@ -944,9 +945,9 @@ mod tests {
     <G2::CE as CommitmentEngineTrait<G2>>::CommitmentKey: CommitmentKeyExtTrait<G2>,
   {
     // this tests public parameters with a size specifically intended for a spark-compressed SNARK
-    let pp_hint1 = &*SPrime::<G1, EE<G1>>::commitment_key_floor();
-    let pp_hint2 = &*SPrime::<G2, EE<G2>>::commitment_key_floor();
-    let pp = PublicParams::<G1, G2, T1, T2>::setup(circuit1, circuit2, pp_hint1, pp_hint2);
+    let ck_hint1 = &*SPrime::<G1, EE<G1>>::commitment_key_floor();
+    let ck_hint2 = &*SPrime::<G2, EE<G2>>::commitment_key_floor();
+    let pp = PublicParams::<G1, G2, T1, T2>::setup(circuit1, circuit2, ck_hint1, ck_hint2);
 
     let digest_str = pp
       .digest()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,9 @@ use errors::NovaError;
 use ff::Field;
 use gadgets::utils::scalar_as_base;
 use nifs::NIFS;
-use r1cs::{R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness};
+use r1cs::{
+  CommitmentKeyHint, R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness,
+};
 use serde::{Deserialize, Serialize};
 use traits::{
   circuit::StepCircuit,
@@ -93,8 +95,51 @@ where
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
-  /// Create a new `PublicParams`
-  pub fn setup(c_primary: &C1, c_secondary: &C2) -> Self {
+  /// Creates a new `PublicParams` for a pair of circuits `C1` and `C2`.
+  ///
+  /// # Note
+  ///
+  /// Some SNARKs, like variants of Spartan, use computation commitments that require
+  /// larger sizes for some parameters. These SNARKs provide a hint for these values by
+  /// implementing `RelaxedR1CSSNARKTrait::commitment_key_floor()`, which can be passed to this function.
+  /// If you're not using such a SNARK, pass `None` instead.
+  ///
+  /// # Arguments
+  ///
+  /// * `c_primary`: The primary circuit of type `C1`.
+  /// * `c_secondary`: The secondary circuit of type `C2`.
+  /// * `optfn1`: An optional `CommitmentKeyHint` for `G1`, which is a function that provides a hint
+  ///   for the number of generators required in the commitment scheme for the primary circuit.
+  /// * `optfn2`: An optional `CommitmentKeyHint` for `G2`, similar to `optfn1`, but for the secondary circuit.
+  ///
+  /// # Example
+  ///
+  /// ```rust
+  /// # use pasta_curves::{vesta, pallas};
+  /// # use nova_snark::spartan::ppsnark::RelaxedR1CSSNARK;
+  /// # use nova_snark::provider::ipa_pc::EvaluationEngine;
+  /// # use nova_snark::traits::{circuit::TrivialCircuit, Group, snark::RelaxedR1CSSNARKTrait};
+  /// use nova_snark::PublicParams;
+  ///
+  /// type G1 = pallas::Point;
+  /// type G2 = vesta::Point;
+  /// type EE<G> = EvaluationEngine<G>;
+  /// type SPrime<G> = RelaxedR1CSSNARK<G, EE<G>>;
+  ///
+  /// let circuit1 = TrivialCircuit::<<G1 as Group>::Scalar>::default();
+  /// let circuit2 = TrivialCircuit::<<G2 as Group>::Scalar>::default();
+  /// // Only relevant for a SNARK using computational commitments, pass None otherwise.
+  /// let pp_hint1 = Some(SPrime::<G1>::commitment_key_floor());
+  /// let pp_hint2 = Some(SPrime::<G2>::commitment_key_floor());
+  ///
+  /// let pp = PublicParams::setup(&circuit1, &circuit2, pp_hint1, pp_hint2);
+  /// ```
+  pub fn setup(
+    c_primary: &C1,
+    c_secondary: &C2,
+    optfn1: Option<CommitmentKeyHint<G1>>,
+    optfn2: Option<CommitmentKeyHint<G2>>,
+  ) -> Self {
     let augmented_circuit_params_primary =
       NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
     let augmented_circuit_params_secondary =
@@ -119,7 +164,7 @@ where
     );
     let mut cs: ShapeCS<G1> = ShapeCS::new();
     let _ = circuit_primary.synthesize(&mut cs);
-    let (r1cs_shape_primary, ck_primary) = cs.r1cs_shape();
+    let (r1cs_shape_primary, ck_primary) = cs.r1cs_shape(ck_hint1);
 
     // Initialize ck for the secondary
     let circuit_secondary: NovaAugmentedCircuit<'_, G1, C2> = NovaAugmentedCircuit::new(
@@ -130,7 +175,7 @@ where
     );
     let mut cs: ShapeCS<G2> = ShapeCS::new();
     let _ = circuit_secondary.synthesize(&mut cs);
-    let (r1cs_shape_secondary, ck_secondary) = cs.r1cs_shape();
+    let (r1cs_shape_secondary, ck_secondary) = cs.r1cs_shape(ck_hint2);
 
     PublicParams {
       F_arity_primary,
@@ -815,6 +860,7 @@ type CE<G> = <G as Group>::CE;
 #[cfg(test)]
 mod tests {
   use crate::provider::bn256_grumpkin::{bn256, grumpkin};
+  use crate::provider::pedersen::CommitmentKeyExtTrait;
   use crate::provider::secp_secq::{secp256k1, secq256k1};
   use crate::traits::evaluation::EvaluationEngineTrait;
   use core::fmt::Write;
@@ -889,8 +935,14 @@ mod tests {
     G2: Group<Base = <G1 as Group>::Scalar>,
     T1: StepCircuit<G1::Scalar>,
     T2: StepCircuit<G2::Scalar>,
+    // required to use the IPA in the initialization of the commitment key hints below
+    <G1::CE as CommitmentEngineTrait<G1>>::CommitmentKey: CommitmentKeyExtTrait<G1>,
+    <G2::CE as CommitmentEngineTrait<G2>>::CommitmentKey: CommitmentKeyExtTrait<G2>,
   {
-    let pp = PublicParams::<G1, G2, T1, T2>::setup(circuit1, circuit2);
+    // this tests public parameters with a size specifically intended for a spark-compressed SNARK
+    let pp_hint1 = Some(SPrime::<G1, EE<G1>>::commitment_key_floor());
+    let pp_hint2 = Some(SPrime::<G2, EE<G2>>::commitment_key_floor());
+    let pp = PublicParams::<G1, G2, T1, T2>::setup(circuit1, circuit2, pp_hint1, pp_hint2);
 
     let digest_str = pp
       .digest()
@@ -969,7 +1021,7 @@ mod tests {
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
       TrivialCircuit<<G2 as Group>::Scalar>,
-    >::setup(&test_circuit1, &test_circuit2);
+    >::setup(&test_circuit1, &test_circuit2, None, None);
 
     let num_steps = 1;
 
@@ -1021,7 +1073,7 @@ mod tests {
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary);
+    >::setup(&circuit_primary, &circuit_secondary, None, None);
 
     let num_steps = 3;
 
@@ -1101,7 +1153,7 @@ mod tests {
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary);
+    >::setup(&circuit_primary, &circuit_secondary, None, None);
 
     let num_steps = 3;
 
@@ -1184,13 +1236,18 @@ mod tests {
     let circuit_primary = TrivialCircuit::default();
     let circuit_secondary = CubicCircuit::default();
 
-    // produce public parameters
+    // produce public parameters, which we'll use with a spark-compressed SNARK
     let pp = PublicParams::<
       G1,
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary);
+    >::setup(
+      &circuit_primary,
+      &circuit_secondary,
+      Some(SPrime::<G1, E1>::commitment_key_floor()),
+      Some(SPrime::<G2, E2>::commitment_key_floor()),
+    );
 
     let num_steps = 3;
 
@@ -1354,7 +1411,7 @@ mod tests {
       G2,
       FifthRootCheckingCircuit<<G1 as Group>::Scalar>,
       TrivialCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary);
+    >::setup(&circuit_primary, &circuit_secondary, None, None);
 
     let num_steps = 3;
 
@@ -1429,7 +1486,7 @@ mod tests {
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&test_circuit1, &test_circuit2);
+    >::setup(&test_circuit1, &test_circuit2, None, None);
 
     let num_steps = 1;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,11 +101,11 @@ where
   ///
   /// Public parameters set up a number of bases for the homomorphic commitment scheme of Nova.
   ///
-  /// Some final ocmpressing SNARKs, like variants of Spartan, use computation commitments that require
+  /// Some final compressing SNARKs, like variants of Spartan, use computation commitments that require
   /// larger sizes for these parameters. These SNARKs provide a hint for these values by
   /// implementing `RelaxedR1CSSNARKTrait::commitment_key_floor()`, which can be passed to this function.
   ///
-  /// If you're not using such a SNARK, pass `&(|_| 0)` instead.
+  /// If you're not using such a SNARK, pass `nova_snark::traits::snark::default_commitment_key_hint()` instead.
   ///
   /// # Arguments
   ///
@@ -866,6 +866,7 @@ mod tests {
   use crate::provider::pedersen::CommitmentKeyExtTrait;
   use crate::provider::secp_secq::{secp256k1, secq256k1};
   use crate::traits::evaluation::EvaluationEngineTrait;
+  use crate::traits::snark::default_commitment_key_hint;
   use core::fmt::Write;
 
   use super::*;
@@ -1024,7 +1025,12 @@ mod tests {
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
       TrivialCircuit<<G2 as Group>::Scalar>,
-    >::setup(&test_circuit1, &test_circuit2, &(|_| 0), &(|_| 0));
+    >::setup(
+      &test_circuit1,
+      &test_circuit2,
+      &*default_commitment_key_hint(),
+      &*default_commitment_key_hint(),
+    );
 
     let num_steps = 1;
 
@@ -1076,7 +1082,12 @@ mod tests {
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, &(|_| 0), &(|_| 0));
+    >::setup(
+      &circuit_primary,
+      &circuit_secondary,
+      &*default_commitment_key_hint(),
+      &*default_commitment_key_hint(),
+    );
 
     let num_steps = 3;
 
@@ -1156,7 +1167,12 @@ mod tests {
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, &(|_| 0), &(|_| 0));
+    >::setup(
+      &circuit_primary,
+      &circuit_secondary,
+      &*default_commitment_key_hint(),
+      &*default_commitment_key_hint(),
+    );
 
     let num_steps = 3;
 
@@ -1414,7 +1430,12 @@ mod tests {
       G2,
       FifthRootCheckingCircuit<<G1 as Group>::Scalar>,
       TrivialCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, &(|_| 0), &(|_| 0));
+    >::setup(
+      &circuit_primary,
+      &circuit_secondary,
+      &*default_commitment_key_hint(),
+      &*default_commitment_key_hint(),
+    );
 
     let num_steps = 3;
 
@@ -1489,7 +1510,12 @@ mod tests {
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&test_circuit1, &test_circuit2, &(|_| 0), &(|_| 0));
+    >::setup(
+      &test_circuit1,
+      &test_circuit2,
+      &*default_commitment_key_hint(),
+      &*default_commitment_key_hint(),
+    );
 
     let num_steps = 1;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,18 +99,21 @@ where
   ///
   /// # Note
   ///
-  /// Some SNARKs, like variants of Spartan, use computation commitments that require
-  /// larger sizes for some parameters. These SNARKs provide a hint for these values by
+  /// Public parameters set up a number of bases for the homomorphic commitment scheme of Nova.
+  ///
+  /// Some final ocmpressing SNARKs, like variants of Spartan, use computation commitments that require
+  /// larger sizes for these parameters. These SNARKs provide a hint for these values by
   /// implementing `RelaxedR1CSSNARKTrait::commitment_key_floor()`, which can be passed to this function.
-  /// If you're not using such a SNARK, pass `None` instead.
+  ///
+  /// If you're not using such a SNARK, pass `&(|_| 0)` instead.
   ///
   /// # Arguments
   ///
   /// * `c_primary`: The primary circuit of type `C1`.
   /// * `c_secondary`: The secondary circuit of type `C2`.
-  /// * `optfn1`: An optional `CommitmentKeyHint` for `G1`, which is a function that provides a hint
+  /// * `ck_hint1`: A `CommitmentKeyHint` for `G1`, which is a function that provides a hint
   ///   for the number of generators required in the commitment scheme for the primary circuit.
-  /// * `optfn2`: An optional `CommitmentKeyHint` for `G2`, similar to `optfn1`, but for the secondary circuit.
+  /// * `ck_hint2`: A `CommitmentKeyHint` for `G2`, similar to `ck_hint1`, but for the secondary circuit.
   ///
   /// # Example
   ///
@@ -128,17 +131,17 @@ where
   ///
   /// let circuit1 = TrivialCircuit::<<G1 as Group>::Scalar>::default();
   /// let circuit2 = TrivialCircuit::<<G2 as Group>::Scalar>::default();
-  /// // Only relevant for a SNARK using computational commitments, pass None otherwise.
-  /// let pp_hint1 = Some(SPrime::<G1>::commitment_key_floor());
-  /// let pp_hint2 = Some(SPrime::<G2>::commitment_key_floor());
+  /// // Only relevant for a SNARK using computational commitments, pass &(|_| 0) otherwise.
+  /// let pp_hint1 = &*SPrime::<G1>::commitment_key_floor();
+  /// let pp_hint2 = &*SPrime::<G2>::commitment_key_floor();
   ///
   /// let pp = PublicParams::setup(&circuit1, &circuit2, pp_hint1, pp_hint2);
   /// ```
   pub fn setup(
     c_primary: &C1,
     c_secondary: &C2,
-    optfn1: Option<CommitmentKeyHint<G1>>,
-    optfn2: Option<CommitmentKeyHint<G2>>,
+    ck_hint1: &CommitmentKeyHint<G1>,
+    ck_hint2: &CommitmentKeyHint<G2>,
   ) -> Self {
     let augmented_circuit_params_primary =
       NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
@@ -940,8 +943,8 @@ mod tests {
     <G2::CE as CommitmentEngineTrait<G2>>::CommitmentKey: CommitmentKeyExtTrait<G2>,
   {
     // this tests public parameters with a size specifically intended for a spark-compressed SNARK
-    let pp_hint1 = Some(SPrime::<G1, EE<G1>>::commitment_key_floor());
-    let pp_hint2 = Some(SPrime::<G2, EE<G2>>::commitment_key_floor());
+    let pp_hint1 = &*SPrime::<G1, EE<G1>>::commitment_key_floor();
+    let pp_hint2 = &*SPrime::<G2, EE<G2>>::commitment_key_floor();
     let pp = PublicParams::<G1, G2, T1, T2>::setup(circuit1, circuit2, pp_hint1, pp_hint2);
 
     let digest_str = pp
@@ -1021,7 +1024,7 @@ mod tests {
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
       TrivialCircuit<<G2 as Group>::Scalar>,
-    >::setup(&test_circuit1, &test_circuit2, None, None);
+    >::setup(&test_circuit1, &test_circuit2, &(|_| 0), &(|_| 0));
 
     let num_steps = 1;
 
@@ -1073,7 +1076,7 @@ mod tests {
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, &(|_| 0), &(|_| 0));
 
     let num_steps = 3;
 
@@ -1153,7 +1156,7 @@ mod tests {
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, &(|_| 0), &(|_| 0));
 
     let num_steps = 3;
 
@@ -1245,8 +1248,8 @@ mod tests {
     >::setup(
       &circuit_primary,
       &circuit_secondary,
-      Some(SPrime::<G1, E1>::commitment_key_floor()),
-      Some(SPrime::<G2, E2>::commitment_key_floor()),
+      &*SPrime::<G1, E1>::commitment_key_floor(),
+      &*SPrime::<G2, E2>::commitment_key_floor(),
     );
 
     let num_steps = 3;
@@ -1411,7 +1414,7 @@ mod tests {
       G2,
       FifthRootCheckingCircuit<<G1 as Group>::Scalar>,
       TrivialCircuit<<G2 as Group>::Scalar>,
-    >::setup(&circuit_primary, &circuit_secondary, None, None);
+    >::setup(&circuit_primary, &circuit_secondary, &(|_| 0), &(|_| 0));
 
     let num_steps = 3;
 
@@ -1486,7 +1489,7 @@ mod tests {
       G2,
       TrivialCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(&test_circuit1, &test_circuit2, None, None);
+    >::setup(&test_circuit1, &test_circuit2, &(|_| 0), &(|_| 0));
 
     let num_steps = 1;
 

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -113,7 +113,9 @@ impl<G: Group> NIFS<G> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{r1cs::SparseMatrix, r1cs::R1CS, traits::Group};
+  use crate::{
+    r1cs::SparseMatrix, r1cs::R1CS, traits::snark::default_commitment_key_hint, traits::Group,
+  };
   use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use ff::{Field, PrimeField};
   use rand::rngs::OsRng;
@@ -166,7 +168,7 @@ mod tests {
     // First create the shape
     let mut cs: TestShapeCS<G> = TestShapeCS::new();
     let _ = synthesize_tiny_r1cs_bellpepper(&mut cs, None);
-    let (shape, ck) = cs.r1cs_shape(&(|_| 0));
+    let (shape, ck) = cs.r1cs_shape(&*default_commitment_key_hint());
     let ro_consts =
       <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::default();
 
@@ -327,7 +329,7 @@ mod tests {
     };
 
     // generate generators and ro constants
-    let ck = R1CS::<G>::commitment_key(&S, &(|_| 0));
+    let ck = R1CS::<G>::commitment_key(&S, &*default_commitment_key_hint());
     let ro_consts =
       <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::default();
 

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -166,7 +166,7 @@ mod tests {
     // First create the shape
     let mut cs: TestShapeCS<G> = TestShapeCS::new();
     let _ = synthesize_tiny_r1cs_bellpepper(&mut cs, None);
-    let (shape, ck) = cs.r1cs_shape();
+    let (shape, ck) = cs.r1cs_shape(None);
     let ro_consts =
       <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::default();
 
@@ -327,7 +327,7 @@ mod tests {
     };
 
     // generate generators and ro constants
-    let ck = R1CS::<G>::commitment_key(&S);
+    let ck = R1CS::<G>::commitment_key(&S, None);
     let ro_consts =
       <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::default();
 

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -166,7 +166,7 @@ mod tests {
     // First create the shape
     let mut cs: TestShapeCS<G> = TestShapeCS::new();
     let _ = synthesize_tiny_r1cs_bellpepper(&mut cs, None);
-    let (shape, ck) = cs.r1cs_shape(None);
+    let (shape, ck) = cs.r1cs_shape(&(|_| 0));
     let ro_consts =
       <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::default();
 
@@ -327,7 +327,7 @@ mod tests {
     };
 
     // generate generators and ro constants
-    let ck = R1CS::<G>::commitment_key(&S, None);
+    let ck = R1CS::<G>::commitment_key(&S, &(|_| 0));
     let ro_consts =
       <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::default();
 

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -2,7 +2,7 @@
 use crate::{
   errors::NovaError,
   traits::{
-    commitment::{CommitmentEngineTrait, CommitmentTrait},
+    commitment::{CommitmentEngineTrait, CommitmentTrait, Len},
     AbsorbInROTrait, CompressedGroup, Group, ROTrait, TranscriptReprTrait,
   },
 };
@@ -19,6 +19,12 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommitmentKey<G: Group> {
   ck: Vec<G::PreprocessedGroupElement>,
+}
+
+impl<G: Group> Len for CommitmentKey<G> {
+  fn len(&self) -> usize {
+    self.ck.len()
+  }
 }
 
 /// A type that holds a commitment

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -22,7 +22,7 @@ pub struct CommitmentKey<G: Group> {
 }
 
 impl<G: Group> Len for CommitmentKey<G> {
-  fn len(&self) -> usize {
+  fn length(&self) -> usize {
     self.ck.len()
   }
 }

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -78,7 +78,7 @@ pub struct RelaxedR1CSInstance<G: Group> {
   pub(crate) u: G::Scalar,
 }
 
-pub type CommitmentKeyHint<G> = Box<dyn Fn(&R1CSShape<G>) -> usize>;
+pub type CommitmentKeyHint<G> = dyn Fn(&R1CSShape<G>) -> usize;
 
 impl<G: Group> R1CS<G> {
   /// Generates public parameters for a Rank-1 Constraint System (R1CS).
@@ -89,17 +89,16 @@ impl<G: Group> R1CS<G> {
   /// # Arguments
   ///
   /// * `S`: The shape of the R1CS matrices.
-  /// * `commitment_key_hint`: An optional function that provides a floor for the number of
-  ///   generators. A good function to provide is the commitment_key_floor field in the trait `RelaxedR1CSSNARKTrait`.
-  ///   If no floot function is provided, the default number of generators will be max(S.num_cons, S.num_vars).
+  /// * `commitment_key_hint`: A function that provides a floor for the number of generators. A good function
+  ///   to provide is the commitment_key_floor field defined in the trait `RelaxedR1CSSNARKTrait`.
   ///
   pub fn commitment_key(
     S: &R1CSShape<G>,
-    commitment_key_floor: Option<CommitmentKeyHint<G>>,
+    commitment_key_floor: &CommitmentKeyHint<G>,
   ) -> CommitmentKey<G> {
     let num_cons = S.num_cons;
     let num_vars = S.num_vars;
-    let generators_hint = commitment_key_floor.map(|f| f(S)).unwrap_or(0);
+    let generators_hint = commitment_key_floor(S);
     G::CE::setup(b"ck", max(max(num_cons, num_vars), generators_hint))
   }
 }

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -98,8 +98,8 @@ impl<G: Group> R1CS<G> {
   ) -> CommitmentKey<G> {
     let num_cons = S.num_cons;
     let num_vars = S.num_vars;
-    let generators_hint = commitment_key_floor(S);
-    G::CE::setup(b"ck", max(max(num_cons, num_vars), generators_hint))
+    let ck_hint = commitment_key_floor(S);
+    G::CE::setup(b"ck", max(max(num_cons, num_vars), ck_hint))
   }
 }
 

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -108,7 +108,8 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
 
     let mut cs: ShapeCS<G> = ShapeCS::new();
     let _ = circuit.synthesize(&mut cs);
-    let (shape, ck) = cs.r1cs_shape();
+
+    let (shape, ck) = cs.r1cs_shape(Some(S::commitment_key_floor()));
 
     let (pk, vk) = S::setup(&ck, &shape)?;
 

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -109,7 +109,7 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
     let mut cs: ShapeCS<G> = ShapeCS::new();
     let _ = circuit.synthesize(&mut cs);
 
-    let (shape, ck) = cs.r1cs_shape(Some(S::commitment_key_floor()));
+    let (shape, ck) = cs.r1cs_shape(&*S::commitment_key_floor());
 
     let (pk, vk) = S::setup(&ck, &shape)?;
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -907,7 +907,9 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for Relaxe
     S: &R1CSShape<G>,
   ) -> Result<(Self::ProverKey, Self::VerifierKey), NovaError> {
     // check the provided commitment key meets minimal requirements
-    assert!(ck.length() >= Self::commitment_key_floor()(S));
+    if ck.length() < Self::commitment_key_floor()(S) {
+      return Err(NovaError::InvalidCommitmentKeyLength);
+    }
     let (pk_ee, vk_ee) = EE::setup(ck);
 
     // pad the R1CS matrices

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -907,7 +907,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for Relaxe
     S: &R1CSShape<G>,
   ) -> Result<(Self::ProverKey, Self::VerifierKey), NovaError> {
     // check the provided commitment key meets minimal requirements
-    assert!(ck.len() >= Self::commitment_key_floor()(S));
+    assert!(ck.length() >= Self::commitment_key_floor()(S));
     let (pk_ee, vk_ee) = EE::setup(ck);
 
     // pad the R1CS matrices

--- a/src/traits/commitment.rs
+++ b/src/traits/commitment.rs
@@ -72,10 +72,18 @@ pub trait CommitmentTrait<G: Group>:
   fn decompress(c: &Self::CompressedCommitment) -> Result<Self, NovaError>;
 }
 
+/// A trait that helps determine the lenght of a structure.
+/// Note this does not impose any memory representation contraints on the structure.
+pub trait Len {
+  /// Returns the length of the structure.
+  fn len(&self) -> usize;
+}
+
 /// A trait that ties different pieces of the commitment generation together
 pub trait CommitmentEngineTrait<G: Group>: Clone + Send + Sync {
   /// Holds the type of the commitment key
-  type CommitmentKey: Clone + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de>;
+  /// The key should quantify its length in terms of group generators.
+  type CommitmentKey: Len + Clone + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de>;
 
   /// Holds the type of the commitment
   type Commitment: CommitmentTrait<G>;

--- a/src/traits/commitment.rs
+++ b/src/traits/commitment.rs
@@ -76,7 +76,7 @@ pub trait CommitmentTrait<G: Group>:
 /// Note this does not impose any memory representation contraints on the structure.
 pub trait Len {
   /// Returns the length of the structure.
-  fn len(&self) -> usize;
+  fn length(&self) -> usize;
 }
 
 /// A trait that ties different pieces of the commitment generation together

--- a/src/traits/snark.rs
+++ b/src/traits/snark.rs
@@ -18,6 +18,15 @@ pub trait RelaxedR1CSSNARKTrait<G: Group>:
   /// A type that represents the verifier's key
   type VerifierKey: Send + Sync + Serialize + for<'de> Deserialize<'de> + DigestHelperTrait<G>;
 
+  /// This associated function (not a method) provides a hint that offers
+  /// a minimum sizing cue for the commitment key used by this SNARK
+  /// implementation. The commitment key passed in setup should then
+  /// be at least as large as this hint.
+  fn commitment_key_floor() -> Box<dyn for<'a> Fn(&'a R1CSShape<G>) -> usize> {
+    // The default is to not put an additional floor on the size of the commitment key
+    Box::new(|_shape: &R1CSShape<G>| 0)
+  }
+
   /// Produces the keys for the prover and the verifier
   fn setup(
     ck: &CommitmentKey<G>,

--- a/src/traits/snark.rs
+++ b/src/traits/snark.rs
@@ -8,6 +8,15 @@ use crate::{
 
 use serde::{Deserialize, Serialize};
 
+/// Public parameter creation takes a size hint. This size hint carries the particular requirements of
+/// the final compressing SNARK the user expected to use with these public parameters, and the below
+/// is a sensible default, which is to not require any more bases then the usual (maximum of the number of
+/// variables and constraints of the involved R1CS circuit).
+pub fn default_commitment_key_hint<G: Group>() -> Box<dyn for<'a> Fn(&'a R1CSShape<G>) -> usize> {
+  // The default is to not put an additional floor on the size of the commitment key
+  Box::new(|_shape: &R1CSShape<G>| 0)
+}
+
 /// A trait that defines the behavior of a `zkSNARK`
 pub trait RelaxedR1CSSNARKTrait<G: Group>:
   Send + Sync + Serialize + for<'de> Deserialize<'de>
@@ -24,7 +33,7 @@ pub trait RelaxedR1CSSNARKTrait<G: Group>:
   /// be at least as large as this hint.
   fn commitment_key_floor() -> Box<dyn for<'a> Fn(&'a R1CSShape<G>) -> usize> {
     // The default is to not put an additional floor on the size of the commitment key
-    Box::new(|_shape: &R1CSShape<G>| 0)
+    default_commitment_key_hint()
   }
 
   /// Produces the keys for the prover and the verifier


### PR DESCRIPTION
## Summary

The size of the public parameters can vary depending on the method used to process them in a later SNARK. In particular, the memory checking techniques used for computational commitments (Spartan paper section 6) requires larger commitment keys. 

However, because public parameters are created before any SNARK that might use them, their creation as a Rust object is harder to parametrize. So the size of the commitment key is currently set, for all public parameters, to the more conservative (larger) size required in `spartan/ppsnark.rs`.

The current PR allows parametrizing public parameter creation with an optional function of the R1CS shape of the circuits: the size of the parameters will be the min of the usual considerations (min of wire /constraint count) and its output. This function can then be provided by SNARKs as an [associated function](https://doc.rust-lang.org/reference/items/associated-items.html#associated-functions-and-methods). It allows the mere type definition of the SNARK to convey its special needs in terms of public parameters. 

The Spartan instance that does have those special needs now implements this function to convey its extra requirements, letting all other SNARKs enjoy smaller parameters.



## In detail

- Implemented the `Len` trait for `CommitmentKey` to allow length quantification in terms of group generators. Made `ppsnark::RelaxedR1CSSNARK` fail setup if given commitment key with insufficient length, as measured by its own `commitment_key_floor()` (see below)
- Made `RelaxedR1CSTrait` include a `fn commitment_key_floor() -> Box<dyn for<'a> Fn(&'a R1CSShape<G>) -> usize>` with default implementation to quantify the Snark's additional commitment key size requirements, in the shape of a closure,
- Made `PublicParams` take a `&dyn for<'a> Fn(&'a R1CSShape<G>) -> usize` parameter for each circuit's group, to parametrize the `CommitmentKey` creation.

Other implementation details:
- defined type alias `CommitmentKeyHint<G> = dyn Fn(&R1CSShape<G>) -> usize` 
- Modified numerous function calls and parameter setups to include parameter `CommitmentKeyHint` that gives a more flexible commitment key generation.
- Added the `CommitmentKeyHint` to the `r1cs` import list and expanded `NovaShape` trait to optionally accept it.