### PR TITLE
chore: Switch dependency from `bellperson` to `bellpepper_core` & `bellpepper` (PoC)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["zkSNARKs", "cryptography", "proofs"]
 [dependencies]
 # TODO: replace with the next version of bellperson
 # See : https://github.com/filecoin-project/bellperson/pull/314
-bellperson = { git="https://github.com/filecoin-project/bellperson", branch="master", default-features = false }
+bellperson = { git="https://github.com/filecoin-project/bellperson", rev="8c5d202e", default-features = false }
 bellpepper-core = { version="0.2.0", default-features = false }
 bellpepper = { version="0.2.0", default-features = false }
 ff = { version = "0.13.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["zkSNARKs", "cryptography", "proofs"]
 [dependencies]
 # TODO: replace with the next version of bellperson
 # See : https://github.com/filecoin-project/bellperson/pull/314
-bellperson = { git="https://github.com/huitseeker/bellperson", branch="use_bellpepper", default-features = false }
+bellperson = { git="https://github.com/filecoin-project/bellperson", branch="master", default-features = false }
 bellpepper-core = { version="0.2.0", default-features = false }
 bellpepper = { version="0.2.0", default-features = false }
 ff = { version = "0.13.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,11 @@ license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
 
 [dependencies]
-bellperson = { version = "0.25", default-features = false }
+# TODO: replace with the next version of bellperson
+# See : https://github.com/filecoin-project/bellperson/pull/314
+bellperson = { git="https://github.com/huitseeker/bellperson", branch="use_bellpepper", default-features = false }
+bellpepper-core = { version="0.2.0", default-features = false }
+bellpepper = { version="0.2.0", default-features = false }
 ff = { version = "0.13.0", features = ["derive"] }
 digest = "0.10"
 sha3 = "0.10"
@@ -21,7 +25,8 @@ rand_chacha = "0.3"
 itertools = "0.11"
 subtle = "2.5"
 pasta_curves = { version = "0.5", features = ["repr-c", "serde"] }
-neptune = { version = "10.0.0", default-features = false }
+# TODO: replace with the next version of neptune
+neptune = { git="https://github.com/lurk-lab/neptune", rev="cfeaa9ab7c4c39e170fe00631caf6e48c1cb52ec", default-features = false }
 generic-array = "0.14"
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,7 @@ rand_chacha = "0.3"
 itertools = "0.11"
 subtle = "2.5"
 pasta_curves = { version = "0.5", features = ["repr-c", "serde"] }
-# TODO: replace with the next version of neptune
-neptune = { git="https://github.com/lurk-lab/neptune", rev="cfeaa9ab7c4c39e170fe00631caf6e48c1cb52ec", default-features = false }
+neptune = { version = "11.0.0", default-features = false }
 generic-array = "0.14"
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use core::marker::PhantomData;
 use criterion::*;
 use ff::PrimeField;

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -1,6 +1,6 @@
 use std::{marker::PhantomData, time::Duration};
 
-use bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ff::PrimeField;
 use nova_snark::{

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case)]
 
-use bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use core::marker::PhantomData;
 use criterion::*;
 use ff::PrimeField;

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -5,13 +5,10 @@
 #![allow(non_snake_case)]
 type G1 = pasta_curves::pallas::Point;
 type G2 = pasta_curves::vesta::Point;
-use ::bellperson::{
-  gadgets::{
-    boolean::{AllocatedBit, Boolean},
-    num::{AllocatedNum, Num},
-    sha256::sha256,
-    Assignment,
-  },
+use bellpepper::gadgets::{sha256::sha256, Assignment};
+use bellpepper_core::{
+  boolean::{AllocatedBit, Boolean},
+  num::{AllocatedNum, Num},
   ConstraintSystem, SynthesisError,
 };
 use core::time::Duration;

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -3,7 +3,7 @@
 //! We execute a configurable number of iterations of the MinRoot function per step of Nova's recursion.
 type G1 = pasta_curves::pallas::Point;
 type G2 = pasta_curves::vesta::Point;
-use ::bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use ff::PrimeField;
 use flate2::{write::ZlibEncoder, Compression};
 use nova_snark::{

--- a/examples/signature.rs
+++ b/examples/signature.rs
@@ -1,6 +1,5 @@
-use bellperson::{
-  gadgets::{boolean::AllocatedBit, test::TestConstraintSystem},
-  ConstraintSystem, SynthesisError,
+use bellpepper_core::{
+  boolean::AllocatedBit, test_cs::TestConstraintSystem, ConstraintSystem, SynthesisError,
 };
 use core::ops::{AddAssign, MulAssign};
 use ff::{

--- a/src/bellperson/mod.rs
+++ b/src/bellperson/mod.rs
@@ -16,7 +16,7 @@ mod tests {
     },
     traits::Group,
   };
-  use bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+  use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use ff::PrimeField;
 
   fn synthesize_alloc_bit<Fr: PrimeField, CS: ConstraintSystem<Fr>>(

--- a/src/bellperson/r1cs.rs
+++ b/src/bellperson/r1cs.rs
@@ -9,7 +9,7 @@ use crate::{
   traits::Group,
   CommitmentKey,
 };
-use bellperson::{Index, LinearCombination};
+use bellpepper_core::{Index, LinearCombination};
 use ff::PrimeField;
 
 /// `NovaWitness` provide a method for acquiring an `R1CSInstance` and `R1CSWitness` from implementers.

--- a/src/bellperson/shape_cs.rs
+++ b/src/bellperson/shape_cs.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crate::traits::Group;
-use bellperson::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
+use bellpepper_core::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 use core::fmt::Write;
 use ff::{Field, PrimeField};
 

--- a/src/bellperson/solver.rs
+++ b/src/bellperson/solver.rs
@@ -3,9 +3,8 @@
 use crate::traits::Group;
 use ff::Field;
 
-use bellperson::{
-  multiexp::DensityTracker, ConstraintSystem, Index, LinearCombination, SynthesisError, Variable,
-};
+use bellpepper_core::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
+use bellperson::multiexp::DensityTracker;
 
 /// A `ConstraintSystem` which calculates witness values for a concrete instance of an R1CS circuit.
 #[derive(PartialEq)]
@@ -139,18 +138,18 @@ impl<G: Group> ConstraintSystem<G::Scalar> for SatisfyingAssignment<G> {
     true
   }
 
-  fn extend(&mut self, other: Self) {
-    self.a_aux_density.extend(other.a_aux_density, false);
-    self.b_input_density.extend(other.b_input_density, true);
-    self.b_aux_density.extend(other.b_aux_density, false);
+  fn extend(&mut self, other: &Self) {
+    self.a_aux_density.extend(&other.a_aux_density, false);
+    self.b_input_density.extend(&other.b_input_density, true);
+    self.b_aux_density.extend(&other.b_aux_density, false);
 
-    self.a.extend(other.a);
-    self.b.extend(other.b);
-    self.c.extend(other.c);
+    self.a.extend(&other.a);
+    self.b.extend(&other.b);
+    self.c.extend(&other.c);
 
     self.input_assignment
             // Skip first input, which must have been a temporarily allocated one variable.
             .extend(&other.input_assignment[1..]);
-    self.aux_assignment.extend(other.aux_assignment);
+    self.aux_assignment.extend(&other.aux_assignment);
   }
 }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -21,12 +21,10 @@ use crate::{
   },
   Commitment,
 };
-use bellperson::{
-  gadgets::{
-    boolean::{AllocatedBit, Boolean},
-    num::AllocatedNum,
-    Assignment,
-  },
+use bellpepper::gadgets::Assignment;
+use bellpepper_core::{
+  boolean::{AllocatedBit, Boolean},
+  num::AllocatedNum,
   ConstraintSystem, SynthesisError,
 };
 use ff::Field;

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -8,12 +8,10 @@ use crate::{
   },
   traits::Group,
 };
-use bellperson::{
-  gadgets::{
-    boolean::{AllocatedBit, Boolean},
-    num::AllocatedNum,
-    Assignment,
-  },
+use bellpepper::gadgets::Assignment;
+use bellpepper_core::{
+  boolean::{AllocatedBit, Boolean},
+  num::AllocatedNum,
   ConstraintSystem, SynthesisError,
 };
 use ff::{Field, PrimeField};

--- a/src/gadgets/nonnative/bignat.rs
+++ b/src/gadgets/nonnative/bignat.rs
@@ -4,7 +4,7 @@ use super::{
   },
   OptionExt,
 };
-use bellperson::{ConstraintSystem, LinearCombination, SynthesisError};
+use bellpepper_core::{ConstraintSystem, LinearCombination, SynthesisError};
 use ff::PrimeField;
 use num_bigint::BigInt;
 use num_traits::cast::ToPrimitive;
@@ -783,7 +783,7 @@ impl<Scalar: PrimeField> Polynomial<Scalar> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use bellperson::{gadgets::test::TestConstraintSystem, Circuit};
+  use bellpepper_core::{test_cs::TestConstraintSystem, Circuit};
   use pasta_curves::pallas::Scalar;
   use proptest::prelude::*;
 

--- a/src/gadgets/nonnative/mod.rs
+++ b/src/gadgets/nonnative/mod.rs
@@ -1,7 +1,7 @@
 //! This module implements various gadgets necessary for doing non-native arithmetic
 //! Code in this module is adapted from [bellman-bignat](https://github.com/alex-ozdemir/bellman-bignat), which is licenced under MIT
 
-use bellperson::SynthesisError;
+use bellpepper_core::SynthesisError;
 use ff::PrimeField;
 
 trait OptionExt<T> {

--- a/src/gadgets/nonnative/util.rs
+++ b/src/gadgets/nonnative/util.rs
@@ -1,6 +1,6 @@
 use super::{BitAccess, OptionExt};
-use bellperson::{
-  gadgets::num::AllocatedNum,
+use bellpepper_core::{
+  num::AllocatedNum,
   {ConstraintSystem, LinearCombination, SynthesisError, Variable},
 };
 use byteorder::WriteBytesExt;

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -15,10 +15,8 @@ use crate::{
   r1cs::{R1CSInstance, RelaxedR1CSInstance},
   traits::{commitment::CommitmentTrait, Group, ROCircuitTrait, ROConstantsCircuit},
 };
-use bellperson::{
-  gadgets::{boolean::Boolean, num::AllocatedNum, Assignment},
-  ConstraintSystem, SynthesisError,
-};
+use bellpepper::gadgets::{boolean::Boolean, num::AllocatedNum, Assignment};
+use bellpepper_core::{ConstraintSystem, SynthesisError};
 use ff::Field;
 
 /// An Allocated R1CS Instance

--- a/src/gadgets/utils.rs
+++ b/src/gadgets/utils.rs
@@ -1,12 +1,10 @@
 //! This module implements various low-level gadgets
 use super::nonnative::bignat::{nat_to_limbs, BigNat};
 use crate::traits::Group;
-use bellperson::{
-  gadgets::{
-    boolean::{AllocatedBit, Boolean},
-    num::AllocatedNum,
-    Assignment,
-  },
+use bellpepper::gadgets::Assignment;
+use bellpepper_core::{
+  boolean::{AllocatedBit, Boolean},
+  num::AllocatedNum,
   ConstraintSystem, LinearCombination, SynthesisError,
 };
 use ff::{Field, PrimeField, PrimeFieldBits};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use crate::bellperson::{
   shape_cs::ShapeCS,
   solver::SatisfyingAssignment,
 };
-use ::bellperson::ConstraintSystem;
+use bellpepper_core::ConstraintSystem;
 use circuit::{NovaAugmentedCircuit, NovaAugmentedCircuitInputs, NovaAugmentedCircuitParams};
 use constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_FE_WITHOUT_IO_FOR_CRHF, NUM_HASH_BITS};
 use core::marker::PhantomData;
@@ -828,7 +828,7 @@ mod tests {
   type S1Prime<G1> = spartan::ppsnark::RelaxedR1CSSNARK<G1, EE1<G1>>;
   type S2Prime<G2> = spartan::ppsnark::RelaxedR1CSSNARK<G2, EE2<G2>>;
 
-  use ::bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+  use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use core::marker::PhantomData;
   use ff::PrimeField;
   use traits::circuit::TrivialTestCircuit;

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -122,7 +122,7 @@ mod tests {
     r1cs::R1CS,
     traits::{Group, ROConstantsTrait},
   };
-  use ::bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+  use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use ff::{Field, PrimeField};
   use rand::rngs::OsRng;
 

--- a/src/provider/poseidon.rs
+++ b/src/provider/poseidon.rs
@@ -1,10 +1,8 @@
 //! Poseidon Constants and Poseidon-based RO used in Nova
 use crate::traits::{ROCircuitTrait, ROConstantsTrait, ROTrait};
-use bellperson::{
-  gadgets::{
-    boolean::{AllocatedBit, Boolean},
-    num::AllocatedNum,
-  },
+use bellpepper_core::{
+  boolean::{AllocatedBit, Boolean},
+  num::AllocatedNum,
   ConstraintSystem, SynthesisError,
 };
 use core::marker::PhantomData;

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -12,7 +12,7 @@ use crate::{
   traits::{circuit::StepCircuit, snark::RelaxedR1CSSNARKTrait, Group},
   Commitment, CommitmentKey,
 };
-use bellperson::{gadgets::num::AllocatedNum, Circuit, ConstraintSystem, SynthesisError};
+use bellpepper_core::{num::AllocatedNum, Circuit, ConstraintSystem, SynthesisError};
 use core::marker::PhantomData;
 use ff::Field;
 use serde::{Deserialize, Serialize};
@@ -154,7 +154,7 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
 mod tests {
   use super::*;
   use crate::provider::bn256_grumpkin::bn256;
-  use ::bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+  use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use core::marker::PhantomData;
   use ff::PrimeField;
 

--- a/src/traits/circuit.rs
+++ b/src/traits/circuit.rs
@@ -1,5 +1,5 @@
 //! This module defines traits that a step function must implement
-use bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use core::marker::PhantomData;
 use ff::PrimeField;
 

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,9 +1,6 @@
 //! This module defines various traits required by the users of the library to implement.
 use crate::errors::NovaError;
-use bellperson::{
-  gadgets::{boolean::AllocatedBit, num::AllocatedNum},
-  ConstraintSystem, SynthesisError,
-};
+use bellpepper_core::{boolean::AllocatedBit, num::AllocatedNum, ConstraintSystem, SynthesisError};
 use core::{
   fmt::Debug,
   ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},


### PR DESCRIPTION
- The `bellperson` library has been replaced maximally (see below) with `bellpepper_core` throughout the project,
- The changes involved updating all import statements across various source, benchmark, and example files, while maintaining the same functionality.
- By way of upgrade, some functions have been refactored to operate with referenced variables rather than owning their variables, improving memory efficiency.

## Dependencies

Before this PR:
```mermaid
graph LR;
    A[bellperson] --> B[neptune];
    B --> C[Nova];
    A --> C;
```

After ~~neptune is released (and~~ https://github.com/filecoin-project/bellperson/pull/314 is ~~merged &~~ released ~~)~~, this PR installs:
```mermaid
graph LR;
    A[bellpepper] --> B[neptune];
    B --> C[Nova];
    A --> C;
    D[bellperson] --> C;
```

Once #177 is rebased on the present PR (and `bellpepper` is simpler and smaller than `bellperson`):
```mermaid
graph LR;
    A[bellpepper] --> B[neptune];
    B --> C[Nova];
    A --> C;
```