### PR TITLE
Streamline traits and bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ bitvec = "1.0"
 byteorder = "1.4.3"
 thiserror = "1.0"
 halo2curves = { version = "0.1.0", features = ["derive_serde"] }
+group = "0.13.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { version = "0.1.4" }

--- a/src/bellperson/r1cs.rs
+++ b/src/bellperson/r1cs.rs
@@ -47,9 +47,9 @@ impl<G: Group> NovaWitness<G> for SatisfyingAssignment<G> {
 
 impl<G: Group> NovaShape<G> for ShapeCS<G> {
   fn r1cs_shape(&self) -> (R1CSShape<G>, CommitmentKey<G>) {
-    let mut A: Vec<(usize, usize, G::Scalar)> = Vec::new();
-    let mut B: Vec<(usize, usize, G::Scalar)> = Vec::new();
-    let mut C: Vec<(usize, usize, G::Scalar)> = Vec::new();
+    let mut A: Vec<(usize, usize, <G as Group>::Scalar)> = Vec::new();
+    let mut B: Vec<(usize, usize, <G as Group>::Scalar)> = Vec::new();
+    let mut C: Vec<(usize, usize, <G as Group>::Scalar)> = Vec::new();
 
     let mut num_cons_added = 0;
     let mut X = (&mut A, &mut B, &mut C, &mut num_cons_added);

--- a/src/bellperson/r1cs.rs
+++ b/src/bellperson/r1cs.rs
@@ -28,10 +28,7 @@ pub trait NovaShape<G: Group> {
   fn r1cs_shape(&self) -> (R1CSShape<G>, CommitmentKey<G>);
 }
 
-impl<G: Group> NovaWitness<G> for SatisfyingAssignment<G>
-where
-  G::Scalar: PrimeField,
-{
+impl<G: Group> NovaWitness<G> for SatisfyingAssignment<G> {
   fn r1cs_instance_and_witness(
     &self,
     shape: &R1CSShape<G>,
@@ -48,10 +45,7 @@ where
   }
 }
 
-impl<G: Group> NovaShape<G> for ShapeCS<G>
-where
-  G::Scalar: PrimeField,
-{
+impl<G: Group> NovaShape<G> for ShapeCS<G> {
   fn r1cs_shape(&self) -> (R1CSShape<G>, CommitmentKey<G>) {
     let mut A: Vec<(usize, usize, G::Scalar)> = Vec::new();
     let mut B: Vec<(usize, usize, G::Scalar)> = Vec::new();

--- a/src/bellperson/shape_cs.rs
+++ b/src/bellperson/shape_cs.rs
@@ -48,10 +48,7 @@ impl Ord for OrderedVariable {
 
 #[allow(clippy::upper_case_acronyms)]
 /// `ShapeCS` is a `ConstraintSystem` for creating `R1CSShape`s for a circuit.
-pub struct ShapeCS<G: Group>
-where
-  G::Scalar: PrimeField + Field,
-{
+pub struct ShapeCS<G: Group> {
   named_objects: HashMap<String, NamedObject>,
   current_namespace: Vec<String>,
   #[allow(clippy::type_complexity)]
@@ -92,10 +89,7 @@ fn proc_lc<Scalar: PrimeField>(
   map
 }
 
-impl<G: Group> ShapeCS<G>
-where
-  G::Scalar: PrimeField,
-{
+impl<G: Group> ShapeCS<G> {
   /// Create a new, default `ShapeCS`,
   pub fn new() -> Self {
     ShapeCS::default()
@@ -216,10 +210,7 @@ where
   }
 }
 
-impl<G: Group> Default for ShapeCS<G>
-where
-  G::Scalar: PrimeField,
-{
+impl<G: Group> Default for ShapeCS<G> {
   fn default() -> Self {
     let mut map = HashMap::new();
     map.insert("ONE".into(), NamedObject::Var(ShapeCS::<G>::one()));
@@ -233,10 +224,7 @@ where
   }
 }
 
-impl<G: Group> ConstraintSystem<G::Scalar> for ShapeCS<G>
-where
-  G::Scalar: PrimeField,
-{
+impl<G: Group> ConstraintSystem<G::Scalar> for ShapeCS<G> {
   type Root = Self;
 
   fn alloc<F, A, AR>(&mut self, annotation: A, _f: F) -> Result<Variable, SynthesisError>

--- a/src/bellperson/shape_cs.rs
+++ b/src/bellperson/shape_cs.rs
@@ -54,9 +54,9 @@ pub struct ShapeCS<G: Group> {
   #[allow(clippy::type_complexity)]
   /// All constraints added to the `ShapeCS`.
   pub constraints: Vec<(
-    LinearCombination<G::Scalar>,
-    LinearCombination<G::Scalar>,
-    LinearCombination<G::Scalar>,
+    LinearCombination<<G as Group>::Scalar>,
+    LinearCombination<<G as Group>::Scalar>,
+    LinearCombination<<G as Group>::Scalar>,
     String,
   )>,
   inputs: Vec<String>,
@@ -138,16 +138,16 @@ impl<G: Group> ShapeCS<G> {
       writeln!(s, "INPUT {}", &input).unwrap()
     }
 
-    let negone = -<G::Scalar>::ONE;
+    let negone = -<<G as Group>::Scalar>::ONE;
 
-    let powers_of_two = (0..G::Scalar::NUM_BITS)
-      .map(|i| G::Scalar::from(2u64).pow_vartime([u64::from(i)]))
+    let powers_of_two = (0..<G as Group>::Scalar::NUM_BITS)
+      .map(|i| <G as Group>::Scalar::from(2u64).pow_vartime([u64::from(i)]))
       .collect::<Vec<_>>();
 
-    let pp = |s: &mut String, lc: &LinearCombination<G::Scalar>| {
+    let pp = |s: &mut String, lc: &LinearCombination<<G as Group>::Scalar>| {
       s.push('(');
       let mut is_first = true;
-      for (var, coeff) in proc_lc::<G::Scalar>(lc) {
+      for (var, coeff) in proc_lc::<<G as Group>::Scalar>(lc) {
         if coeff == negone {
           s.push_str(" - ")
         } else if !is_first {
@@ -155,7 +155,7 @@ impl<G: Group> ShapeCS<G> {
         }
         is_first = false;
 
-        if coeff != <G::Scalar>::ONE && coeff != negone {
+        if coeff != <<G as Group>::Scalar>::ONE && coeff != negone {
           for (i, x) in powers_of_two.iter().enumerate() {
             if x == &coeff {
               write!(s, "2^{i} . ").unwrap();
@@ -224,12 +224,12 @@ impl<G: Group> Default for ShapeCS<G> {
   }
 }
 
-impl<G: Group> ConstraintSystem<G::Scalar> for ShapeCS<G> {
+impl<G: Group> ConstraintSystem<<G as Group>::Scalar> for ShapeCS<G> {
   type Root = Self;
 
   fn alloc<F, A, AR>(&mut self, annotation: A, _f: F) -> Result<Variable, SynthesisError>
   where
-    F: FnOnce() -> Result<G::Scalar, SynthesisError>,
+    F: FnOnce() -> Result<<G as Group>::Scalar, SynthesisError>,
     A: FnOnce() -> AR,
     AR: Into<String>,
   {
@@ -241,7 +241,7 @@ impl<G: Group> ConstraintSystem<G::Scalar> for ShapeCS<G> {
 
   fn alloc_input<F, A, AR>(&mut self, annotation: A, _f: F) -> Result<Variable, SynthesisError>
   where
-    F: FnOnce() -> Result<G::Scalar, SynthesisError>,
+    F: FnOnce() -> Result<<G as Group>::Scalar, SynthesisError>,
     A: FnOnce() -> AR,
     AR: Into<String>,
   {
@@ -255,9 +255,9 @@ impl<G: Group> ConstraintSystem<G::Scalar> for ShapeCS<G> {
   where
     A: FnOnce() -> AR,
     AR: Into<String>,
-    LA: FnOnce(LinearCombination<G::Scalar>) -> LinearCombination<G::Scalar>,
-    LB: FnOnce(LinearCombination<G::Scalar>) -> LinearCombination<G::Scalar>,
-    LC: FnOnce(LinearCombination<G::Scalar>) -> LinearCombination<G::Scalar>,
+    LA: FnOnce(LinearCombination<<G as Group>::Scalar>) -> LinearCombination<<G as Group>::Scalar>,
+    LB: FnOnce(LinearCombination<<G as Group>::Scalar>) -> LinearCombination<<G as Group>::Scalar>,
+    LC: FnOnce(LinearCombination<<G as Group>::Scalar>) -> LinearCombination<<G as Group>::Scalar>,
   {
     let path = compute_path(&self.current_namespace, &annotation().into());
     let index = self.constraints.len();

--- a/src/bellperson/solver.rs
+++ b/src/bellperson/solver.rs
@@ -1,7 +1,7 @@
 //! Support for generating R1CS witness using bellperson.
 
 use crate::traits::Group;
-use ff::{Field, PrimeField};
+use ff::Field;
 
 use bellperson::{
   multiexp::DensityTracker, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable,
@@ -9,10 +9,7 @@ use bellperson::{
 
 /// A `ConstraintSystem` which calculates witness values for a concrete instance of an R1CS circuit.
 #[derive(PartialEq)]
-pub struct SatisfyingAssignment<G: Group>
-where
-  G::Scalar: PrimeField,
-{
+pub struct SatisfyingAssignment<G: Group> {
   // Density of queries
   a_aux_density: DensityTracker,
   b_input_density: DensityTracker,
@@ -29,10 +26,7 @@ where
 }
 use std::fmt;
 
-impl<G: Group> fmt::Debug for SatisfyingAssignment<G>
-where
-  G::Scalar: PrimeField,
-{
+impl<G: Group> fmt::Debug for SatisfyingAssignment<G> {
   fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
     fmt
       .debug_struct("SatisfyingAssignment")
@@ -69,10 +63,7 @@ where
   }
 }
 
-impl<G: Group> ConstraintSystem<G::Scalar> for SatisfyingAssignment<G>
-where
-  G::Scalar: PrimeField,
-{
+impl<G: Group> ConstraintSystem<G::Scalar> for SatisfyingAssignment<G> {
   type Root = Self;
 
   fn new() -> Self {

--- a/src/bellperson/solver.rs
+++ b/src/bellperson/solver.rs
@@ -16,13 +16,13 @@ pub struct SatisfyingAssignment<G: Group> {
   b_aux_density: DensityTracker,
 
   // Evaluations of A, B, C polynomials
-  a: Vec<G::Scalar>,
-  b: Vec<G::Scalar>,
-  c: Vec<G::Scalar>,
+  a: Vec<<G as Group>::Scalar>,
+  b: Vec<<G as Group>::Scalar>,
+  c: Vec<<G as Group>::Scalar>,
 
   // Assignments of variables
-  pub(crate) input_assignment: Vec<G::Scalar>,
-  pub(crate) aux_assignment: Vec<G::Scalar>,
+  pub(crate) input_assignment: Vec<<G as Group>::Scalar>,
+  pub(crate) aux_assignment: Vec<<G as Group>::Scalar>,
 }
 use std::fmt;
 
@@ -63,11 +63,11 @@ impl<G: Group> fmt::Debug for SatisfyingAssignment<G> {
   }
 }
 
-impl<G: Group> ConstraintSystem<G::Scalar> for SatisfyingAssignment<G> {
+impl<G: Group> ConstraintSystem<<G as Group>::Scalar> for SatisfyingAssignment<G> {
   type Root = Self;
 
   fn new() -> Self {
-    let input_assignment = vec![G::Scalar::ONE];
+    let input_assignment = vec![<G as Group>::Scalar::ONE];
     let mut d = DensityTracker::new();
     d.add_element();
 
@@ -85,7 +85,7 @@ impl<G: Group> ConstraintSystem<G::Scalar> for SatisfyingAssignment<G> {
 
   fn alloc<F, A, AR>(&mut self, _: A, f: F) -> Result<Variable, SynthesisError>
   where
-    F: FnOnce() -> Result<G::Scalar, SynthesisError>,
+    F: FnOnce() -> Result<<G as Group>::Scalar, SynthesisError>,
     A: FnOnce() -> AR,
     AR: Into<String>,
   {
@@ -98,7 +98,7 @@ impl<G: Group> ConstraintSystem<G::Scalar> for SatisfyingAssignment<G> {
 
   fn alloc_input<F, A, AR>(&mut self, _: A, f: F) -> Result<Variable, SynthesisError>
   where
-    F: FnOnce() -> Result<G::Scalar, SynthesisError>,
+    F: FnOnce() -> Result<<G as Group>::Scalar, SynthesisError>,
     A: FnOnce() -> AR,
     AR: Into<String>,
   {
@@ -112,9 +112,9 @@ impl<G: Group> ConstraintSystem<G::Scalar> for SatisfyingAssignment<G> {
   where
     A: FnOnce() -> AR,
     AR: Into<String>,
-    LA: FnOnce(LinearCombination<G::Scalar>) -> LinearCombination<G::Scalar>,
-    LB: FnOnce(LinearCombination<G::Scalar>) -> LinearCombination<G::Scalar>,
-    LC: FnOnce(LinearCombination<G::Scalar>) -> LinearCombination<G::Scalar>,
+    LA: FnOnce(LinearCombination<<G as Group>::Scalar>) -> LinearCombination<<G as Group>::Scalar>,
+    LB: FnOnce(LinearCombination<<G as Group>::Scalar>) -> LinearCombination<<G as Group>::Scalar>,
+    LC: FnOnce(LinearCombination<<G as Group>::Scalar>) -> LinearCombination<<G as Group>::Scalar>,
   {
     // Do nothing: we don't care about linear-combination evaluations in this context.
   }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -52,7 +52,7 @@ impl NovaAugmentedCircuitParams {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct NovaAugmentedCircuitInputs<G: Group> {
-  params: G::Scalar, // Hash(Shape of u2, Gens for u2). Needed for computing the challenge.
+  params: <G as Group>::Scalar, // Hash(Shape of u2, Gens for u2). Needed for computing the challenge.
   i: G::Base,
   z0: Vec<G::Base>,
   zi: Option<Vec<G::Base>>,
@@ -65,7 +65,7 @@ impl<G: Group> NovaAugmentedCircuitInputs<G> {
   /// Create new inputs/witness for the verification circuit
   #[allow(clippy::too_many_arguments)]
   pub fn new(
-    params: G::Scalar,
+    params: <G as Group>::Scalar,
     i: G::Base,
     z0: Vec<G::Base>,
     zi: Option<Vec<G::Base>>,

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -852,7 +852,7 @@ mod tests {
       }
     }
 
-    pub fn scalar_mul(&self, scalar: &G::Scalar) -> Self {
+    pub fn scalar_mul(&self, scalar: &<G as Group>::Scalar) -> Self {
       let mut res = Self {
         x: G::Base::ZERO,
         y: G::Base::ZERO,
@@ -903,7 +903,7 @@ mod tests {
 
   fn test_ecc_ops_with<C, G>()
   where
-    C: CurveAffine<Base = G::Base, ScalarExt = G::Scalar>,
+    C: CurveAffine<Base = G::Base, ScalarExt = <G as Group>::Scalar>,
     G: Group,
   {
     // perform some curve arithmetic
@@ -954,7 +954,9 @@ mod tests {
     assert_eq!(e_curve, e_curve_2);
   }
 
-  fn synthesize_smul<G, CS>(mut cs: CS) -> (AllocatedPoint<G>, AllocatedPoint<G>, G::Scalar)
+  fn synthesize_smul<G, CS>(
+    mut cs: CS,
+  ) -> (AllocatedPoint<G>, AllocatedPoint<G>, <G as Group>::Scalar)
   where
     G: Group,
     CS: ConstraintSystem<G::Base>,
@@ -962,7 +964,7 @@ mod tests {
     let a = alloc_random_point(cs.namespace(|| "a")).unwrap();
     inputize_allocted_point(&a, cs.namespace(|| "inputize a")).unwrap();
 
-    let s = G::Scalar::random(&mut OsRng);
+    let s = <G as Group>::Scalar::random(&mut OsRng);
     // Allocate bits for s
     let bits: Vec<AllocatedBit> = s
       .to_le_bits()

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -104,14 +104,22 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
     // Allocate X0 and X1. If the input instance is None, then allocate default values 0.
     let X0 = BigNat::alloc_from_nat(
       cs.namespace(|| "allocate X[0]"),
-      || Ok(f_to_nat(&inst.map_or(G::Scalar::ZERO, |inst| inst.X[0]))),
+      || {
+        Ok(f_to_nat(
+          &inst.map_or(<G as Group>::Scalar::ZERO, |inst| inst.X[0]),
+        ))
+      },
       limb_width,
       n_limbs,
     )?;
 
     let X1 = BigNat::alloc_from_nat(
       cs.namespace(|| "allocate X[1]"),
-      || Ok(f_to_nat(&inst.map_or(G::Scalar::ZERO, |inst| inst.X[1]))),
+      || {
+        Ok(f_to_nat(
+          &inst.map_or(<G as Group>::Scalar::ZERO, |inst| inst.X[1]),
+        ))
+      },
       limb_width,
       n_limbs,
     )?;
@@ -133,14 +141,14 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
 
     let X0 = BigNat::alloc_from_nat(
       cs.namespace(|| "allocate x_default[0]"),
-      || Ok(f_to_nat(&G::Scalar::ZERO)),
+      || Ok(f_to_nat(&<G as Group>::Scalar::ZERO)),
       limb_width,
       n_limbs,
     )?;
 
     let X1 = BigNat::alloc_from_nat(
       cs.namespace(|| "allocate x_default[1]"),
-      || Ok(f_to_nat(&G::Scalar::ZERO)),
+      || Ok(f_to_nat(&<G as Group>::Scalar::ZERO)),
       limb_width,
       n_limbs,
     )?;

--- a/src/gadgets/utils.rs
+++ b/src/gadgets/utils.rs
@@ -77,7 +77,7 @@ pub fn alloc_one<F: PrimeField, CS: ConstraintSystem<F>>(
 /// Allocate a scalar as a base. Only to be used is the scalar fits in base!
 pub fn alloc_scalar_as_base<G, CS>(
   mut cs: CS,
-  input: Option<G::Scalar>,
+  input: Option<<G as Group>::Scalar>,
 ) -> Result<AllocatedNum<G::Base>, SynthesisError>
 where
   G: Group,
@@ -85,7 +85,10 @@ where
   CS: ConstraintSystem<<G as Group>::Base>,
 {
   AllocatedNum::alloc(cs.namespace(|| "allocate scalar as base"), || {
-    let input_bits = input.unwrap_or(G::Scalar::ZERO).clone().to_le_bits();
+    let input_bits = input
+      .unwrap_or(<G as Group>::Scalar::ZERO)
+      .clone()
+      .to_le_bits();
     let mut mult = G::Base::ONE;
     let mut val = G::Base::ZERO;
     for bit in input_bits {
@@ -99,7 +102,7 @@ where
 }
 
 /// interepret scalar as base
-pub fn scalar_as_base<G: Group>(input: G::Scalar) -> G::Base {
+pub fn scalar_as_base<G: Group>(input: <G as Group>::Scalar) -> G::Base {
   let input_bits = input.to_le_bits();
   let mut mult = G::Base::ONE;
   let mut val = G::Base::ZERO;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,8 @@ pub struct PublicParams<G1, G2, C1, C2>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
-  C2: StepCircuit<G2::Scalar>,
+  C1: StepCircuit<<G1 as Group>::Scalar>,
+  C2: StepCircuit<<G2 as Group>::Scalar>,
 {
   F_arity_primary: usize,
   F_arity_secondary: usize,
@@ -70,7 +70,7 @@ where
   r1cs_shape_secondary: R1CSShape<G2>,
   augmented_circuit_params_primary: NovaAugmentedCircuitParams,
   augmented_circuit_params_secondary: NovaAugmentedCircuitParams,
-  digest: G1::Scalar, // digest of everything else with this field set to G1::Scalar::ZERO
+  digest: <G1 as Group>::Scalar, // digest of everything else with this field set to G1::Scalar::ZERO
   _p_c1: PhantomData<C1>,
   _p_c2: PhantomData<C2>,
 }
@@ -79,8 +79,8 @@ impl<G1, G2, C1, C2> PublicParams<G1, G2, C1, C2>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
-  C2: StepCircuit<G2::Scalar>,
+  C1: StepCircuit<<G1 as Group>::Scalar>,
+  C2: StepCircuit<<G2 as Group>::Scalar>,
 {
   /// Create a new `PublicParams`
   pub fn setup(c_primary: C1, c_secondary: C2) -> Self {
@@ -134,7 +134,7 @@ where
       r1cs_shape_secondary,
       augmented_circuit_params_primary,
       augmented_circuit_params_secondary,
-      digest: G1::Scalar::ZERO,
+      digest: <G1 as Group>::Scalar::ZERO,
       _p_c1: Default::default(),
       _p_c2: Default::default(),
     };
@@ -169,8 +169,8 @@ pub struct RecursiveSNARK<G1, G2, C1, C2>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
-  C2: StepCircuit<G2::Scalar>,
+  C1: StepCircuit<<G1 as Group>::Scalar>,
+  C2: StepCircuit<<G2 as Group>::Scalar>,
 {
   r_W_primary: RelaxedR1CSWitness<G1>,
   r_U_primary: RelaxedR1CSInstance<G1>,
@@ -179,8 +179,8 @@ where
   l_w_secondary: R1CSWitness<G2>,
   l_u_secondary: R1CSInstance<G2>,
   i: usize,
-  zi_primary: Vec<G1::Scalar>,
-  zi_secondary: Vec<G2::Scalar>,
+  zi_primary: Vec<<G1 as Group>::Scalar>,
+  zi_secondary: Vec<<G2 as Group>::Scalar>,
   _p_c1: PhantomData<C1>,
   _p_c2: PhantomData<C2>,
 }
@@ -189,16 +189,16 @@ impl<G1, G2, C1, C2> RecursiveSNARK<G1, G2, C1, C2>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
-  C2: StepCircuit<G2::Scalar>,
+  C1: StepCircuit<<G1 as Group>::Scalar>,
+  C2: StepCircuit<<G2 as Group>::Scalar>,
 {
   /// Create new instance of recursive SNARK
   pub fn new(
     pp: &PublicParams<G1, G2, C1, C2>,
     c_primary: &C1,
     c_secondary: &C2,
-    z0_primary: Vec<G1::Scalar>,
-    z0_secondary: Vec<G2::Scalar>,
+    z0_primary: Vec<<G1 as Group>::Scalar>,
+    z0_secondary: Vec<<G2 as Group>::Scalar>,
   ) -> Self {
     // Expected outputs of the two circuits
     let zi_primary = c_primary.output(&z0_primary);
@@ -208,7 +208,7 @@ where
     let mut cs_primary: SatisfyingAssignment<G1> = SatisfyingAssignment::new();
     let inputs_primary: NovaAugmentedCircuitInputs<G2> = NovaAugmentedCircuitInputs::new(
       scalar_as_base::<G1>(pp.digest),
-      G1::Scalar::ZERO,
+      <G1 as Group>::Scalar::ZERO,
       z0_primary,
       None,
       None,
@@ -232,7 +232,7 @@ where
     let mut cs_secondary: SatisfyingAssignment<G2> = SatisfyingAssignment::new();
     let inputs_secondary: NovaAugmentedCircuitInputs<G1> = NovaAugmentedCircuitInputs::new(
       pp.digest,
-      G2::Scalar::ZERO,
+      <G2 as Group>::Scalar::ZERO,
       z0_secondary,
       None,
       None,
@@ -291,8 +291,8 @@ where
     pp: &PublicParams<G1, G2, C1, C2>,
     c_primary: &C1,
     c_secondary: &C2,
-    z0_primary: Vec<G1::Scalar>,
-    z0_secondary: Vec<G2::Scalar>,
+    z0_primary: Vec<<G1 as Group>::Scalar>,
+    z0_secondary: Vec<<G2 as Group>::Scalar>,
   ) -> Result<(), NovaError> {
     if z0_primary.len() != pp.F_arity_primary || z0_secondary.len() != pp.F_arity_secondary {
       return Err(NovaError::InvalidInitialInputLength);
@@ -320,7 +320,7 @@ where
     let mut cs_primary: SatisfyingAssignment<G1> = SatisfyingAssignment::new();
     let inputs_primary: NovaAugmentedCircuitInputs<G2> = NovaAugmentedCircuitInputs::new(
       scalar_as_base::<G1>(pp.digest),
-      G1::Scalar::from(self.i as u64),
+      <G1 as Group>::Scalar::from(self.i as u64),
       z0_primary,
       Some(self.zi_primary.clone()),
       Some(self.r_U_secondary.clone()),
@@ -357,7 +357,7 @@ where
     let mut cs_secondary: SatisfyingAssignment<G2> = SatisfyingAssignment::new();
     let inputs_secondary: NovaAugmentedCircuitInputs<G1> = NovaAugmentedCircuitInputs::new(
       pp.digest,
-      G2::Scalar::from(self.i as u64),
+      <G2 as Group>::Scalar::from(self.i as u64),
       z0_secondary,
       Some(self.zi_secondary.clone()),
       Some(self.r_U_primary.clone()),
@@ -400,9 +400,9 @@ where
     &self,
     pp: &PublicParams<G1, G2, C1, C2>,
     num_steps: usize,
-    z0_primary: &[G1::Scalar],
-    z0_secondary: &[G2::Scalar],
-  ) -> Result<(Vec<G1::Scalar>, Vec<G2::Scalar>), NovaError> {
+    z0_primary: &[<G1 as Group>::Scalar],
+    z0_secondary: &[<G2 as Group>::Scalar],
+  ) -> Result<(Vec<<G1 as Group>::Scalar>, Vec<<G2 as Group>::Scalar>), NovaError> {
     // number of steps cannot be zero
     if num_steps == 0 {
       return Err(NovaError::ProofVerifyError);
@@ -428,7 +428,7 @@ where
         NUM_FE_WITHOUT_IO_FOR_CRHF + 2 * pp.F_arity_primary,
       );
       hasher.absorb(pp.digest);
-      hasher.absorb(G1::Scalar::from(num_steps as u64));
+      hasher.absorb(<G1 as Group>::Scalar::from(num_steps as u64));
       for e in z0_primary {
         hasher.absorb(*e);
       }
@@ -442,7 +442,7 @@ where
         NUM_FE_WITHOUT_IO_FOR_CRHF + 2 * pp.F_arity_secondary,
       );
       hasher2.absorb(scalar_as_base::<G1>(pp.digest));
-      hasher2.absorb(G2::Scalar::from(num_steps as u64));
+      hasher2.absorb(<G2 as Group>::Scalar::from(num_steps as u64));
       for e in z0_secondary {
         hasher2.absorb(*e);
       }
@@ -505,8 +505,8 @@ pub struct ProverKey<G1, G2, C1, C2, S1, S2>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
-  C2: StepCircuit<G2::Scalar>,
+  C1: StepCircuit<<G1 as Group>::Scalar>,
+  C2: StepCircuit<<G2 as Group>::Scalar>,
   S1: RelaxedR1CSSNARKTrait<G1>,
   S2: RelaxedR1CSSNARKTrait<G2>,
 {
@@ -523,8 +523,8 @@ pub struct VerifierKey<G1, G2, C1, C2, S1, S2>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
-  C2: StepCircuit<G2::Scalar>,
+  C1: StepCircuit<<G1 as Group>::Scalar>,
+  C2: StepCircuit<<G2 as Group>::Scalar>,
   S1: RelaxedR1CSSNARKTrait<G1>,
   S2: RelaxedR1CSSNARKTrait<G2>,
 {
@@ -532,7 +532,7 @@ where
   F_arity_secondary: usize,
   ro_consts_primary: ROConstants<G1>,
   ro_consts_secondary: ROConstants<G2>,
-  digest: G1::Scalar,
+  digest: <G1 as Group>::Scalar,
   vk_primary: S1::VerifierKey,
   vk_secondary: S2::VerifierKey,
   _p_c1: PhantomData<C1>,
@@ -546,8 +546,8 @@ pub struct CompressedSNARK<G1, G2, C1, C2, S1, S2>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
-  C2: StepCircuit<G2::Scalar>,
+  C1: StepCircuit<<G1 as Group>::Scalar>,
+  C2: StepCircuit<<G2 as Group>::Scalar>,
   S1: RelaxedR1CSSNARKTrait<G1>,
   S2: RelaxedR1CSSNARKTrait<G2>,
 {
@@ -559,8 +559,8 @@ where
   nifs_secondary: NIFS<G2>,
   f_W_snark_secondary: S2,
 
-  zn_primary: Vec<G1::Scalar>,
-  zn_secondary: Vec<G2::Scalar>,
+  zn_primary: Vec<<G1 as Group>::Scalar>,
+  zn_secondary: Vec<<G2 as Group>::Scalar>,
 
   _p_c1: PhantomData<C1>,
   _p_c2: PhantomData<C2>,
@@ -570,8 +570,8 @@ impl<G1, G2, C1, C2, S1, S2> CompressedSNARK<G1, G2, C1, C2, S1, S2>
 where
   G1: Group<Base = <G2 as Group>::Scalar>,
   G2: Group<Base = <G1 as Group>::Scalar>,
-  C1: StepCircuit<G1::Scalar>,
-  C2: StepCircuit<G2::Scalar>,
+  C1: StepCircuit<<G1 as Group>::Scalar>,
+  C2: StepCircuit<<G2 as Group>::Scalar>,
   S1: RelaxedR1CSSNARKTrait<G1>,
   S2: RelaxedR1CSSNARKTrait<G2>,
 {
@@ -672,9 +672,9 @@ where
     &self,
     vk: &VerifierKey<G1, G2, C1, C2, S1, S2>,
     num_steps: usize,
-    z0_primary: Vec<G1::Scalar>,
-    z0_secondary: Vec<G2::Scalar>,
-  ) -> Result<(Vec<G1::Scalar>, Vec<G2::Scalar>), NovaError> {
+    z0_primary: Vec<<G1 as Group>::Scalar>,
+    z0_secondary: Vec<<G2 as Group>::Scalar>,
+  ) -> Result<(Vec<<G1 as Group>::Scalar>, Vec<<G2 as Group>::Scalar>), NovaError> {
     // number of steps cannot be zero
     if num_steps == 0 {
       return Err(NovaError::ProofVerifyError);
@@ -695,7 +695,7 @@ where
         NUM_FE_WITHOUT_IO_FOR_CRHF + 2 * vk.F_arity_primary,
       );
       hasher.absorb(vk.digest);
-      hasher.absorb(G1::Scalar::from(num_steps as u64));
+      hasher.absorb(<G1 as Group>::Scalar::from(num_steps as u64));
       for e in z0_primary {
         hasher.absorb(e);
       }
@@ -709,7 +709,7 @@ where
         NUM_FE_WITHOUT_IO_FOR_CRHF + 2 * vk.F_arity_secondary,
       );
       hasher2.absorb(scalar_as_base::<G1>(vk.digest));
-      hasher2.absorb(G2::Scalar::from(num_steps as u64));
+      hasher2.absorb(<G2 as Group>::Scalar::from(num_steps as u64));
       for e in z0_secondary {
         hasher2.absorb(e);
       }
@@ -764,7 +764,7 @@ type Commitment<G> = <<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment;
 type CompressedCommitment<G> = <<<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment as CommitmentTrait<G>>::CompressedCommitment;
 type CE<G> = <G as Group>::CE;
 
-fn compute_digest<G: Group, T: Serialize>(o: &T) -> G::Scalar {
+fn compute_digest<G: Group, T: Serialize>(o: &T) -> <G as Group>::Scalar {
   // obtain a vector of bytes representing public parameters
   let bytes = bincode::serialize(o).unwrap();
   // convert pp_bytes into a short digest
@@ -780,8 +780,8 @@ fn compute_digest<G: Group, T: Serialize>(o: &T) -> G::Scalar {
   });
 
   // turn the bit vector into a scalar
-  let mut digest = G::Scalar::ZERO;
-  let mut coeff = G::Scalar::ONE;
+  let mut digest = <G as Group>::Scalar::ZERO;
+  let mut coeff = <G as Group>::Scalar::ONE;
   for bit in bv {
     if bit {
       digest += coeff;
@@ -862,8 +862,8 @@ mod tests {
   where
     G1: Group<Base = <G2 as Group>::Scalar>,
     G2: Group<Base = <G1 as Group>::Scalar>,
-    T1: StepCircuit<G1::Scalar>,
-    T2: StepCircuit<G2::Scalar>,
+    T1: StepCircuit<<G1 as Group>::Scalar>,
+    T2: StepCircuit<<G2 as Group>::Scalar>,
   {
     let pp = PublicParams::<G1, G2, T1, T2>::setup(circuit1, circuit2);
 

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -36,7 +36,7 @@ impl<G: Group> NIFS<G> {
   pub fn prove(
     ck: &CommitmentKey<G>,
     ro_consts: &ROConstants<G>,
-    pp_digest: &G::Scalar,
+    pp_digest: &<G as Group>::Scalar,
     S: &R1CSShape<G>,
     U1: &RelaxedR1CSInstance<G>,
     W1: &RelaxedR1CSWitness<G>,
@@ -86,7 +86,7 @@ impl<G: Group> NIFS<G> {
   pub fn verify(
     &self,
     ro_consts: &ROConstants<G>,
-    pp_digest: &G::Scalar,
+    pp_digest: &<G as Group>::Scalar,
     U1: &RelaxedR1CSInstance<G>,
     U2: &R1CSInstance<G>,
   ) -> Result<RelaxedR1CSInstance<G>, NovaError> {
@@ -180,7 +180,7 @@ mod tests {
 
     // Now get the instance and assignment for one instance
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();
-    let _ = synthesize_tiny_r1cs_bellperson(&mut cs, Some(G::Scalar::from(5)));
+    let _ = synthesize_tiny_r1cs_bellperson(&mut cs, Some(<G as Group>::Scalar::from(5)));
     let (U1, W1) = cs.r1cs_instance_and_witness(&shape, &ck).unwrap();
 
     // Make sure that the first instance is satisfiable
@@ -188,7 +188,7 @@ mod tests {
 
     // Now get the instance and assignment for second instance
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();
-    let _ = synthesize_tiny_r1cs_bellperson(&mut cs, Some(G::Scalar::from(135)));
+    let _ = synthesize_tiny_r1cs_bellperson(&mut cs, Some(<G as Group>::Scalar::from(135)));
     let (U2, W2) = cs.r1cs_instance_and_witness(&shape, &ck).unwrap();
 
     // Make sure that the second instance is satisfiable
@@ -268,7 +268,7 @@ mod tests {
   }
 
   fn test_tiny_r1cs_with<G: Group>() {
-    let one = <G::Scalar as Field>::ONE;
+    let one = <<G as Group>::Scalar as Field>::ONE;
     let (num_cons, num_vars, num_io, A, B, C) = {
       let num_cons = 4;
       let num_vars = 3;
@@ -285,9 +285,9 @@ mod tests {
       // constraint and a column for every entry in z = (vars, u, inputs)
       // An R1CS instance is satisfiable iff:
       // Az \circ Bz = u \cdot Cz + E, where z = (vars, 1, inputs)
-      let mut A: Vec<(usize, usize, G::Scalar)> = Vec::new();
-      let mut B: Vec<(usize, usize, G::Scalar)> = Vec::new();
-      let mut C: Vec<(usize, usize, G::Scalar)> = Vec::new();
+      let mut A: Vec<(usize, usize, <G as Group>::Scalar)> = Vec::new();
+      let mut B: Vec<(usize, usize, <G as Group>::Scalar)> = Vec::new();
+      let mut C: Vec<(usize, usize, <G as Group>::Scalar)> = Vec::new();
 
       // constraint 0 entries in (A,B,C)
       // `I0 * I0 - Z0 = 0`
@@ -331,7 +331,9 @@ mod tests {
       <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::new();
 
     let rand_inst_witness_generator =
-      |ck: &CommitmentKey<G>, I: &G::Scalar| -> (G::Scalar, R1CSInstance<G>, R1CSWitness<G>) {
+      |ck: &CommitmentKey<G>,
+       I: &<G as Group>::Scalar|
+       -> (<G as Group>::Scalar, R1CSInstance<G>, R1CSWitness<G>) {
         let i0 = *I;
 
         // compute a satisfying (vars, X) tuple
@@ -366,7 +368,7 @@ mod tests {
       };
 
     let mut csprng: OsRng = OsRng;
-    let I = G::Scalar::random(&mut csprng); // the first input is picked randomly for the first instance
+    let I = <G as Group>::Scalar::random(&mut csprng); // the first input is picked randomly for the first instance
     let (O, U1, W1) = rand_inst_witness_generator(&ck, &I);
     let (_O, U2, W2) = rand_inst_witness_generator(&ck, &O);
 

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -58,13 +58,13 @@ macro_rules! impl_traits {
       type Scalar = $name::Scalar;
       type CompressedGroupElement = $name_compressed;
       type PreprocessedGroupElement = $name::Affine;
-      type RO = PoseidonRO<Self::Base, Self::Scalar>;
+      type RO = PoseidonRO<Self::Base, <Self as Group>::Scalar>;
       type ROCircuit = PoseidonROCircuit<Self::Base>;
       type TE = Keccak256Transcript<Self>;
       type CE = CommitmentEngine<Self>;
 
       fn vartime_multiscalar_mul(
-        scalars: &[Self::Scalar],
+        scalars: &[<Self as Group>::Scalar],
         bases: &[Self::PreprocessedGroupElement],
       ) -> Self {
         cpu_best_multiexp(scalars, bases)

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -75,9 +75,9 @@ where
     pk: &Self::ProverKey,
     transcript: &mut G::TE,
     comm: &Commitment<G>,
-    poly: &[G::Scalar],
-    point: &[G::Scalar],
-    eval: &G::Scalar,
+    poly: &[<G as Group>::Scalar],
+    point: &[<G as Group>::Scalar],
+    eval: &<G as Group>::Scalar,
   ) -> Result<Self::EvaluationArgument, NovaError> {
     let u = InnerProductInstance::new(comm, &EqPolynomial::new(point.to_vec()).evals(), eval);
     let w = InnerProductWitness::new(poly);
@@ -92,8 +92,8 @@ where
     vk: &Self::VerifierKey,
     transcript: &mut G::TE,
     comm: &Commitment<G>,
-    point: &[G::Scalar],
-    eval: &G::Scalar,
+    point: &[<G as Group>::Scalar],
+    eval: &<G as Group>::Scalar,
     arg: &Self::EvaluationArgument,
   ) -> Result<(), NovaError> {
     let u = InnerProductInstance::new(comm, &EqPolynomial::new(point.to_vec()).evals(), eval);
@@ -125,12 +125,16 @@ where
 /// and the claim that c = <a, b>.
 pub struct InnerProductInstance<G: Group> {
   comm_a_vec: Commitment<G>,
-  b_vec: Vec<G::Scalar>,
-  c: G::Scalar,
+  b_vec: Vec<<G as Group>::Scalar>,
+  c: <G as Group>::Scalar,
 }
 
 impl<G: Group> InnerProductInstance<G> {
-  fn new(comm_a_vec: &Commitment<G>, b_vec: &[G::Scalar], c: &G::Scalar) -> Self {
+  fn new(
+    comm_a_vec: &Commitment<G>,
+    b_vec: &[<G as Group>::Scalar],
+    c: &<G as Group>::Scalar,
+  ) -> Self {
     InnerProductInstance {
       comm_a_vec: *comm_a_vec,
       b_vec: b_vec.to_vec(),
@@ -151,11 +155,11 @@ impl<G: Group> TranscriptReprTrait<G> for InnerProductInstance<G> {
 }
 
 struct InnerProductWitness<G: Group> {
-  a_vec: Vec<G::Scalar>,
+  a_vec: Vec<<G as Group>::Scalar>,
 }
 
 impl<G: Group> InnerProductWitness<G> {
-  fn new(a_vec: &[G::Scalar]) -> Self {
+  fn new(a_vec: &[<G as Group>::Scalar]) -> Self {
     InnerProductWitness {
       a_vec: a_vec.to_vec(),
     }
@@ -168,7 +172,7 @@ impl<G: Group> InnerProductWitness<G> {
 struct InnerProductArgument<G: Group> {
   L_vec: Vec<CompressedCommitment<G>>,
   R_vec: Vec<CompressedCommitment<G>>,
-  a_hat: G::Scalar,
+  a_hat: <G as Group>::Scalar,
   _p: PhantomData<G>,
 }
 
@@ -204,16 +208,16 @@ where
     let ck_c = ck_c.scale(&r);
 
     // a closure that executes a step of the recursive inner product argument
-    let prove_inner = |a_vec: &[G::Scalar],
-                       b_vec: &[G::Scalar],
+    let prove_inner = |a_vec: &[<G as Group>::Scalar],
+                       b_vec: &[<G as Group>::Scalar],
                        ck: &CommitmentKey<G>,
                        transcript: &mut G::TE|
      -> Result<
       (
         CompressedCommitment<G>,
         CompressedCommitment<G>,
-        Vec<G::Scalar>,
-        Vec<G::Scalar>,
+        Vec<<G as Group>::Scalar>,
+        Vec<<G as Group>::Scalar>,
         CommitmentKey<G>,
       ),
       NovaError,
@@ -230,7 +234,7 @@ where
           .iter()
           .chain(iter::once(&c_L))
           .copied()
-          .collect::<Vec<G::Scalar>>(),
+          .collect::<Vec<<G as Group>::Scalar>>(),
       )
       .compress();
       let R = CE::<G>::commit(
@@ -239,7 +243,7 @@ where
           .iter()
           .chain(iter::once(&c_R))
           .copied()
-          .collect::<Vec<G::Scalar>>(),
+          .collect::<Vec<<G as Group>::Scalar>>(),
       )
       .compress();
 
@@ -254,13 +258,13 @@ where
         .par_iter()
         .zip(a_vec[n / 2..n].par_iter())
         .map(|(a_L, a_R)| *a_L * r + r_inverse * *a_R)
-        .collect::<Vec<G::Scalar>>();
+        .collect::<Vec<<G as Group>::Scalar>>();
 
       let b_vec_folded = b_vec[0..n / 2]
         .par_iter()
         .zip(b_vec[n / 2..n].par_iter())
         .map(|(b_L, b_R)| *b_L * r_inverse + r * *b_R)
-        .collect::<Vec<G::Scalar>>();
+        .collect::<Vec<<G as Group>::Scalar>>();
 
       let ck_folded = ck.fold(&r_inverse, &r);
 
@@ -322,32 +326,33 @@ where
 
     let P = U.comm_a_vec + CE::<G>::commit(&ck_c, &[U.c]);
 
-    let batch_invert = |v: &[G::Scalar]| -> Result<Vec<G::Scalar>, NovaError> {
-      let mut products = vec![G::Scalar::ZERO; v.len()];
-      let mut acc = G::Scalar::ONE;
+    let batch_invert =
+      |v: &[<G as Group>::Scalar]| -> Result<Vec<<G as Group>::Scalar>, NovaError> {
+        let mut products = vec![<G as Group>::Scalar::ZERO; v.len()];
+        let mut acc = <G as Group>::Scalar::ONE;
 
-      for i in 0..v.len() {
-        products[i] = acc;
-        acc *= v[i];
-      }
+        for i in 0..v.len() {
+          products[i] = acc;
+          acc *= v[i];
+        }
 
-      // we can compute an inversion only if acc is non-zero
-      if acc == G::Scalar::ZERO {
-        return Err(NovaError::InvalidInputLength);
-      }
+        // we can compute an inversion only if acc is non-zero
+        if acc == <G as Group>::Scalar::ZERO {
+          return Err(NovaError::InvalidInputLength);
+        }
 
-      // compute the inverse once for all entries
-      acc = acc.invert().unwrap();
+        // compute the inverse once for all entries
+        acc = acc.invert().unwrap();
 
-      let mut inv = vec![G::Scalar::ZERO; v.len()];
-      for i in 0..v.len() {
-        let tmp = acc * v[v.len() - 1 - i];
-        inv[v.len() - 1 - i] = products[v.len() - 1 - i] * acc;
-        acc = tmp;
-      }
+        let mut inv = vec![<G as Group>::Scalar::ZERO; v.len()];
+        for i in 0..v.len() {
+          let tmp = acc * v[v.len() - 1 - i];
+          inv[v.len() - 1 - i] = products[v.len() - 1 - i] * acc;
+          acc = tmp;
+        }
 
-      Ok(inv)
-    };
+        Ok(inv)
+      };
 
     // compute a vector of public coins using self.L_vec and self.R_vec
     let r = (0..self.L_vec.len())
@@ -356,24 +361,24 @@ where
         transcript.absorb(b"R", &self.R_vec[i]);
         transcript.squeeze(b"r")
       })
-      .collect::<Result<Vec<G::Scalar>, NovaError>>()?;
+      .collect::<Result<Vec<<G as Group>::Scalar>, NovaError>>()?;
 
     // precompute scalars necessary for verification
-    let r_square: Vec<G::Scalar> = (0..self.L_vec.len())
+    let r_square: Vec<<G as Group>::Scalar> = (0..self.L_vec.len())
       .into_par_iter()
       .map(|i| r[i] * r[i])
       .collect();
     let r_inverse = batch_invert(&r)?;
-    let r_inverse_square: Vec<G::Scalar> = (0..self.L_vec.len())
+    let r_inverse_square: Vec<<G as Group>::Scalar> = (0..self.L_vec.len())
       .into_par_iter()
       .map(|i| r_inverse[i] * r_inverse[i])
       .collect();
 
     // compute the vector with the tensor structure
     let s = {
-      let mut s = vec![G::Scalar::ZERO; n];
+      let mut s = vec![<G as Group>::Scalar::ZERO; n];
       s[0] = {
-        let mut v = G::Scalar::ONE;
+        let mut v = <G as Group>::Scalar::ONE;
         for r_inverse_i in &r_inverse {
           v *= r_inverse_i;
         }
@@ -406,9 +411,9 @@ where
         &r_square
           .iter()
           .chain(r_inverse_square.iter())
-          .chain(iter::once(&G::Scalar::ONE))
+          .chain(iter::once(&<G as Group>::Scalar::ONE))
           .copied()
-          .collect::<Vec<G::Scalar>>(),
+          .collect::<Vec<<G as Group>::Scalar>>(),
       )
     };
 

--- a/src/provider/keccak.rs
+++ b/src/provider/keccak.rs
@@ -59,7 +59,7 @@ impl<G: Group> TranscriptEngineTrait<G> for Keccak256Transcript<G> {
     }
   }
 
-  fn squeeze(&mut self, label: &'static [u8]) -> Result<G::Scalar, NovaError> {
+  fn squeeze(&mut self, label: &'static [u8]) -> Result<<G as Group>::Scalar, NovaError> {
     // we gather the full input from the round, preceded by the current state of the transcript
     let input = [
       DOM_SEP_TAG,
@@ -82,7 +82,7 @@ impl<G: Group> TranscriptEngineTrait<G> for Keccak256Transcript<G> {
     self.transcript = Keccak256::new();
 
     // squeeze out a challenge
-    Ok(G::Scalar::from_uniform(&output))
+    Ok(<G as Group>::Scalar::from_uniform(&output))
   }
 
   fn absorb<T: TranscriptReprTrait<G>>(&mut self, label: &'static [u8], o: &T) {
@@ -231,8 +231,11 @@ mod tests {
     let c1: <G as Group>::Scalar = transcript.squeeze(b"c1").unwrap();
 
     let c1_bytes = squeeze_for_testing(&manual_transcript[..], 0u16, initial_state, b"c1");
-    let to_hex = |g: G::Scalar| hex::encode(g.to_repr().as_ref());
-    assert_eq!(to_hex(c1), to_hex(G::Scalar::from_uniform(&c1_bytes)));
+    let to_hex = |g: <G as Group>::Scalar| hex::encode(g.to_repr().as_ref());
+    assert_eq!(
+      to_hex(c1),
+      to_hex(<G as Group>::Scalar::from_uniform(&c1_bytes))
+    );
   }
 
   #[test]

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -62,14 +62,14 @@ macro_rules! impl_traits {
       type Scalar = $name::Scalar;
       type CompressedGroupElement = $name_compressed;
       type PreprocessedGroupElement = $name::Affine;
-      type RO = PoseidonRO<Self::Base, Self::Scalar>;
+      type RO = PoseidonRO<Self::Base, <Self as Group>::Scalar>;
       type ROCircuit = PoseidonROCircuit<Self::Base>;
       type TE = Keccak256Transcript<Self>;
       type CE = CommitmentEngine<Self>;
 
       #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
       fn vartime_multiscalar_mul(
-        scalars: &[Self::Scalar],
+        scalars: &[<Self as Group>::Scalar],
         bases: &[Self::PreprocessedGroupElement],
       ) -> Self {
         if scalars.len() >= 128 {
@@ -81,7 +81,7 @@ macro_rules! impl_traits {
 
       #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
       fn vartime_multiscalar_mul(
-        scalars: &[Self::Scalar],
+        scalars: &[<Self as Group>::Scalar],
         bases: &[Self::PreprocessedGroupElement],
       ) -> Self {
         cpu_best_multiexp(scalars, bases)

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -98,26 +98,26 @@ impl<G: Group> TranscriptReprTrait<G> for CompressedCommitment<G> {
   }
 }
 
-impl<G: Group> MulAssign<G::Scalar> for Commitment<G> {
-  fn mul_assign(&mut self, scalar: G::Scalar) {
+impl<G: Group> MulAssign<<G as Group>::Scalar> for Commitment<G> {
+  fn mul_assign(&mut self, scalar: <G as Group>::Scalar) {
     let result = (self as &Commitment<G>).comm * scalar;
     *self = Commitment { comm: result };
   }
 }
 
-impl<'a, 'b, G: Group> Mul<&'b G::Scalar> for &'a Commitment<G> {
+impl<'a, 'b, G: Group> Mul<&'b <G as Group>::Scalar> for &'a Commitment<G> {
   type Output = Commitment<G>;
-  fn mul(self, scalar: &'b G::Scalar) -> Commitment<G> {
+  fn mul(self, scalar: &'b <G as Group>::Scalar) -> Commitment<G> {
     Commitment {
       comm: self.comm * scalar,
     }
   }
 }
 
-impl<G: Group> Mul<G::Scalar> for Commitment<G> {
+impl<G: Group> Mul<<G as Group>::Scalar> for Commitment<G> {
   type Output = Commitment<G>;
 
-  fn mul(self, scalar: G::Scalar) -> Commitment<G> {
+  fn mul(self, scalar: <G as Group>::Scalar) -> Commitment<G> {
     Commitment {
       comm: self.comm * scalar,
     }
@@ -195,7 +195,7 @@ impl<G: Group> CommitmentEngineTrait<G> for CommitmentEngine<G> {
     }
   }
 
-  fn commit(ck: &Self::CommitmentKey, v: &[G::Scalar]) -> Self::Commitment {
+  fn commit(ck: &Self::CommitmentKey, v: &[<G as Group>::Scalar]) -> Self::Commitment {
     assert!(ck.ck.len() >= v.len());
     Commitment {
       comm: G::vartime_multiscalar_mul(v, &ck.ck[..v.len()]),
@@ -217,10 +217,10 @@ pub trait CommitmentKeyExtTrait<G: Group> {
   fn combine(&self, other: &Self) -> Self;
 
   /// Folds the two commitment keys into one using the provided weights
-  fn fold(&self, w1: &G::Scalar, w2: &G::Scalar) -> Self;
+  fn fold(&self, w1: &<G as Group>::Scalar, w2: &<G as Group>::Scalar) -> Self;
 
   /// Scales the commitment key using the provided scalar
-  fn scale(&self, r: &G::Scalar) -> Self;
+  fn scale(&self, r: &<G as Group>::Scalar) -> Self;
 
   /// Reinterprets commitments as commitment keys
   fn reinterpret_commitments_as_ck(
@@ -259,7 +259,7 @@ impl<G: Group> CommitmentKeyExtTrait<G> for CommitmentKey<G> {
   }
 
   // combines the left and right halves of `self` using `w1` and `w2` as the weights
-  fn fold(&self, w1: &G::Scalar, w2: &G::Scalar) -> CommitmentKey<G> {
+  fn fold(&self, w1: &<G as Group>::Scalar, w2: &<G as Group>::Scalar) -> CommitmentKey<G> {
     let w = vec![*w1, *w2];
     let (L, R) = self.split_at(self.ck.len() / 2);
 
@@ -278,7 +278,7 @@ impl<G: Group> CommitmentKeyExtTrait<G> for CommitmentKey<G> {
   }
 
   /// Scales each element in `self` by `r`
-  fn scale(&self, r: &G::Scalar) -> Self {
+  fn scale(&self, r: &<G as Group>::Scalar) -> Self {
     let ck_scaled = self
       .ck
       .clone()

--- a/src/provider/poseidon.rs
+++ b/src/provider/poseidon.rs
@@ -219,14 +219,15 @@ mod tests {
   {
     // Check that the number computed inside the circuit is equal to the number computed outside the circuit
     let mut csprng: OsRng = OsRng;
-    let constants = PoseidonConstantsCircuit::<G::Scalar>::new();
+    let constants = PoseidonConstantsCircuit::<<G as Group>::Scalar>::new();
     let num_absorbs = 32;
-    let mut ro: PoseidonRO<G::Scalar, G::Base> = PoseidonRO::new(constants.clone(), num_absorbs);
-    let mut ro_gadget: PoseidonROCircuit<G::Scalar> =
+    let mut ro: PoseidonRO<<G as Group>::Scalar, G::Base> =
+      PoseidonRO::new(constants.clone(), num_absorbs);
+    let mut ro_gadget: PoseidonROCircuit<<G as Group>::Scalar> =
       PoseidonROCircuit::new(constants, num_absorbs);
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();
     for i in 0..num_absorbs {
-      let num = G::Scalar::random(&mut csprng);
+      let num = <G as Group>::Scalar::random(&mut csprng);
       ro.absorb(num);
       let num_gadget =
         AllocatedNum::alloc(cs.namespace(|| format!("data {i}")), || Ok(num)).unwrap();

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -27,19 +27,21 @@ pub struct R1CS<G: Group> {
 
 /// A type that holds the shape of the R1CS matrices
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct R1CSShape<G: Group> {
   pub(crate) num_cons: usize,
   pub(crate) num_vars: usize,
   pub(crate) num_io: usize,
-  pub(crate) A: Vec<(usize, usize, G::Scalar)>,
-  pub(crate) B: Vec<(usize, usize, G::Scalar)>,
-  pub(crate) C: Vec<(usize, usize, G::Scalar)>,
+  pub(crate) A: Vec<(usize, usize, <G as Group>::Scalar)>,
+  pub(crate) B: Vec<(usize, usize, <G as Group>::Scalar)>,
+  pub(crate) C: Vec<(usize, usize, <G as Group>::Scalar)>,
 }
 
 /// A type that holds a witness for a given R1CS instance
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct R1CSWitness<G: Group> {
-  W: Vec<G::Scalar>,
+  W: Vec<<G as Group>::Scalar>,
 }
 
 /// A type that holds an R1CS instance
@@ -47,14 +49,15 @@ pub struct R1CSWitness<G: Group> {
 #[serde(bound = "")]
 pub struct R1CSInstance<G: Group> {
   pub(crate) comm_W: Commitment<G>,
-  pub(crate) X: Vec<G::Scalar>,
+  pub(crate) X: Vec<<G as Group>::Scalar>,
 }
 
 /// A type that holds a witness for a given Relaxed R1CS instance
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct RelaxedR1CSWitness<G: Group> {
-  pub(crate) W: Vec<G::Scalar>,
-  pub(crate) E: Vec<G::Scalar>,
+  pub(crate) W: Vec<<G as Group>::Scalar>,
+  pub(crate) E: Vec<<G as Group>::Scalar>,
 }
 
 /// A type that holds a Relaxed R1CS instance
@@ -63,8 +66,8 @@ pub struct RelaxedR1CSWitness<G: Group> {
 pub struct RelaxedR1CSInstance<G: Group> {
   pub(crate) comm_W: Commitment<G>,
   pub(crate) comm_E: Commitment<G>,
-  pub(crate) X: Vec<G::Scalar>,
-  pub(crate) u: G::Scalar,
+  pub(crate) X: Vec<<G as Group>::Scalar>,
+  pub(crate) u: <G as Group>::Scalar,
 }
 
 impl<G: Group> R1CS<G> {
@@ -83,14 +86,14 @@ impl<G: Group> R1CSShape<G> {
     num_cons: usize,
     num_vars: usize,
     num_io: usize,
-    A: &[(usize, usize, G::Scalar)],
-    B: &[(usize, usize, G::Scalar)],
-    C: &[(usize, usize, G::Scalar)],
+    A: &[(usize, usize, <G as Group>::Scalar)],
+    B: &[(usize, usize, <G as Group>::Scalar)],
+    C: &[(usize, usize, <G as Group>::Scalar)],
   ) -> Result<R1CSShape<G>, NovaError> {
     let is_valid = |num_cons: usize,
                     num_vars: usize,
                     num_io: usize,
-                    M: &[(usize, usize, G::Scalar)]|
+                    M: &[(usize, usize, <G as Group>::Scalar)]|
      -> Result<(), NovaError> {
       let res = (0..M.len())
         .map(|i| {
@@ -145,8 +148,15 @@ impl<G: Group> R1CSShape<G> {
 
   pub fn multiply_vec(
     &self,
-    z: &[G::Scalar],
-  ) -> Result<(Vec<G::Scalar>, Vec<G::Scalar>, Vec<G::Scalar>), NovaError> {
+    z: &[<G as Group>::Scalar],
+  ) -> Result<
+    (
+      Vec<<G as Group>::Scalar>,
+      Vec<<G as Group>::Scalar>,
+      Vec<<G as Group>::Scalar>,
+    ),
+    NovaError,
+  > {
     if z.len() != self.num_io + self.num_vars + 1 {
       return Err(NovaError::InvalidWitnessLength);
     }
@@ -154,18 +164,23 @@ impl<G: Group> R1CSShape<G> {
     // computes a product between a sparse matrix `M` and a vector `z`
     // This does not perform any validation of entries in M (e.g., if entries in `M` reference indexes outside the range of `z`)
     // This is safe since we know that `M` is valid
-    let sparse_matrix_vec_product =
-      |M: &Vec<(usize, usize, G::Scalar)>, num_rows: usize, z: &[G::Scalar]| -> Vec<G::Scalar> {
-        (0..M.len())
-          .map(|i| {
-            let (row, col, val) = M[i];
-            (row, val * z[col])
-          })
-          .fold(vec![G::Scalar::ZERO; num_rows], |mut Mz, (r, v)| {
+    let sparse_matrix_vec_product = |M: &Vec<(usize, usize, <G as Group>::Scalar)>,
+                                     num_rows: usize,
+                                     z: &[<G as Group>::Scalar]|
+     -> Vec<<G as Group>::Scalar> {
+      (0..M.len())
+        .map(|i| {
+          let (row, col, val) = M[i];
+          (row, val * z[col])
+        })
+        .fold(
+          vec![<G as Group>::Scalar::ZERO; num_rows],
+          |mut Mz, (r, v)| {
             Mz[r] += v;
             Mz
-          })
-      };
+          },
+        )
+    };
 
     let (Az, (Bz, Cz)) = rayon::join(
       || sparse_matrix_vec_product(&self.A, self.num_cons, z),
@@ -232,7 +247,11 @@ impl<G: Group> R1CSShape<G> {
 
     // verify if Az * Bz = u*Cz
     let res_eq: bool = {
-      let z = concat(vec![W.W.clone(), vec![G::Scalar::ONE], U.X.clone()]);
+      let z = concat(vec![
+        W.W.clone(),
+        vec![<G as Group>::Scalar::ONE],
+        U.X.clone(),
+      ]);
       let (Az, Bz, Cz) = self.multiply_vec(&z)?;
       assert_eq!(Az.len(), self.num_cons);
       assert_eq!(Bz.len(), self.num_cons);
@@ -264,33 +283,37 @@ impl<G: Group> R1CSShape<G> {
     W1: &RelaxedR1CSWitness<G>,
     U2: &R1CSInstance<G>,
     W2: &R1CSWitness<G>,
-  ) -> Result<(Vec<G::Scalar>, Commitment<G>), NovaError> {
+  ) -> Result<(Vec<<G as Group>::Scalar>, Commitment<G>), NovaError> {
     let (AZ_1, BZ_1, CZ_1) = {
       let Z1 = concat(vec![W1.W.clone(), vec![U1.u], U1.X.clone()]);
       self.multiply_vec(&Z1)?
     };
 
     let (AZ_2, BZ_2, CZ_2) = {
-      let Z2 = concat(vec![W2.W.clone(), vec![G::Scalar::ONE], U2.X.clone()]);
+      let Z2 = concat(vec![
+        W2.W.clone(),
+        vec![<G as Group>::Scalar::ONE],
+        U2.X.clone(),
+      ]);
       self.multiply_vec(&Z2)?
     };
 
     let AZ_1_circ_BZ_2 = (0..AZ_1.len())
       .into_par_iter()
       .map(|i| AZ_1[i] * BZ_2[i])
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
     let AZ_2_circ_BZ_1 = (0..AZ_2.len())
       .into_par_iter()
       .map(|i| AZ_2[i] * BZ_1[i])
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
     let u_1_cdot_CZ_2 = (0..CZ_2.len())
       .into_par_iter()
       .map(|i| U1.u * CZ_2[i])
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
     let u_2_cdot_CZ_1 = (0..CZ_1.len())
       .into_par_iter()
       .map(|i| CZ_1[i])
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
 
     let T = AZ_1_circ_BZ_2
       .par_iter()
@@ -298,7 +321,7 @@ impl<G: Group> R1CSShape<G> {
       .zip(&u_1_cdot_CZ_2)
       .zip(&u_2_cdot_CZ_1)
       .map(|(((a, b), c), d)| *a + *b - *c - *d)
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
 
     let comm_T = CE::<G>::commit(ck, &T);
 
@@ -332,21 +355,22 @@ impl<G: Group> R1CSShape<G> {
     // otherwise, we need to pad the number of variables and renumber variable accesses
     let num_vars_padded = m;
     let num_cons_padded = m;
-    let apply_pad = |M: &[(usize, usize, G::Scalar)]| -> Vec<(usize, usize, G::Scalar)> {
-      M.par_iter()
-        .map(|(r, c, v)| {
-          (
-            *r,
-            if c >= &self.num_vars {
-              c + num_vars_padded - self.num_vars
-            } else {
-              *c
-            },
-            *v,
-          )
-        })
-        .collect::<Vec<_>>()
-    };
+    let apply_pad =
+      |M: &[(usize, usize, <G as Group>::Scalar)]| -> Vec<(usize, usize, <G as Group>::Scalar)> {
+        M.par_iter()
+          .map(|(r, c, v)| {
+            (
+              *r,
+              if c >= &self.num_vars {
+                c + num_vars_padded - self.num_vars
+              } else {
+                *c
+              },
+              *v,
+            )
+          })
+          .collect::<Vec<_>>()
+      };
 
     let A_padded = apply_pad(&self.A);
     let B_padded = apply_pad(&self.B);
@@ -365,7 +389,7 @@ impl<G: Group> R1CSShape<G> {
 
 impl<G: Group> R1CSWitness<G> {
   /// A method to create a witness object using a vector of scalars
-  pub fn new(S: &R1CSShape<G>, W: &[G::Scalar]) -> Result<R1CSWitness<G>, NovaError> {
+  pub fn new(S: &R1CSShape<G>, W: &[<G as Group>::Scalar]) -> Result<R1CSWitness<G>, NovaError> {
     if S.num_vars != W.len() {
       Err(NovaError::InvalidWitnessLength)
     } else {
@@ -384,7 +408,7 @@ impl<G: Group> R1CSInstance<G> {
   pub fn new(
     S: &R1CSShape<G>,
     comm_W: &Commitment<G>,
-    X: &[G::Scalar],
+    X: &[<G as Group>::Scalar],
   ) -> Result<R1CSInstance<G>, NovaError> {
     if S.num_io != X.len() {
       Err(NovaError::InvalidInputLength)
@@ -410,8 +434,8 @@ impl<G: Group> RelaxedR1CSWitness<G> {
   /// Produces a default RelaxedR1CSWitness given an R1CSShape
   pub fn default(S: &R1CSShape<G>) -> RelaxedR1CSWitness<G> {
     RelaxedR1CSWitness {
-      W: vec![G::Scalar::ZERO; S.num_vars],
-      E: vec![G::Scalar::ZERO; S.num_cons],
+      W: vec![<G as Group>::Scalar::ZERO; S.num_vars],
+      E: vec![<G as Group>::Scalar::ZERO; S.num_cons],
     }
   }
 
@@ -419,7 +443,7 @@ impl<G: Group> RelaxedR1CSWitness<G> {
   pub fn from_r1cs_witness(S: &R1CSShape<G>, witness: &R1CSWitness<G>) -> RelaxedR1CSWitness<G> {
     RelaxedR1CSWitness {
       W: witness.W.clone(),
-      E: vec![G::Scalar::ZERO; S.num_cons],
+      E: vec![<G as Group>::Scalar::ZERO; S.num_cons],
     }
   }
 
@@ -432,8 +456,8 @@ impl<G: Group> RelaxedR1CSWitness<G> {
   pub fn fold(
     &self,
     W2: &R1CSWitness<G>,
-    T: &[G::Scalar],
-    r: &G::Scalar,
+    T: &[<G as Group>::Scalar],
+    r: &<G as Group>::Scalar,
   ) -> Result<RelaxedR1CSWitness<G>, NovaError> {
     let (W1, E1) = (&self.W, &self.E);
     let W2 = &W2.W;
@@ -446,12 +470,12 @@ impl<G: Group> RelaxedR1CSWitness<G> {
       .par_iter()
       .zip(W2)
       .map(|(a, b)| *a + *r * *b)
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
     let E = E1
       .par_iter()
       .zip(T)
       .map(|(a, b)| *a + *r * *b)
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
     Ok(RelaxedR1CSWitness { W, E })
   }
 
@@ -459,13 +483,13 @@ impl<G: Group> RelaxedR1CSWitness<G> {
   pub fn pad(&self, S: &R1CSShape<G>) -> RelaxedR1CSWitness<G> {
     let W = {
       let mut W = self.W.clone();
-      W.extend(vec![G::Scalar::ZERO; S.num_vars - W.len()]);
+      W.extend(vec![<G as Group>::Scalar::ZERO; S.num_vars - W.len()]);
       W
     };
 
     let E = {
       let mut E = self.E.clone();
-      E.extend(vec![G::Scalar::ZERO; S.num_cons - E.len()]);
+      E.extend(vec![<G as Group>::Scalar::ZERO; S.num_cons - E.len()]);
       E
     };
 
@@ -480,8 +504,8 @@ impl<G: Group> RelaxedR1CSInstance<G> {
     RelaxedR1CSInstance {
       comm_W,
       comm_E,
-      u: G::Scalar::ZERO,
-      X: vec![G::Scalar::ZERO; S.num_io],
+      u: <G as Group>::Scalar::ZERO,
+      X: vec![<G as Group>::Scalar::ZERO; S.num_io],
     }
   }
 
@@ -493,7 +517,7 @@ impl<G: Group> RelaxedR1CSInstance<G> {
   ) -> RelaxedR1CSInstance<G> {
     let mut r_instance = RelaxedR1CSInstance::default(ck, S);
     r_instance.comm_W = instance.comm_W;
-    r_instance.u = G::Scalar::ONE;
+    r_instance.u = <G as Group>::Scalar::ONE;
     r_instance.X = instance.X.clone();
     r_instance
   }
@@ -501,12 +525,12 @@ impl<G: Group> RelaxedR1CSInstance<G> {
   /// Initializes a new RelaxedR1CSInstance from an R1CSInstance
   pub fn from_r1cs_instance_unchecked(
     comm_W: &Commitment<G>,
-    X: &[G::Scalar],
+    X: &[<G as Group>::Scalar],
   ) -> RelaxedR1CSInstance<G> {
     RelaxedR1CSInstance {
       comm_W: *comm_W,
       comm_E: Commitment::<G>::default(),
-      u: G::Scalar::ONE,
+      u: <G as Group>::Scalar::ONE,
       X: X.to_vec(),
     }
   }
@@ -516,7 +540,7 @@ impl<G: Group> RelaxedR1CSInstance<G> {
     &self,
     U2: &R1CSInstance<G>,
     comm_T: &Commitment<G>,
-    r: &G::Scalar,
+    r: &<G as Group>::Scalar,
   ) -> Result<RelaxedR1CSInstance<G>, NovaError> {
     let (X1, u1, comm_W_1, comm_E_1) =
       (&self.X, &self.u, &self.comm_W.clone(), &self.comm_E.clone());
@@ -527,7 +551,7 @@ impl<G: Group> RelaxedR1CSInstance<G> {
       .par_iter()
       .zip(X2)
       .map(|(a, b)| *a + *r * *b)
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
     let comm_W = *comm_W_1 + *comm_W_2 * *r;
     let comm_E = *comm_E_1 + *comm_T * *r;
     let u = *u1 + *r;
@@ -561,7 +585,8 @@ impl<G: Group> AbsorbInROTrait<G> for RelaxedR1CSInstance<G> {
 
     // absorb each element of self.X in bignum format
     for x in &self.X {
-      let limbs: Vec<G::Scalar> = nat_to_limbs(&f_to_nat(x), BN_LIMB_WIDTH, BN_N_LIMBS).unwrap();
+      let limbs: Vec<<G as Group>::Scalar> =
+        nat_to_limbs(&f_to_nat(x), BN_LIMB_WIDTH, BN_N_LIMBS).unwrap();
       for limb in limbs {
         ro.absorb(scalar_as_base::<G>(limb));
       }

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -17,25 +17,30 @@ use core::marker::PhantomData;
 use ff::Field;
 use serde::{Deserialize, Serialize};
 
-struct DirectCircuit<G: Group, SC: StepCircuit<G::Scalar>> {
-  z_i: Option<Vec<G::Scalar>>, // inputs to the circuit
-  sc: SC,                      // step circuit to be executed
+struct DirectCircuit<G: Group, SC: StepCircuit<<G as Group>::Scalar>> {
+  z_i: Option<Vec<<G as Group>::Scalar>>, // inputs to the circuit
+  sc: SC,                                 // step circuit to be executed
 }
 
-impl<G: Group, SC: StepCircuit<G::Scalar>> Circuit<G::Scalar> for DirectCircuit<G, SC> {
-  fn synthesize<CS: ConstraintSystem<G::Scalar>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
+impl<G: Group, SC: StepCircuit<<G as Group>::Scalar>> Circuit<<G as Group>::Scalar>
+  for DirectCircuit<G, SC>
+{
+  fn synthesize<CS: ConstraintSystem<<G as Group>::Scalar>>(
+    self,
+    cs: &mut CS,
+  ) -> Result<(), SynthesisError> {
     // obtain the arity information
     let arity = self.sc.arity();
 
     // Allocate zi. If inputs.zi is not provided, allocate default value 0
-    let zero = vec![G::Scalar::ZERO; arity];
+    let zero = vec![<G as Group>::Scalar::ZERO; arity];
     let z_i = (0..arity)
       .map(|i| {
         AllocatedNum::alloc(cs.namespace(|| format!("zi_{i}")), || {
           Ok(self.z_i.as_ref().unwrap_or(&zero)[i])
         })
       })
-      .collect::<Result<Vec<AllocatedNum<G::Scalar>>, _>>()?;
+      .collect::<Result<Vec<AllocatedNum<<G as Group>::Scalar>>, _>>()?;
 
     let z_i_plus_one = self.sc.synthesize(&mut cs.namespace(|| "F"), &z_i)?;
 
@@ -82,14 +87,16 @@ pub struct DirectSNARK<G, S, C>
 where
   G: Group,
   S: RelaxedR1CSSNARKTrait<G>,
-  C: StepCircuit<G::Scalar>,
+  C: StepCircuit<<G as Group>::Scalar>,
 {
   comm_W: Commitment<G>, // commitment to the witness
   snark: S,              // snark proving the witness is satisfying
   _p: PhantomData<C>,
 }
 
-impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNARK<G, S, C> {
+impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<<G as Group>::Scalar>>
+  DirectSNARK<G, S, C>
+{
   /// Produces prover and verifier keys for the direct SNARK
   pub fn setup(sc: C) -> Result<(ProverKey<G, S>, VerifierKey<G, S>), NovaError> {
     // construct a circuit that can be synthesized
@@ -109,7 +116,11 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
   }
 
   /// Produces a proof of satisfiability of the provided circuit
-  pub fn prove(pk: &ProverKey<G, S>, sc: C, z_i: &[G::Scalar]) -> Result<Self, NovaError> {
+  pub fn prove(
+    pk: &ProverKey<G, S>,
+    sc: C,
+    z_i: &[<G as Group>::Scalar],
+  ) -> Result<Self, NovaError> {
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();
 
     let circuit: DirectCircuit<G, C> = DirectCircuit {
@@ -139,7 +150,11 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
   }
 
   /// Verifies a proof of satisfiability
-  pub fn verify(&self, vk: &VerifierKey<G, S>, io: &[G::Scalar]) -> Result<(), NovaError> {
+  pub fn verify(
+    &self,
+    vk: &VerifierKey<G, S>,
+    io: &[<G as Group>::Scalar],
+  ) -> Result<(), NovaError> {
     // construct an instance using the provided commitment to the witness and z_i and z_{i+1}
     let u_relaxed = RelaxedR1CSInstance::from_r1cs_instance_unchecked(&self.comm_W, io);
 

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -14,10 +14,10 @@ use crate::{traits::Group, Commitment};
 use ff::Field;
 use polynomial::SparsePolynomial;
 
-fn powers<G: Group>(s: &G::Scalar, n: usize) -> Vec<G::Scalar> {
+fn powers<G: Group>(s: &<G as Group>::Scalar, n: usize) -> Vec<<G as Group>::Scalar> {
   assert!(n >= 1);
   let mut powers = Vec::new();
-  powers.push(G::Scalar::ONE);
+  powers.push(<G as Group>::Scalar::ONE);
   for i in 1..n {
     powers.push(powers[i - 1] * s);
   }
@@ -26,7 +26,7 @@ fn powers<G: Group>(s: &G::Scalar, n: usize) -> Vec<G::Scalar> {
 
 /// A type that holds a witness to a polynomial evaluation instance
 pub struct PolyEvalWitness<G: Group> {
-  p: Vec<G::Scalar>, // polynomial
+  p: Vec<<G as Group>::Scalar>, // polynomial
 }
 
 impl<G: Group> PolyEvalWitness<G> {
@@ -36,7 +36,7 @@ impl<G: Group> PolyEvalWitness<G> {
       W.iter()
         .map(|w| {
           let mut p = w.p.clone();
-          p.resize(n, G::Scalar::ZERO);
+          p.resize(n, <G as Group>::Scalar::ZERO);
           PolyEvalWitness { p }
         })
         .collect()
@@ -45,9 +45,9 @@ impl<G: Group> PolyEvalWitness<G> {
     }
   }
 
-  fn weighted_sum(W: &[PolyEvalWitness<G>], s: &[G::Scalar]) -> PolyEvalWitness<G> {
+  fn weighted_sum(W: &[PolyEvalWitness<G>], s: &[<G as Group>::Scalar]) -> PolyEvalWitness<G> {
     assert_eq!(W.len(), s.len());
-    let mut p = vec![G::Scalar::ZERO; W[0].p.len()];
+    let mut p = vec![<G as Group>::Scalar::ZERO; W[0].p.len()];
     for i in 0..W.len() {
       for j in 0..W[i].p.len() {
         p[j] += W[i].p[j] * s[i]
@@ -56,9 +56,9 @@ impl<G: Group> PolyEvalWitness<G> {
     PolyEvalWitness { p }
   }
 
-  fn batch(p_vec: &[&Vec<G::Scalar>], s: &G::Scalar) -> PolyEvalWitness<G> {
+  fn batch(p_vec: &[&Vec<<G as Group>::Scalar>], s: &<G as Group>::Scalar) -> PolyEvalWitness<G> {
     let powers_of_s = powers::<G>(s, p_vec.len());
-    let mut p = vec![G::Scalar::ZERO; p_vec[0].len()];
+    let mut p = vec![<G as Group>::Scalar::ZERO; p_vec[0].len()];
     for i in 0..p_vec.len() {
       for (j, item) in p.iter_mut().enumerate().take(p_vec[i].len()) {
         *item += p_vec[i][j] * powers_of_s[i]
@@ -70,9 +70,9 @@ impl<G: Group> PolyEvalWitness<G> {
 
 /// A type that holds a polynomial evaluation instance
 pub struct PolyEvalInstance<G: Group> {
-  c: Commitment<G>,  // commitment to the polynomial
-  x: Vec<G::Scalar>, // evaluation point
-  e: G::Scalar,      // claimed evaluation
+  c: Commitment<G>,             // commitment to the polynomial
+  x: Vec<<G as Group>::Scalar>, // evaluation point
+  e: <G as Group>::Scalar,      // claimed evaluation
 }
 
 impl<G: Group> PolyEvalInstance<G> {
@@ -81,7 +81,7 @@ impl<G: Group> PolyEvalInstance<G> {
     if let Some(ell) = U.iter().map(|u| u.x.len()).max() {
       U.iter()
         .map(|u| {
-          let mut x = vec![G::Scalar::ZERO; ell - u.x.len()];
+          let mut x = vec![<G as Group>::Scalar::ZERO; ell - u.x.len()];
           x.extend(u.x.clone());
           PolyEvalInstance { c: u.c, x, e: u.e }
         })
@@ -93,9 +93,9 @@ impl<G: Group> PolyEvalInstance<G> {
 
   fn batch(
     c_vec: &[Commitment<G>],
-    x: &[G::Scalar],
-    e_vec: &[G::Scalar],
-    s: &G::Scalar,
+    x: &[<G as Group>::Scalar],
+    e_vec: &[<G as Group>::Scalar],
+    s: &<G as Group>::Scalar,
   ) -> PolyEvalInstance<G> {
     let powers_of_s = powers::<G>(s, c_vec.len());
     let e = e_vec

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -60,17 +60,17 @@ pub struct R1CSShapeSparkRepr<G: Group> {
   N: usize, // size of the vectors
 
   // dense representation
-  row: Vec<G::Scalar>,
-  col: Vec<G::Scalar>,
-  val_A: Vec<G::Scalar>,
-  val_B: Vec<G::Scalar>,
-  val_C: Vec<G::Scalar>,
+  row: Vec<<G as Group>::Scalar>,
+  col: Vec<<G as Group>::Scalar>,
+  val_A: Vec<<G as Group>::Scalar>,
+  val_B: Vec<<G as Group>::Scalar>,
+  val_C: Vec<<G as Group>::Scalar>,
 
   // timestamp polynomials
-  row_read_ts: Vec<G::Scalar>,
-  row_audit_ts: Vec<G::Scalar>,
-  col_read_ts: Vec<G::Scalar>,
-  col_audit_ts: Vec<G::Scalar>,
+  row_read_ts: Vec<<G as Group>::Scalar>,
+  row_audit_ts: Vec<<G as Group>::Scalar>,
+  col_read_ts: Vec<<G as Group>::Scalar>,
+  col_audit_ts: Vec<<G as Group>::Scalar>,
 }
 
 /// A type that holds a commitment to a sparse polynomial
@@ -144,26 +144,40 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     };
 
     let val_A = {
-      let mut val = S.A.iter().map(|(_, _, v)| *v).collect::<Vec<G::Scalar>>();
-      val.resize(N, G::Scalar::ZERO);
+      let mut val = S
+        .A
+        .iter()
+        .map(|(_, _, v)| *v)
+        .collect::<Vec<<G as Group>::Scalar>>();
+      val.resize(N, <G as Group>::Scalar::ZERO);
       val
     };
 
     let val_B = {
       // prepend zeros
-      let mut val = vec![G::Scalar::ZERO; S.A.len()];
-      val.extend(S.B.iter().map(|(_, _, v)| *v).collect::<Vec<G::Scalar>>());
+      let mut val = vec![<G as Group>::Scalar::ZERO; S.A.len()];
+      val.extend(
+        S.B
+          .iter()
+          .map(|(_, _, v)| *v)
+          .collect::<Vec<<G as Group>::Scalar>>(),
+      );
       // append zeros
-      val.resize(N, G::Scalar::ZERO);
+      val.resize(N, <G as Group>::Scalar::ZERO);
       val
     };
 
     let val_C = {
       // prepend zeros
-      let mut val = vec![G::Scalar::ZERO; S.A.len() + S.B.len()];
-      val.extend(S.C.iter().map(|(_, _, v)| *v).collect::<Vec<G::Scalar>>());
+      let mut val = vec![<G as Group>::Scalar::ZERO; S.A.len() + S.B.len()];
+      val.extend(
+        S.C
+          .iter()
+          .map(|(_, _, v)| *v)
+          .collect::<Vec<<G as Group>::Scalar>>(),
+      );
       // append zeros
-      val.resize(N, G::Scalar::ZERO);
+      val.resize(N, <G as Group>::Scalar::ZERO);
       val
     };
 
@@ -191,10 +205,10 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     let (col_read_ts, col_audit_ts) = timestamp_calc(N, N, &col);
 
     // a routine to turn a vector of usize into a vector scalars
-    let to_vec_scalar = |v: &[usize]| -> Vec<G::Scalar> {
+    let to_vec_scalar = |v: &[usize]| -> Vec<<G as Group>::Scalar> {
       (0..v.len())
-        .map(|i| G::Scalar::from(v[i] as u64))
-        .collect::<Vec<G::Scalar>>()
+        .map(|i| <G as Group>::Scalar::from(v[i] as u64))
+        .collect::<Vec<<G as Group>::Scalar>>()
     };
 
     R1CSShapeSparkRepr {
@@ -249,16 +263,16 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
   fn evaluation_oracles(
     &self,
     S: &R1CSShape<G>,
-    r_x: &[G::Scalar],
-    z: &[G::Scalar],
+    r_x: &[<G as Group>::Scalar],
+    z: &[<G as Group>::Scalar],
   ) -> (
-    Vec<G::Scalar>,
-    Vec<G::Scalar>,
-    Vec<G::Scalar>,
-    Vec<G::Scalar>,
+    Vec<<G as Group>::Scalar>,
+    Vec<<G as Group>::Scalar>,
+    Vec<<G as Group>::Scalar>,
+    Vec<<G as Group>::Scalar>,
   ) {
     let r_x_padded = {
-      let mut x = vec![G::Scalar::ZERO; self.N.log_2() - r_x.len()];
+      let mut x = vec![<G as Group>::Scalar::ZERO; self.N.log_2() - r_x.len()];
       x.extend(r_x);
       x
     };
@@ -266,7 +280,7 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     let mem_row = EqPolynomial::new(r_x_padded).evals();
     let mem_col = {
       let mut z = z.to_vec();
-      z.resize(self.N, G::Scalar::ZERO);
+      z.resize(self.N, <G as Group>::Scalar::ZERO);
       z
     };
 
@@ -276,7 +290,7 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
       .chain(S.B.iter())
       .chain(S.C.iter())
       .map(|(r, _, _)| mem_row[*r])
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
 
     let mut E_col = S
       .A
@@ -284,7 +298,7 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
       .chain(S.B.iter())
       .chain(S.C.iter())
       .map(|(_, c, _)| mem_col[*c])
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
 
     E_row.resize(self.N, mem_row[0]); // we place mem_row[0] since resized row is appended with 0s
     E_col.resize(self.N, mem_col[0]);
@@ -296,7 +310,7 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
 /// Defines a trait for implementing sum-check in a generic manner
 pub trait SumcheckEngine<G: Group> {
   /// returns the initial claims
-  fn initial_claims(&self) -> Vec<G::Scalar>;
+  fn initial_claims(&self) -> Vec<<G as Group>::Scalar>;
 
   /// degree of the sum-check polynomial
   fn degree(&self) -> usize;
@@ -305,81 +319,89 @@ pub trait SumcheckEngine<G: Group> {
   fn size(&self) -> usize;
 
   /// returns evaluation points at 0, 2, d-1 (where d is the degree of the sum-check polynomial)
-  fn evaluation_points(&self) -> Vec<Vec<G::Scalar>>;
+  fn evaluation_points(&self) -> Vec<Vec<<G as Group>::Scalar>>;
 
   /// bounds a variable in the constituent polynomials
-  fn bound(&mut self, r: &G::Scalar);
+  fn bound(&mut self, r: &<G as Group>::Scalar);
 
   /// returns the final claims
-  fn final_claims(&self) -> Vec<Vec<G::Scalar>>;
+  fn final_claims(&self) -> Vec<Vec<<G as Group>::Scalar>>;
 }
 
 struct ProductSumcheckInstance<G: Group> {
-  pub(crate) claims: Vec<G::Scalar>, // claimed products
+  pub(crate) claims: Vec<<G as Group>::Scalar>, // claimed products
   pub(crate) comm_output_vec: Vec<Commitment<G>>,
 
-  input_vec: Vec<Vec<G::Scalar>>,
-  output_vec: Vec<Vec<G::Scalar>>,
+  input_vec: Vec<Vec<<G as Group>::Scalar>>,
+  output_vec: Vec<Vec<<G as Group>::Scalar>>,
 
-  poly_A: MultilinearPolynomial<G::Scalar>,
-  poly_B_vec: Vec<MultilinearPolynomial<G::Scalar>>,
-  poly_C_vec: Vec<MultilinearPolynomial<G::Scalar>>,
-  poly_D_vec: Vec<MultilinearPolynomial<G::Scalar>>,
+  poly_A: MultilinearPolynomial<<G as Group>::Scalar>,
+  poly_B_vec: Vec<MultilinearPolynomial<<G as Group>::Scalar>>,
+  poly_C_vec: Vec<MultilinearPolynomial<<G as Group>::Scalar>>,
+  poly_D_vec: Vec<MultilinearPolynomial<<G as Group>::Scalar>>,
 }
 
 impl<G: Group> ProductSumcheckInstance<G> {
   pub fn new(
     ck: &CommitmentKey<G>,
-    input_vec: Vec<Vec<G::Scalar>>, // list of input vectors
+    input_vec: Vec<Vec<<G as Group>::Scalar>>, // list of input vectors
     transcript: &mut G::TE,
   ) -> Result<Self, NovaError> {
-    let compute_layer = |input: &[G::Scalar]| -> (Vec<G::Scalar>, Vec<G::Scalar>, Vec<G::Scalar>) {
+    let compute_layer = |input: &[<G as Group>::Scalar]| -> (
+      Vec<<G as Group>::Scalar>,
+      Vec<<G as Group>::Scalar>,
+      Vec<<G as Group>::Scalar>,
+    ) {
       let left = (0..input.len() / 2)
         .map(|i| input[2 * i])
-        .collect::<Vec<G::Scalar>>();
+        .collect::<Vec<<G as Group>::Scalar>>();
 
       let right = (0..input.len() / 2)
         .map(|i| input[2 * i + 1])
-        .collect::<Vec<G::Scalar>>();
+        .collect::<Vec<<G as Group>::Scalar>>();
 
       assert_eq!(left.len(), right.len());
 
       let output = (0..left.len())
         .map(|i| left[i] * right[i])
-        .collect::<Vec<G::Scalar>>();
+        .collect::<Vec<<G as Group>::Scalar>>();
 
       (left, right, output)
     };
 
     // a closure that returns left, right, output, product
-    let prepare_inputs =
-      |input: &[G::Scalar]| -> (Vec<G::Scalar>, Vec<G::Scalar>, Vec<G::Scalar>, G::Scalar) {
-        let mut left: Vec<G::Scalar> = Vec::new();
-        let mut right: Vec<G::Scalar> = Vec::new();
-        let mut output: Vec<G::Scalar> = Vec::new();
+    let prepare_inputs = |input: &[<G as Group>::Scalar]| -> (
+      Vec<<G as Group>::Scalar>,
+      Vec<<G as Group>::Scalar>,
+      Vec<<G as Group>::Scalar>,
+      <G as Group>::Scalar,
+    ) {
+      let mut left: Vec<<G as Group>::Scalar> = Vec::new();
+      let mut right: Vec<<G as Group>::Scalar> = Vec::new();
+      let mut output: Vec<<G as Group>::Scalar> = Vec::new();
 
-        let mut out = input.to_vec();
-        for _i in 0..input.len().log_2() {
-          let (l, r, o) = compute_layer(&out);
-          out = o.clone();
+      let mut out = input.to_vec();
+      for _i in 0..input.len().log_2() {
+        let (l, r, o) = compute_layer(&out);
+        out = o.clone();
 
-          left.extend(l);
-          right.extend(r);
-          output.extend(o);
-        }
+        left.extend(l);
+        right.extend(r);
+        output.extend(o);
+      }
 
-        // add a dummy product operation to make the left.len() == right.len() == output.len() == input.len()
-        left.push(output[output.len() - 1]);
-        right.push(G::Scalar::ZERO);
-        output.push(G::Scalar::ZERO);
+      // add a dummy product operation to make the left.len() == right.len() == output.len() == input.len()
+      left.push(output[output.len() - 1]);
+      right.push(<G as Group>::Scalar::ZERO);
+      output.push(<G as Group>::Scalar::ZERO);
 
-        // output is stored at the last but one position
-        let product = output[output.len() - 2];
+      // output is stored at the last but one position
+      let product = output[output.len() - 2];
 
-        assert_eq!(left.len(), right.len());
-        assert_eq!(left.len(), output.len());
-        (left, right, output, product)
-      };
+      assert_eq!(left.len(), right.len());
+      assert_eq!(left.len(), output.len());
+      (left, right, output, product)
+    };
 
     let mut left_vec = Vec::new();
     let mut right_vec = Vec::new();
@@ -407,7 +429,7 @@ impl<G: Group> ProductSumcheckInstance<G> {
     let num_rounds = output_vec[0].len().log_2();
     let rand_eq = (0..num_rounds)
       .map(|_i| transcript.squeeze(b"e"))
-      .collect::<Result<Vec<G::Scalar>, NovaError>>()?;
+      .collect::<Result<Vec<<G as Group>::Scalar>, NovaError>>()?;
 
     let poly_A = MultilinearPolynomial::new(EqPolynomial::new(rand_eq).evals());
     let poly_B_vec = left_vec
@@ -440,8 +462,8 @@ impl<G: Group> ProductSumcheckInstance<G> {
 }
 
 impl<G: Group> SumcheckEngine<G> for ProductSumcheckInstance<G> {
-  fn initial_claims(&self) -> Vec<G::Scalar> {
-    vec![G::Scalar::ZERO; 8]
+  fn initial_claims(&self) -> Vec<<G as Group>::Scalar> {
+    vec![<G as Group>::Scalar::ZERO; 8]
   }
 
   fn degree(&self) -> usize {
@@ -461,15 +483,16 @@ impl<G: Group> SumcheckEngine<G> for ProductSumcheckInstance<G> {
     self.poly_A.len()
   }
 
-  fn evaluation_points(&self) -> Vec<Vec<G::Scalar>> {
+  fn evaluation_points(&self) -> Vec<Vec<<G as Group>::Scalar>> {
     let poly_A = &self.poly_A;
 
-    let comb_func =
-      |poly_A_comp: &G::Scalar,
-       poly_B_comp: &G::Scalar,
-       poly_C_comp: &G::Scalar,
-       poly_D_comp: &G::Scalar|
-       -> G::Scalar { *poly_A_comp * (*poly_B_comp * *poly_C_comp - *poly_D_comp) };
+    let comb_func = |poly_A_comp: &<G as Group>::Scalar,
+                     poly_B_comp: &<G as Group>::Scalar,
+                     poly_C_comp: &<G as Group>::Scalar,
+                     poly_D_comp: &<G as Group>::Scalar|
+     -> <G as Group>::Scalar {
+      *poly_A_comp * (*poly_B_comp * *poly_C_comp - *poly_D_comp)
+    };
 
     self
       .poly_B_vec
@@ -511,15 +534,21 @@ impl<G: Group> SumcheckEngine<G> for ProductSumcheckInstance<G> {
             (eval_point_0, eval_point_2, eval_point_3)
           })
           .reduce(
-            || (G::Scalar::ZERO, G::Scalar::ZERO, G::Scalar::ZERO),
+            || {
+              (
+                <G as Group>::Scalar::ZERO,
+                <G as Group>::Scalar::ZERO,
+                <G as Group>::Scalar::ZERO,
+              )
+            },
             |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
           );
         vec![eval_point_0, eval_point_2, eval_point_3]
       })
-      .collect::<Vec<Vec<G::Scalar>>>()
+      .collect::<Vec<Vec<<G as Group>::Scalar>>>()
   }
 
-  fn bound(&mut self, r: &G::Scalar) {
+  fn bound(&mut self, r: &<G as Group>::Scalar) {
     self.poly_A.bound_poly_var_top(r);
     for ((poly_B, poly_C), poly_D) in self
       .poly_B_vec
@@ -532,7 +561,7 @@ impl<G: Group> SumcheckEngine<G> for ProductSumcheckInstance<G> {
       poly_D.bound_poly_var_top(r);
     }
   }
-  fn final_claims(&self) -> Vec<Vec<G::Scalar>> {
+  fn final_claims(&self) -> Vec<Vec<<G as Group>::Scalar>> {
     let poly_A_final = vec![self.poly_A[0]];
     let poly_B_final = (0..self.poly_B_vec.len())
       .map(|i| self.poly_B_vec[i][0])
@@ -549,15 +578,15 @@ impl<G: Group> SumcheckEngine<G> for ProductSumcheckInstance<G> {
 }
 
 struct OuterSumcheckInstance<G: Group> {
-  poly_tau: MultilinearPolynomial<G::Scalar>,
-  poly_Az: MultilinearPolynomial<G::Scalar>,
-  poly_Bz: MultilinearPolynomial<G::Scalar>,
-  poly_uCz_E: MultilinearPolynomial<G::Scalar>,
+  poly_tau: MultilinearPolynomial<<G as Group>::Scalar>,
+  poly_Az: MultilinearPolynomial<<G as Group>::Scalar>,
+  poly_Bz: MultilinearPolynomial<<G as Group>::Scalar>,
+  poly_uCz_E: MultilinearPolynomial<<G as Group>::Scalar>,
 }
 
 impl<G: Group> SumcheckEngine<G> for OuterSumcheckInstance<G> {
-  fn initial_claims(&self) -> Vec<G::Scalar> {
-    vec![G::Scalar::ZERO]
+  fn initial_claims(&self) -> Vec<<G as Group>::Scalar> {
+    vec![<G as Group>::Scalar::ZERO]
   }
 
   fn degree(&self) -> usize {
@@ -571,19 +600,20 @@ impl<G: Group> SumcheckEngine<G> for OuterSumcheckInstance<G> {
     self.poly_tau.len()
   }
 
-  fn evaluation_points(&self) -> Vec<Vec<G::Scalar>> {
+  fn evaluation_points(&self) -> Vec<Vec<<G as Group>::Scalar>> {
     let (poly_A, poly_B, poly_C, poly_D) = (
       &self.poly_tau,
       &self.poly_Az,
       &self.poly_Bz,
       &self.poly_uCz_E,
     );
-    let comb_func =
-      |poly_A_comp: &G::Scalar,
-       poly_B_comp: &G::Scalar,
-       poly_C_comp: &G::Scalar,
-       poly_D_comp: &G::Scalar|
-       -> G::Scalar { *poly_A_comp * (*poly_B_comp * *poly_C_comp - *poly_D_comp) };
+    let comb_func = |poly_A_comp: &<G as Group>::Scalar,
+                     poly_B_comp: &<G as Group>::Scalar,
+                     poly_C_comp: &<G as Group>::Scalar,
+                     poly_D_comp: &<G as Group>::Scalar|
+     -> <G as Group>::Scalar {
+      *poly_A_comp * (*poly_B_comp * *poly_C_comp - *poly_D_comp)
+    };
     let len = poly_A.len() / 2;
 
     // Make an iterator returning the contributions to the evaluations
@@ -619,21 +649,27 @@ impl<G: Group> SumcheckEngine<G> for OuterSumcheckInstance<G> {
         (eval_point_0, eval_point_2, eval_point_3)
       })
       .reduce(
-        || (G::Scalar::ZERO, G::Scalar::ZERO, G::Scalar::ZERO),
+        || {
+          (
+            <G as Group>::Scalar::ZERO,
+            <G as Group>::Scalar::ZERO,
+            <G as Group>::Scalar::ZERO,
+          )
+        },
         |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
       );
 
     vec![vec![eval_point_0, eval_point_2, eval_point_3]]
   }
 
-  fn bound(&mut self, r: &G::Scalar) {
+  fn bound(&mut self, r: &<G as Group>::Scalar) {
     self.poly_tau.bound_poly_var_top(r);
     self.poly_Az.bound_poly_var_top(r);
     self.poly_Bz.bound_poly_var_top(r);
     self.poly_uCz_E.bound_poly_var_top(r);
   }
 
-  fn final_claims(&self) -> Vec<Vec<G::Scalar>> {
+  fn final_claims(&self) -> Vec<Vec<<G as Group>::Scalar>> {
     vec![vec![
       self.poly_tau[0],
       self.poly_Az[0],
@@ -644,14 +680,14 @@ impl<G: Group> SumcheckEngine<G> for OuterSumcheckInstance<G> {
 }
 
 struct InnerSumcheckInstance<G: Group> {
-  claim: G::Scalar,
-  poly_E_row: MultilinearPolynomial<G::Scalar>,
-  poly_E_col: MultilinearPolynomial<G::Scalar>,
-  poly_val: MultilinearPolynomial<G::Scalar>,
+  claim: <G as Group>::Scalar,
+  poly_E_row: MultilinearPolynomial<<G as Group>::Scalar>,
+  poly_E_col: MultilinearPolynomial<<G as Group>::Scalar>,
+  poly_val: MultilinearPolynomial<<G as Group>::Scalar>,
 }
 
 impl<G: Group> SumcheckEngine<G> for InnerSumcheckInstance<G> {
-  fn initial_claims(&self) -> Vec<G::Scalar> {
+  fn initial_claims(&self) -> Vec<<G as Group>::Scalar> {
     vec![self.claim]
   }
 
@@ -665,12 +701,12 @@ impl<G: Group> SumcheckEngine<G> for InnerSumcheckInstance<G> {
     self.poly_E_row.len()
   }
 
-  fn evaluation_points(&self) -> Vec<Vec<G::Scalar>> {
+  fn evaluation_points(&self) -> Vec<Vec<<G as Group>::Scalar>> {
     let (poly_A, poly_B, poly_C) = (&self.poly_E_row, &self.poly_E_col, &self.poly_val);
-    let comb_func = |poly_A_comp: &G::Scalar,
-                     poly_B_comp: &G::Scalar,
-                     poly_C_comp: &G::Scalar|
-     -> G::Scalar { *poly_A_comp * *poly_B_comp * *poly_C_comp };
+    let comb_func = |poly_A_comp: &<G as Group>::Scalar,
+                     poly_B_comp: &<G as Group>::Scalar,
+                     poly_C_comp: &<G as Group>::Scalar|
+     -> <G as Group>::Scalar { *poly_A_comp * *poly_B_comp * *poly_C_comp };
     let len = poly_A.len() / 2;
 
     // Make an iterator returning the contributions to the evaluations
@@ -702,20 +738,26 @@ impl<G: Group> SumcheckEngine<G> for InnerSumcheckInstance<G> {
         (eval_point_0, eval_point_2, eval_point_3)
       })
       .reduce(
-        || (G::Scalar::ZERO, G::Scalar::ZERO, G::Scalar::ZERO),
+        || {
+          (
+            <G as Group>::Scalar::ZERO,
+            <G as Group>::Scalar::ZERO,
+            <G as Group>::Scalar::ZERO,
+          )
+        },
         |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
       );
 
     vec![vec![eval_point_0, eval_point_2, eval_point_3]]
   }
 
-  fn bound(&mut self, r: &G::Scalar) {
+  fn bound(&mut self, r: &<G as Group>::Scalar) {
     self.poly_E_row.bound_poly_var_top(r);
     self.poly_E_col.bound_poly_var_top(r);
     self.poly_val.bound_poly_var_top(r);
   }
 
-  fn final_claims(&self) -> Vec<Vec<G::Scalar>> {
+  fn final_claims(&self) -> Vec<Vec<<G as Group>::Scalar>> {
     vec![vec![
       self.poly_E_row[0],
       self.poly_E_col[0],
@@ -732,7 +774,7 @@ pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> {
   S: R1CSShape<G>,
   S_repr: R1CSShapeSparkRepr<G>,
   S_comm: R1CSShapeSparkCommitment<G>,
-  vk_digest: G::Scalar, // digest of verifier's key
+  vk_digest: <G as Group>::Scalar, // digest of verifier's key
 }
 
 /// A type that represents the verifier's key
@@ -743,7 +785,7 @@ pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> {
   num_vars: usize,
   vk_ee: EE::VerifierKey,
   S_comm: R1CSShapeSparkCommitment<G>,
-  digest: G::Scalar,
+  digest: <G as Group>::Scalar,
 }
 
 /// A succinct proof of knowledge of a witness to a relaxed R1CS instance
@@ -762,45 +804,45 @@ pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> 
   comm_E_col: CompressedCommitment<G>,
 
   // initial claims
-  eval_Az_at_tau: G::Scalar,
-  eval_Bz_at_tau: G::Scalar,
-  eval_Cz_at_tau: G::Scalar,
+  eval_Az_at_tau: <G as Group>::Scalar,
+  eval_Bz_at_tau: <G as Group>::Scalar,
+  eval_Cz_at_tau: <G as Group>::Scalar,
 
   comm_output_arr: [CompressedCommitment<G>; 8],
-  claims_product_arr: [G::Scalar; 8],
+  claims_product_arr: [<G as Group>::Scalar; 8],
 
   // satisfiability sum-check
   sc_sat: SumcheckProof<G>,
 
   // claims from the end of the sum-check
-  eval_Az: G::Scalar,
-  eval_Bz: G::Scalar,
-  eval_Cz: G::Scalar,
-  eval_E: G::Scalar,
-  eval_E_row: G::Scalar,
-  eval_E_col: G::Scalar,
-  eval_val_A: G::Scalar,
-  eval_val_B: G::Scalar,
-  eval_val_C: G::Scalar,
-  eval_left_arr: [G::Scalar; 8],
-  eval_right_arr: [G::Scalar; 8],
-  eval_output_arr: [G::Scalar; 8],
-  eval_input_arr: [G::Scalar; 8],
-  eval_output2_arr: [G::Scalar; 8],
+  eval_Az: <G as Group>::Scalar,
+  eval_Bz: <G as Group>::Scalar,
+  eval_Cz: <G as Group>::Scalar,
+  eval_E: <G as Group>::Scalar,
+  eval_E_row: <G as Group>::Scalar,
+  eval_E_col: <G as Group>::Scalar,
+  eval_val_A: <G as Group>::Scalar,
+  eval_val_B: <G as Group>::Scalar,
+  eval_val_C: <G as Group>::Scalar,
+  eval_left_arr: [<G as Group>::Scalar; 8],
+  eval_right_arr: [<G as Group>::Scalar; 8],
+  eval_output_arr: [<G as Group>::Scalar; 8],
+  eval_input_arr: [<G as Group>::Scalar; 8],
+  eval_output2_arr: [<G as Group>::Scalar; 8],
 
-  eval_row: G::Scalar,
-  eval_row_read_ts: G::Scalar,
-  eval_E_row_at_r_prod: G::Scalar,
-  eval_row_audit_ts: G::Scalar,
-  eval_col: G::Scalar,
-  eval_col_read_ts: G::Scalar,
-  eval_E_col_at_r_prod: G::Scalar,
-  eval_col_audit_ts: G::Scalar,
-  eval_W: G::Scalar,
+  eval_row: <G as Group>::Scalar,
+  eval_row_read_ts: <G as Group>::Scalar,
+  eval_E_row_at_r_prod: <G as Group>::Scalar,
+  eval_row_audit_ts: <G as Group>::Scalar,
+  eval_col: <G as Group>::Scalar,
+  eval_col_read_ts: <G as Group>::Scalar,
+  eval_E_col_at_r_prod: <G as Group>::Scalar,
+  eval_col_audit_ts: <G as Group>::Scalar,
+  eval_W: <G as Group>::Scalar,
 
   // batch openings of all multilinear polynomials
   sc_proof_batch: SumcheckProof<G>,
-  evals_batch_arr: [G::Scalar; 7],
+  evals_batch_arr: [<G as Group>::Scalar; 7],
   eval_arg: EE::EvaluationArgument,
 }
 
@@ -813,10 +855,10 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARK<G, EE>
   ) -> Result<
     (
       SumcheckProof<G>,
-      Vec<G::Scalar>,
-      Vec<Vec<G::Scalar>>,
-      Vec<Vec<G::Scalar>>,
-      Vec<Vec<G::Scalar>>,
+      Vec<<G as Group>::Scalar>,
+      Vec<Vec<<G as Group>::Scalar>>,
+      Vec<Vec<<G as Group>::Scalar>>,
+      Vec<Vec<<G as Group>::Scalar>>,
     ),
     NovaError,
   >
@@ -840,7 +882,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARK<G, EE>
         .into_iter()
         .chain(claims_outer)
         .chain(claims_inner)
-        .collect::<Vec<G::Scalar>>()
+        .collect::<Vec<<G as Group>::Scalar>>()
     };
 
     let num_claims = claims.len();
@@ -861,11 +903,11 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARK<G, EE>
       .sum();
 
     let mut e = claim;
-    let mut r: Vec<G::Scalar> = Vec::new();
+    let mut r: Vec<<G as Group>::Scalar> = Vec::new();
     let mut cubic_polys: Vec<CompressedUniPoly<G>> = Vec::new();
     let num_rounds = mem.size().log_2();
     for _i in 0..num_rounds {
-      let mut evals: Vec<Vec<G::Scalar>> = Vec::new();
+      let mut evals: Vec<Vec<<G as Group>::Scalar>> = Vec::new();
       evals.extend(mem.evaluation_points());
       evals.extend(outer.evaluation_points());
       evals.extend(inner.evaluation_points());
@@ -936,7 +978,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
         num_vars: S.num_vars,
         S_comm: S_comm.clone(),
         vk_ee,
-        digest: G::Scalar::ZERO,
+        digest: <G as Group>::Scalar::ZERO,
       };
       vk.digest = compute_digest::<G, VerifierKey<G, EE>>(&vk);
       vk
@@ -991,16 +1033,16 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
     let num_rounds_sat = pk.S_repr.N.log_2();
     let tau = (0..num_rounds_sat)
       .map(|_| transcript.squeeze(b"t"))
-      .collect::<Result<Vec<G::Scalar>, NovaError>>()?;
+      .collect::<Result<Vec<<G as Group>::Scalar>, NovaError>>()?;
 
     // (1) send commitments to Az, Bz, and Cz along with their evaluations at tau
     let (Az, Bz, Cz, E) = {
-      Az.resize(pk.S_repr.N, G::Scalar::ZERO);
-      Bz.resize(pk.S_repr.N, G::Scalar::ZERO);
-      Cz.resize(pk.S_repr.N, G::Scalar::ZERO);
+      Az.resize(pk.S_repr.N, <G as Group>::Scalar::ZERO);
+      Bz.resize(pk.S_repr.N, <G as Group>::Scalar::ZERO);
+      Cz.resize(pk.S_repr.N, <G as Group>::Scalar::ZERO);
 
       let mut E = W.E.clone();
-      E.resize(pk.S_repr.N, G::Scalar::ZERO);
+      E.resize(pk.S_repr.N, <G as Group>::Scalar::ZERO);
 
       (Az, Bz, Cz, E)
     };
@@ -1008,7 +1050,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
       let evals_at_tau = [&Az, &Bz, &Cz]
         .into_par_iter()
         .map(|p| MultilinearPolynomial::evaluate_with(p, &tau))
-        .collect::<Vec<G::Scalar>>();
+        .collect::<Vec<<G as Group>::Scalar>>();
       (evals_at_tau[0], evals_at_tau[1], evals_at_tau[2])
     };
 
@@ -1054,7 +1096,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
       poly_uCz_E: {
         let uCz_E = (0..Cz.len())
           .map(|i| U.u * Cz[i] + E[i])
-          .collect::<Vec<G::Scalar>>();
+          .collect::<Vec<<G as Group>::Scalar>>();
         MultilinearPolynomial::new(uCz_E)
       },
     };
@@ -1067,7 +1109,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
       .zip(pk.S_repr.val_B.iter())
       .zip(pk.S_repr.val_C.iter())
       .map(|((v_a, v_b), v_c)| *v_a + c_inner * *v_b + c_inner * c_inner * *v_c)
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
     let mut inner_sc_inst = InnerSumcheckInstance {
       claim: eval_Az_at_tau + c_inner * eval_Bz_at_tau + c_inner * c_inner * eval_Cz_at_tau,
       poly_E_row: MultilinearPolynomial::new(E_row.clone()),
@@ -1082,59 +1124,73 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
     let gamma_2 = transcript.squeeze(b"g2")?;
 
     let gamma_1_sqr = gamma_1 * gamma_1;
-    let hash_func = |addr: &G::Scalar, val: &G::Scalar, ts: &G::Scalar| -> G::Scalar {
-      (*ts * gamma_1_sqr + *val * gamma_1 + *addr) - gamma_2
-    };
+    let hash_func =
+      |addr: &<G as Group>::Scalar,
+       val: &<G as Group>::Scalar,
+       ts: &<G as Group>::Scalar|
+       -> <G as Group>::Scalar { (*ts * gamma_1_sqr + *val * gamma_1 + *addr) - gamma_2 };
 
     let init_row = (0..mem_row.len())
-      .map(|i| hash_func(&G::Scalar::from(i as u64), &mem_row[i], &G::Scalar::ZERO))
-      .collect::<Vec<G::Scalar>>();
+      .map(|i| {
+        hash_func(
+          &<G as Group>::Scalar::from(i as u64),
+          &mem_row[i],
+          &<G as Group>::Scalar::ZERO,
+        )
+      })
+      .collect::<Vec<<G as Group>::Scalar>>();
     let read_row = (0..E_row.len())
       .map(|i| hash_func(&pk.S_repr.row[i], &E_row[i], &pk.S_repr.row_read_ts[i]))
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
     let write_row = (0..E_row.len())
       .map(|i| {
         hash_func(
           &pk.S_repr.row[i],
           &E_row[i],
-          &(pk.S_repr.row_read_ts[i] + G::Scalar::ONE),
+          &(pk.S_repr.row_read_ts[i] + <G as Group>::Scalar::ONE),
         )
       })
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
     let audit_row = (0..mem_row.len())
       .map(|i| {
         hash_func(
-          &G::Scalar::from(i as u64),
+          &<G as Group>::Scalar::from(i as u64),
           &mem_row[i],
           &pk.S_repr.row_audit_ts[i],
         )
       })
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
 
     let init_col = (0..mem_col.len())
-      .map(|i| hash_func(&G::Scalar::from(i as u64), &mem_col[i], &G::Scalar::ZERO))
-      .collect::<Vec<G::Scalar>>();
+      .map(|i| {
+        hash_func(
+          &<G as Group>::Scalar::from(i as u64),
+          &mem_col[i],
+          &<G as Group>::Scalar::ZERO,
+        )
+      })
+      .collect::<Vec<<G as Group>::Scalar>>();
     let read_col = (0..E_col.len())
       .map(|i| hash_func(&pk.S_repr.col[i], &E_col[i], &pk.S_repr.col_read_ts[i]))
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
     let write_col = (0..E_col.len())
       .map(|i| {
         hash_func(
           &pk.S_repr.col[i],
           &E_col[i],
-          &(pk.S_repr.col_read_ts[i] + G::Scalar::ONE),
+          &(pk.S_repr.col_read_ts[i] + <G as Group>::Scalar::ONE),
         )
       })
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
     let audit_col = (0..mem_col.len())
       .map(|i| {
         hash_func(
-          &G::Scalar::from(i as u64),
+          &<G as Group>::Scalar::from(i as u64),
           &mem_col[i],
           &pk.S_repr.col_audit_ts[i],
         )
       })
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
 
     let mut mem_sc_inst = ProductSumcheckInstance::new(
       ck,
@@ -1161,7 +1217,8 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
     let eval_output_vec = claims_mem[3].clone();
 
     // claims from the end of sum-check
-    let (eval_Az, eval_Bz): (G::Scalar, G::Scalar) = (claims_outer[0][1], claims_outer[0][2]);
+    let (eval_Az, eval_Bz): (<G as Group>::Scalar, <G as Group>::Scalar) =
+      (claims_outer[0][1], claims_outer[0][2]);
     let eval_Cz = MultilinearPolynomial::evaluate_with(&Cz, &r_sat);
     let eval_E = MultilinearPolynomial::evaluate_with(&E, &r_sat);
     let eval_E_row = claims_inner[0][0];
@@ -1176,7 +1233,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
     .chain(eval_left_vec.clone())
     .chain(eval_right_vec.clone())
     .chain(eval_output_vec.clone())
-    .collect::<Vec<G::Scalar>>();
+    .collect::<Vec<<G as Group>::Scalar>>();
 
     // absorb all the claimed evaluations
     transcript.absorb(b"e", &eval_vec.as_slice());
@@ -1196,20 +1253,20 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
       .input_vec
       .iter()
       .map(|i| MultilinearPolynomial::evaluate_with(i, &rand_ext[1..]))
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
 
     let eval_output2_vec = mem_sc_inst
       .output_vec
       .iter()
       .map(|o| MultilinearPolynomial::evaluate_with(o, &rand_ext[1..]))
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
 
     // add claimed evaluations to the transcript
     let evals = eval_input_vec
       .clone()
       .into_iter()
       .chain(eval_output2_vec.clone())
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
     transcript.absorb(b"e", &evals.as_slice());
 
     // squeeze a challenge to combine multiple claims into one
@@ -1243,16 +1300,17 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
       .map(|(c, r_i)| *c * *r_i)
       .fold(Commitment::<G>::default(), |acc, item| acc + item);
 
-    let weighted_sum = |W: &[Vec<G::Scalar>], s: &[G::Scalar]| -> Vec<G::Scalar> {
-      assert_eq!(W.len(), s.len());
-      let mut p = vec![G::Scalar::ZERO; W[0].len()];
-      for i in 0..W.len() {
-        for (j, item) in W[i].iter().enumerate().take(W[i].len()) {
-          p[j] += *item * s[i]
+    let weighted_sum =
+      |W: &[Vec<<G as Group>::Scalar>], s: &[<G as Group>::Scalar]| -> Vec<<G as Group>::Scalar> {
+        assert_eq!(W.len(), s.len());
+        let mut p = vec![<G as Group>::Scalar::ZERO; W[0].len()];
+        for i in 0..W.len() {
+          for (j, item) in W[i].iter().enumerate().take(W[i].len()) {
+            p[j] += *item * s[i]
+          }
         }
-      }
-      p
-    };
+        p
+      };
 
     let poly_output = weighted_sum(&mem_sc_inst.output_vec, &powers_of_rho);
 
@@ -1276,8 +1334,8 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
 
     // claimed_product = output(1, ..., 1, 0)
     let x = {
-      let mut x = vec![G::Scalar::ONE; r_sat.len()];
-      x[r_sat.len() - 1] = G::Scalar::ZERO;
+      let mut x = vec![<G as Group>::Scalar::ONE; r_sat.len()];
+      x[r_sat.len() - 1] = <G as Group>::Scalar::ZERO;
       x
     };
     w_u_vec.push((
@@ -1315,7 +1373,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
     ]
     .into_par_iter()
     .map(|p| MultilinearPolynomial::evaluate_with(p, &r_prod))
-    .collect::<Vec<G::Scalar>>();
+    .collect::<Vec<<G as Group>::Scalar>>();
 
     let eval_row = evals[0];
     let eval_row_read_ts = evals[1];
@@ -1454,19 +1512,19 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
       .map(|(u, p)| u.e * p)
       .sum();
 
-    let mut polys_left: Vec<MultilinearPolynomial<G::Scalar>> = w_vec_padded
+    let mut polys_left: Vec<MultilinearPolynomial<<G as Group>::Scalar>> = w_vec_padded
       .iter()
       .map(|w| MultilinearPolynomial::new(w.p.clone()))
       .collect();
-    let mut polys_right: Vec<MultilinearPolynomial<G::Scalar>> = u_vec_padded
+    let mut polys_right: Vec<MultilinearPolynomial<<G as Group>::Scalar>> = u_vec_padded
       .iter()
       .map(|u| MultilinearPolynomial::new(EqPolynomial::new(u.x.clone()).evals()))
       .collect();
 
     let num_rounds_z = u_vec_padded[0].x.len();
-    let comb_func = |poly_A_comp: &G::Scalar, poly_B_comp: &G::Scalar| -> G::Scalar {
-      *poly_A_comp * *poly_B_comp
-    };
+    let comb_func = |poly_A_comp: &<G as Group>::Scalar,
+                     poly_B_comp: &<G as Group>::Scalar|
+     -> <G as Group>::Scalar { *poly_A_comp * *poly_B_comp };
     let (sc_proof_batch, r_z, claims_batch) = SumcheckProof::prove_quad_batch(
       &claim_batch_joint,
       num_rounds_z,
@@ -1477,13 +1535,14 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
       &mut transcript,
     )?;
 
-    let (claims_batch_left, _): (Vec<G::Scalar>, Vec<G::Scalar>) = claims_batch;
+    let (claims_batch_left, _): (Vec<<G as Group>::Scalar>, Vec<<G as Group>::Scalar>) =
+      claims_batch;
 
     transcript.absorb(b"l", &claims_batch_left.as_slice());
 
     // we now combine evaluation claims at the same point rz into one
     let gamma = transcript.squeeze(b"g")?;
-    let powers_of_gamma: Vec<G::Scalar> = powers::<G>(&gamma, num_claims);
+    let powers_of_gamma: Vec<<G as Group>::Scalar> = powers::<G>(&gamma, num_claims);
     let comm_joint = u_vec_padded
       .iter()
       .zip(powers_of_gamma.iter())
@@ -1578,7 +1637,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
     let num_rounds_sat = vk.S_comm.N.log_2();
     let tau = (0..num_rounds_sat)
       .map(|_i| transcript.squeeze(b"t"))
-      .collect::<Result<Vec<G::Scalar>, NovaError>>()?;
+      .collect::<Result<Vec<<G as Group>::Scalar>, NovaError>>()?;
 
     transcript.absorb(
       b"e",
@@ -1613,9 +1672,11 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
 
     // hash function
     let gamma_1_sqr = gamma_1 * gamma_1;
-    let hash_func = |addr: &G::Scalar, val: &G::Scalar, ts: &G::Scalar| -> G::Scalar {
-      (*ts * gamma_1_sqr + *val * gamma_1 + *addr) - gamma_2
-    };
+    let hash_func =
+      |addr: &<G as Group>::Scalar,
+       val: &<G as Group>::Scalar,
+       ts: &<G as Group>::Scalar|
+       -> <G as Group>::Scalar { (*ts * gamma_1_sqr + *val * gamma_1 + *addr) - gamma_2 };
 
     // check the required multiset relationship
     // row
@@ -1643,7 +1704,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
     let num_rounds = vk.S_comm.N.log_2();
     let rand_eq = (0..num_rounds)
       .map(|_i| transcript.squeeze(b"e"))
-      .collect::<Result<Vec<G::Scalar>, NovaError>>()?;
+      .collect::<Result<Vec<<G as Group>::Scalar>, NovaError>>()?;
 
     let num_claims = 10;
     let coeffs = {
@@ -1663,7 +1724,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
     // verify claim_sat_final
     let taus_bound_r_sat = EqPolynomial::new(tau.clone()).evaluate(&r_sat);
     let rand_eq_bound_r_sat = EqPolynomial::new(rand_eq).evaluate(&r_sat);
-    let claim_mem_final_expected: G::Scalar = (0..8)
+    let claim_mem_final_expected: <G as Group>::Scalar = (0..8)
       .map(|i| {
         coeffs[i]
           * rand_eq_bound_r_sat
@@ -1700,7 +1761,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
     .chain(self.eval_left_arr)
     .chain(self.eval_right_arr)
     .chain(self.eval_output_arr)
-    .collect::<Vec<G::Scalar>>();
+    .collect::<Vec<<G as Group>::Scalar>>();
 
     transcript.absorb(b"e", &eval_vec.as_slice());
     // we now combine eval_left = left(rand) and eval_right = right(rand)
@@ -1720,7 +1781,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
       .eval_input_arr
       .into_iter()
       .chain(self.eval_output2_arr)
-      .collect::<Vec<G::Scalar>>();
+      .collect::<Vec<<G as Group>::Scalar>>();
     transcript.absorb(b"e", &evals.as_slice());
 
     // squeeze a challenge to combine multiple claims into one
@@ -1770,8 +1831,8 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
 
     // claimed_product = output(1, ..., 1, 0)
     let x = {
-      let mut x = vec![G::Scalar::ONE; r_sat.len()];
-      x[r_sat.len() - 1] = G::Scalar::ZERO;
+      let mut x = vec![<G as Group>::Scalar::ONE; r_sat.len()];
+      x[r_sat.len() - 1] = <G as Group>::Scalar::ZERO;
       x
     };
     u_vec.push(PolyEvalInstance {
@@ -1837,9 +1898,9 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
       let (factor, r_prod_unpad) = {
         let l = vk.S_comm.N.log_2() - (2 * vk.num_vars).log_2();
 
-        let mut factor = G::Scalar::ONE;
+        let mut factor = <G as Group>::Scalar::ONE;
         for r_p in r_prod.iter().take(l) {
-          factor *= G::Scalar::ONE - r_p
+          factor *= <G as Group>::Scalar::ONE - r_p
         }
 
         let r_prod_unpad = {
@@ -1857,13 +1918,13 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
         poly_X.extend(
           (0..U.X.len())
             .map(|i| (i + 1, U.X[i]))
-            .collect::<Vec<(usize, G::Scalar)>>(),
+            .collect::<Vec<(usize, <G as Group>::Scalar)>>(),
         );
         SparsePolynomial::new((vk.num_vars as f64).log2() as usize, poly_X)
           .evaluate(&r_prod_unpad[1..])
       };
-      let eval_Z =
-        factor * ((G::Scalar::ONE - r_prod_unpad[0]) * self.eval_W + r_prod_unpad[0] * eval_X);
+      let eval_Z = factor
+        * ((<G as Group>::Scalar::ONE - r_prod_unpad[0]) * self.eval_W + r_prod_unpad[0] * eval_X);
 
       (eval_Z, r_prod_unpad)
     };
@@ -1879,7 +1940,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
       let addr = IdentityPolynomial::new(r_prod.len()).evaluate(&r_prod);
       let val = EqPolynomial::new(tau.to_vec()).evaluate(&r_prod);
       (
-        hash_func(&addr, &val, &G::Scalar::ZERO),
+        hash_func(&addr, &val, &<G as Group>::Scalar::ZERO),
         hash_func(&addr, &val, &self.eval_row_audit_ts),
       )
     };
@@ -1894,7 +1955,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
         hash_func(
           &self.eval_row,
           &self.eval_E_row_at_r_prod,
-          &(self.eval_row_read_ts + G::Scalar::ONE),
+          &(self.eval_row_read_ts + <G as Group>::Scalar::ONE),
         ),
       )
     };
@@ -1912,7 +1973,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
       let addr = IdentityPolynomial::new(r_prod.len()).evaluate(&r_prod);
       let val = eval_Z;
       (
-        hash_func(&addr, &val, &G::Scalar::ZERO),
+        hash_func(&addr, &val, &<G as Group>::Scalar::ZERO),
         hash_func(&addr, &val, &self.eval_col_audit_ts),
       )
     };
@@ -1927,7 +1988,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
         hash_func(
           &self.eval_col,
           &self.eval_E_col_at_r_prod,
-          &(self.eval_col_read_ts + G::Scalar::ONE),
+          &(self.eval_col_read_ts + <G as Group>::Scalar::ONE),
         ),
       )
     };
@@ -1993,7 +2054,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
       let evals = u_vec_padded
         .iter()
         .map(|u| poly_rz.evaluate(&u.x))
-        .collect::<Vec<G::Scalar>>();
+        .collect::<Vec<<G as Group>::Scalar>>();
 
       evals
         .iter()
@@ -2011,7 +2072,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
 
     // we now combine evaluation claims at the same point rz into one
     let gamma = transcript.squeeze(b"g")?;
-    let powers_of_gamma: Vec<G::Scalar> = powers::<G>(&gamma, num_claims);
+    let powers_of_gamma: Vec<<G as Group>::Scalar> = powers::<G>(&gamma, num_claims);
     let comm_joint = u_vec_padded
       .iter()
       .zip(powers_of_gamma.iter())

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -21,13 +21,13 @@ impl<G: Group> SumcheckProof<G> {
 
   pub fn verify(
     &self,
-    claim: G::Scalar,
+    claim: <G as Group>::Scalar,
     num_rounds: usize,
     degree_bound: usize,
     transcript: &mut G::TE,
-  ) -> Result<(G::Scalar, Vec<G::Scalar>), NovaError> {
+  ) -> Result<(<G as Group>::Scalar, Vec<<G as Group>::Scalar>), NovaError> {
     let mut e = claim;
-    let mut r: Vec<G::Scalar> = Vec::new();
+    let mut r: Vec<<G as Group>::Scalar> = Vec::new();
 
     // verify that there is a univariate polynomial for each round
     if self.compressed_polys.len() != num_rounds {
@@ -63,12 +63,12 @@ impl<G: Group> SumcheckProof<G> {
 
   #[inline]
   fn compute_eval_points<F>(
-    poly_A: &MultilinearPolynomial<G::Scalar>,
-    poly_B: &MultilinearPolynomial<G::Scalar>,
+    poly_A: &MultilinearPolynomial<<G as Group>::Scalar>,
+    poly_B: &MultilinearPolynomial<<G as Group>::Scalar>,
     comb_func: &F,
-  ) -> (G::Scalar, G::Scalar)
+  ) -> (<G as Group>::Scalar, <G as Group>::Scalar)
   where
-    F: Fn(&G::Scalar, &G::Scalar) -> G::Scalar + Sync,
+    F: Fn(&<G as Group>::Scalar, &<G as Group>::Scalar) -> <G as Group>::Scalar + Sync,
   {
     let len = poly_A.len() / 2;
     (0..len)
@@ -84,23 +84,23 @@ impl<G: Group> SumcheckProof<G> {
         (eval_point_0, eval_point_2)
       })
       .reduce(
-        || (G::Scalar::ZERO, G::Scalar::ZERO),
+        || (<G as Group>::Scalar::ZERO, <G as Group>::Scalar::ZERO),
         |a, b| (a.0 + b.0, a.1 + b.1),
       )
   }
 
   pub fn prove_quad<F>(
-    claim: &G::Scalar,
+    claim: &<G as Group>::Scalar,
     num_rounds: usize,
-    poly_A: &mut MultilinearPolynomial<G::Scalar>,
-    poly_B: &mut MultilinearPolynomial<G::Scalar>,
+    poly_A: &mut MultilinearPolynomial<<G as Group>::Scalar>,
+    poly_B: &mut MultilinearPolynomial<<G as Group>::Scalar>,
     comb_func: F,
     transcript: &mut G::TE,
-  ) -> Result<(Self, Vec<G::Scalar>, Vec<G::Scalar>), NovaError>
+  ) -> Result<(Self, Vec<<G as Group>::Scalar>, Vec<<G as Group>::Scalar>), NovaError>
   where
-    F: Fn(&G::Scalar, &G::Scalar) -> G::Scalar + Sync,
+    F: Fn(&<G as Group>::Scalar, &<G as Group>::Scalar) -> <G as Group>::Scalar + Sync,
   {
-    let mut r: Vec<G::Scalar> = Vec::new();
+    let mut r: Vec<<G as Group>::Scalar> = Vec::new();
     let mut polys: Vec<CompressedUniPoly<G>> = Vec::new();
     let mut claim_per_round = *claim;
     for _ in 0..num_rounds {
@@ -137,23 +137,30 @@ impl<G: Group> SumcheckProof<G> {
   }
 
   pub fn prove_quad_batch<F>(
-    claim: &G::Scalar,
+    claim: &<G as Group>::Scalar,
     num_rounds: usize,
-    poly_A_vec: &mut Vec<MultilinearPolynomial<G::Scalar>>,
-    poly_B_vec: &mut Vec<MultilinearPolynomial<G::Scalar>>,
-    coeffs: &[G::Scalar],
+    poly_A_vec: &mut Vec<MultilinearPolynomial<<G as Group>::Scalar>>,
+    poly_B_vec: &mut Vec<MultilinearPolynomial<<G as Group>::Scalar>>,
+    coeffs: &[<G as Group>::Scalar],
     comb_func: F,
     transcript: &mut G::TE,
-  ) -> Result<(Self, Vec<G::Scalar>, (Vec<G::Scalar>, Vec<G::Scalar>)), NovaError>
+  ) -> Result<
+    (
+      Self,
+      Vec<<G as Group>::Scalar>,
+      (Vec<<G as Group>::Scalar>, Vec<<G as Group>::Scalar>),
+    ),
+    NovaError,
+  >
   where
-    F: Fn(&G::Scalar, &G::Scalar) -> G::Scalar + Sync,
+    F: Fn(&<G as Group>::Scalar, &<G as Group>::Scalar) -> <G as Group>::Scalar + Sync,
   {
     let mut e = *claim;
-    let mut r: Vec<G::Scalar> = Vec::new();
+    let mut r: Vec<<G as Group>::Scalar> = Vec::new();
     let mut quad_polys: Vec<CompressedUniPoly<G>> = Vec::new();
 
     for _j in 0..num_rounds {
-      let mut evals: Vec<(G::Scalar, G::Scalar)> = Vec::new();
+      let mut evals: Vec<(<G as Group>::Scalar, <G as Group>::Scalar)> = Vec::new();
 
       for (poly_A, poly_B) in poly_A_vec.iter().zip(poly_B_vec.iter()) {
         let (eval_point_0, eval_point_2) = Self::compute_eval_points(poly_A, poly_B, &comb_func);
@@ -191,19 +198,25 @@ impl<G: Group> SumcheckProof<G> {
   }
 
   pub fn prove_cubic_with_additive_term<F>(
-    claim: &G::Scalar,
+    claim: &<G as Group>::Scalar,
     num_rounds: usize,
-    poly_A: &mut MultilinearPolynomial<G::Scalar>,
-    poly_B: &mut MultilinearPolynomial<G::Scalar>,
-    poly_C: &mut MultilinearPolynomial<G::Scalar>,
-    poly_D: &mut MultilinearPolynomial<G::Scalar>,
+    poly_A: &mut MultilinearPolynomial<<G as Group>::Scalar>,
+    poly_B: &mut MultilinearPolynomial<<G as Group>::Scalar>,
+    poly_C: &mut MultilinearPolynomial<<G as Group>::Scalar>,
+    poly_D: &mut MultilinearPolynomial<<G as Group>::Scalar>,
     comb_func: F,
     transcript: &mut G::TE,
-  ) -> Result<(Self, Vec<G::Scalar>, Vec<G::Scalar>), NovaError>
+  ) -> Result<(Self, Vec<<G as Group>::Scalar>, Vec<<G as Group>::Scalar>), NovaError>
   where
-    F: Fn(&G::Scalar, &G::Scalar, &G::Scalar, &G::Scalar) -> G::Scalar + Sync,
+    F: Fn(
+        &<G as Group>::Scalar,
+        &<G as Group>::Scalar,
+        &<G as Group>::Scalar,
+        &<G as Group>::Scalar,
+      ) -> <G as Group>::Scalar
+      + Sync,
   {
-    let mut r: Vec<G::Scalar> = Vec::new();
+    let mut r: Vec<<G as Group>::Scalar> = Vec::new();
     let mut polys: Vec<CompressedUniPoly<G>> = Vec::new();
     let mut claim_per_round = *claim;
 
@@ -244,7 +257,13 @@ impl<G: Group> SumcheckProof<G> {
             (eval_point_0, eval_point_2, eval_point_3)
           })
           .reduce(
-            || (G::Scalar::ZERO, G::Scalar::ZERO, G::Scalar::ZERO),
+            || {
+              (
+                <G as Group>::Scalar::ZERO,
+                <G as Group>::Scalar::ZERO,
+                <G as Group>::Scalar::ZERO,
+              )
+            },
             |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
           );
 
@@ -289,24 +308,25 @@ impl<G: Group> SumcheckProof<G> {
 // ax^3 + bx^2 + cx + d stored as vec![a,b,c,d]
 #[derive(Debug)]
 pub struct UniPoly<G: Group> {
-  coeffs: Vec<G::Scalar>,
+  coeffs: Vec<<G as Group>::Scalar>,
 }
 
 // ax^2 + bx + c stored as vec![a,c]
 // ax^3 + bx^2 + cx + d stored as vec![a,c,d]
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct CompressedUniPoly<G: Group> {
-  coeffs_except_linear_term: Vec<G::Scalar>,
+  coeffs_except_linear_term: Vec<<G as Group>::Scalar>,
   _p: PhantomData<G>,
 }
 
 impl<G: Group> UniPoly<G> {
-  pub fn from_evals(evals: &[G::Scalar]) -> Self {
+  pub fn from_evals(evals: &[<G as Group>::Scalar]) -> Self {
     // we only support degree-2 or degree-3 univariate polynomials
     assert!(evals.len() == 3 || evals.len() == 4);
     let coeffs = if evals.len() == 3 {
       // ax^2 + bx + c
-      let two_inv = G::Scalar::from(2).invert().unwrap();
+      let two_inv = <G as Group>::Scalar::from(2).invert().unwrap();
 
       let c = evals[0];
       let a = two_inv * (evals[2] - evals[1] - evals[1] + c);
@@ -314,8 +334,8 @@ impl<G: Group> UniPoly<G> {
       vec![c, b, a]
     } else {
       // ax^3 + bx^2 + cx + d
-      let two_inv = G::Scalar::from(2).invert().unwrap();
-      let six_inv = G::Scalar::from(6).invert().unwrap();
+      let two_inv = <G as Group>::Scalar::from(2).invert().unwrap();
+      let six_inv = <G as Group>::Scalar::from(6).invert().unwrap();
 
       let d = evals[0];
       let a = six_inv
@@ -338,18 +358,18 @@ impl<G: Group> UniPoly<G> {
     self.coeffs.len() - 1
   }
 
-  pub fn eval_at_zero(&self) -> G::Scalar {
+  pub fn eval_at_zero(&self) -> <G as Group>::Scalar {
     self.coeffs[0]
   }
 
-  pub fn eval_at_one(&self) -> G::Scalar {
+  pub fn eval_at_one(&self) -> <G as Group>::Scalar {
     (0..self.coeffs.len())
       .into_par_iter()
       .map(|i| self.coeffs[i])
-      .reduce(|| G::Scalar::ZERO, |a, b| a + b)
+      .reduce(|| <G as Group>::Scalar::ZERO, |a, b| a + b)
   }
 
-  pub fn evaluate(&self, r: &G::Scalar) -> G::Scalar {
+  pub fn evaluate(&self, r: &<G as Group>::Scalar) -> <G as Group>::Scalar {
     let mut eval = self.coeffs[0];
     let mut power = *r;
     for coeff in self.coeffs.iter().skip(1) {
@@ -372,14 +392,14 @@ impl<G: Group> UniPoly<G> {
 impl<G: Group> CompressedUniPoly<G> {
   // we require eval(0) + eval(1) = hint, so we can solve for the linear term as:
   // linear_term = hint - 2 * constant_term - deg2 term - deg3 term
-  pub fn decompress(&self, hint: &G::Scalar) -> UniPoly<G> {
+  pub fn decompress(&self, hint: &<G as Group>::Scalar) -> UniPoly<G> {
     let mut linear_term =
       *hint - self.coeffs_except_linear_term[0] - self.coeffs_except_linear_term[0];
     for i in 1..self.coeffs_except_linear_term.len() {
       linear_term -= self.coeffs_except_linear_term[i];
     }
 
-    let mut coeffs: Vec<G::Scalar> = Vec::new();
+    let mut coeffs: Vec<<G as Group>::Scalar> = Vec::new();
     coeffs.push(self.coeffs_except_linear_term[0]);
     coeffs.push(linear_term);
     coeffs.extend(&self.coeffs_except_linear_term[1..]);

--- a/src/traits/commitment.rs
+++ b/src/traits/commitment.rs
@@ -49,7 +49,7 @@ pub trait CommitmentTrait<G: Group>:
   + AbsorbInROTrait<G>
   + CommitmentOps
   + CommitmentOpsOwned
-  + ScalarMul<G::Scalar>
+  + ScalarMul<<G as Group>::Scalar>
 {
   /// Holds the type of the compressed commitment
   type CompressedCommitment: Clone
@@ -86,5 +86,5 @@ pub trait CommitmentEngineTrait<G: Group>:
   fn setup(label: &'static [u8], n: usize) -> Self::CommitmentKey;
 
   /// Commits to the provided vector using the provided generators
-  fn commit(ck: &Self::CommitmentKey, v: &[G::Scalar]) -> Self::Commitment;
+  fn commit(ck: &Self::CommitmentKey, v: &[<G as Group>::Scalar]) -> Self::Commitment;
 }

--- a/src/traits/evaluation.rs
+++ b/src/traits/evaluation.rs
@@ -34,9 +34,9 @@ pub trait EvaluationEngineTrait<G: Group>:
     pk: &Self::ProverKey,
     transcript: &mut G::TE,
     comm: &<Self::CE as CommitmentEngineTrait<G>>::Commitment,
-    poly: &[G::Scalar],
-    point: &[G::Scalar],
-    eval: &G::Scalar,
+    poly: &[<G as Group>::Scalar],
+    point: &[<G as Group>::Scalar],
+    eval: &<G as Group>::Scalar,
   ) -> Result<Self::EvaluationArgument, NovaError>;
 
   /// A method to verify the purported evaluation of a multilinear polynomials
@@ -44,8 +44,8 @@ pub trait EvaluationEngineTrait<G: Group>:
     vk: &Self::VerifierKey,
     transcript: &mut G::TE,
     comm: &<Self::CE as CommitmentEngineTrait<G>>::Commitment,
-    point: &[G::Scalar],
-    eval: &G::Scalar,
+    point: &[<G as Group>::Scalar],
+    eval: &<G as Group>::Scalar,
     arg: &Self::EvaluationArgument,
   ) -> Result<(), NovaError>;
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -41,8 +41,7 @@ pub trait Group:
     + for<'de> Deserialize<'de>;
 
   /// A type representing an element of the scalar field of the group
-  type Scalar: PrimeField
-    + PrimeFieldBits
+  type Scalar: PrimeFieldBits
     + PrimeFieldExt
     + Send
     + Sync

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -9,6 +9,7 @@ use core::{
   ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
 };
 use ff::{PrimeField, PrimeFieldBits};
+use group::Group as BaseGroupTrait;
 use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
 
@@ -19,19 +20,7 @@ use commitment::CommitmentEngineTrait;
 /// Represents an element of a group
 /// This is currently tailored for an elliptic curve group
 pub trait Group:
-  Clone
-  + Copy
-  + Debug
-  + Eq
-  + Sized
-  + GroupOps
-  + GroupOpsOwned
-  + ScalarMul<<Self as Group>::Scalar>
-  + ScalarMulOwned<<Self as Group>::Scalar>
-  + Send
-  + Sync
-  + Serialize
-  + for<'de> Deserialize<'de>
+  BaseGroupTrait<Scalar = <Self as Group>::Scalar> + Serialize + for<'de> Deserialize<'de>
 {
   /// A type representing an element of the base field of the group
   type Base: PrimeField
@@ -59,7 +48,7 @@ pub trait Group:
 
   /// A type that represents a circuit-friendly sponge that consumes elements
   /// from the base field and squeezes out elements of the scalar field
-  type RO: ROTrait<Self::Base, Self::Scalar> + Serialize + for<'de> Deserialize<'de>;
+  type RO: ROTrait<Self::Base, <Self as Group>::Scalar> + Serialize + for<'de> Deserialize<'de>;
 
   /// An alternate implementation of Self::RO in the circuit model
   type ROCircuit: ROCircuitTrait<Self::Base> + Serialize + for<'de> Deserialize<'de>;
@@ -72,7 +61,7 @@ pub trait Group:
 
   /// A method to compute a multiexponentation
   fn vartime_multiscalar_mul(
-    scalars: &[Self::Scalar],
+    scalars: &[<Self as Group>::Scalar],
     bases: &[Self::PreprocessedGroupElement],
   ) -> Self;
 
@@ -218,7 +207,7 @@ pub trait TranscriptEngineTrait<G: Group>: Send + Sync {
   fn new(label: &'static [u8]) -> Self;
 
   /// returns a scalar element of the group as a challenge
-  fn squeeze(&mut self, label: &'static [u8]) -> Result<G::Scalar, NovaError>;
+  fn squeeze(&mut self, label: &'static [u8]) -> Result<<G as Group>::Scalar, NovaError>;
 
   /// absorbs any type that implements TranscriptReprTrait under a label
   fn absorb<T: TranscriptReprTrait<G>>(&mut self, label: &'static [u8], o: &T);


### PR DESCRIPTION
## What this does
- removes uneeded trait bounds in a few places (1st commit),
- pegs the group trait on the `zkcrypto::group::Group` (2nd commit),

## What this does not do
- use the `zkcrypto::group::GroupEncoding` trait, as the chosen `GroupEncoding` implementations for `Pallas` and `Vesta` are the same (`[u8;32]`) and it would thus not be possible to implement two distinct instances of `CompressedGroupElement` on this type, requiring exactly the same sort of wrapper as we have now.

Partially helps with #198.