### PR TITLE
Remove uneeded circuit allocations in RecursiveSNARK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ num-traits = "0.2"
 num-integer = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
-flate2 = "1.0"
 bitvec = "1.0"
 byteorder = "1.4.3"
 thiserror = "1.0"
@@ -44,6 +43,7 @@ getrandom = { version = "0.2.0", default-features = false, features = ["js"] }
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
 rand = "0.8.4"
+flate2 = "1.0"
 hex = "0.4.3"
 pprof = { version = "0.11" }
 cfg-if = "1.0.0"

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -65,7 +65,7 @@ fn bench_compressed_snark(c: &mut Criterion) {
     let c_secondary = TrivialTestCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(c_primary.clone(), c_secondary.clone());
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary);
 
     // Produce prover and verifier keys for CompressedSNARK
     let (pk, vk) = CompressedSNARK::<_, _, _, _, S1, S2>::setup(&pp).unwrap();
@@ -152,7 +152,7 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
     let c_secondary = TrivialTestCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(c_primary.clone(), c_secondary.clone());
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary);
 
     // Produce prover and verifier keys for CompressedSNARK
     let (pk, vk) = CompressedSNARK::<_, _, _, _, SS1, SS2>::setup(&pp).unwrap();

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -27,7 +27,7 @@ criterion_main!(compute_digest);
 fn bench_compute_digest(c: &mut Criterion) {
   c.bench_function("compute_digest", |b| {
     b.iter(|| {
-      PublicParams::<G1, G2, C1, C2>::setup(black_box(C1::new(10)), black_box(C2::default()))
+      PublicParams::<G1, G2, C1, C2>::setup(black_box(&C1::new(10)), black_box(&C2::default()))
     })
   });
 }

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -56,7 +56,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
     let c_secondary = TrivialTestCircuit::default();
 
     // Produce public parameters
-    let pp = PublicParams::<G1, G2, C1, C2>::setup(c_primary.clone(), c_secondary.clone());
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(&c_primary, &c_secondary);
 
     // Bench time to produce a recursive SNARK;
     // we execute a certain number of warm-up steps since executing

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -201,8 +201,7 @@ fn bench_recursive_snark(c: &mut Criterion) {
 
     // Produce public parameters
     let ttc = TrivialTestCircuit::default();
-    let pp =
-      PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc);
+    let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc);
 
     let circuit_secondary = TrivialTestCircuit::default();
     let z0_primary = vec![<G1 as Group>::Scalar::from(2u64)];

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -200,8 +200,9 @@ fn bench_recursive_snark(c: &mut Criterion) {
     group.sample_size(10);
 
     // Produce public parameters
+    let ttc = TrivialTestCircuit::default();
     let pp =
-      PublicParams::<G1, G2, C1, C2>::setup(circuit_primary.clone(), TrivialTestCircuit::default());
+      PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc);
 
     let circuit_secondary = TrivialTestCircuit::default();
     let z0_primary = vec![<G1 as Group>::Scalar::from(2u64)];

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -172,7 +172,7 @@ fn main() {
       G2,
       MinRootCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(circuit_primary.clone(), circuit_secondary.clone());
+    >::setup(&circuit_primary, &circuit_secondary);
     println!("PublicParams::setup, took {:?} ", start.elapsed());
 
     println!(

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -40,7 +40,7 @@ pub struct NovaAugmentedCircuitParams {
 }
 
 impl NovaAugmentedCircuitParams {
-  pub fn new(limb_width: usize, n_limbs: usize, is_primary_circuit: bool) -> Self {
+  pub const fn new(limb_width: usize, n_limbs: usize, is_primary_circuit: bool) -> Self {
     Self {
       limb_width,
       n_limbs,
@@ -96,7 +96,7 @@ pub struct NovaAugmentedCircuit<G: Group, SC: StepCircuit<G::Base>> {
 
 impl<G: Group, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<G, SC> {
   /// Create a new verification circuit for the input relaxed r1cs instances
-  pub fn new(
+  pub const fn new(
     params: NovaAugmentedCircuitParams,
     inputs: Option<NovaAugmentedCircuitInputs<G>>,
     step_circuit: SC,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -87,19 +87,19 @@ impl<G: Group> NovaAugmentedCircuitInputs<G> {
 
 /// The augmented circuit F' in Nova that includes a step circuit F
 /// and the circuit for the verifier in Nova's non-interactive folding scheme
-pub struct NovaAugmentedCircuit<G: Group, SC: StepCircuit<G::Base>> {
+pub struct NovaAugmentedCircuit<'a, G: Group, SC: StepCircuit<G::Base>> {
   params: NovaAugmentedCircuitParams,
   ro_consts: ROConstantsCircuit<G>,
   inputs: Option<NovaAugmentedCircuitInputs<G>>,
-  step_circuit: SC, // The function that is applied for each step
+  step_circuit: &'a SC, // The function that is applied for each step
 }
 
-impl<G: Group, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<G, SC> {
+impl<'a, G: Group, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> {
   /// Create a new verification circuit for the input relaxed r1cs instances
   pub const fn new(
     params: NovaAugmentedCircuitParams,
     inputs: Option<NovaAugmentedCircuitInputs<G>>,
-    step_circuit: SC,
+    step_circuit: &'a SC,
     ro_consts: ROConstantsCircuit<G>,
   ) -> Self {
     Self {
@@ -262,8 +262,8 @@ impl<G: Group, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<G, SC> {
   }
 }
 
-impl<G: Group, SC: StepCircuit<G::Base>> Circuit<<G as Group>::Base>
-  for NovaAugmentedCircuit<G, SC>
+impl<'a, G: Group, SC: StepCircuit<G::Base>> Circuit<<G as Group>::Base>
+  for NovaAugmentedCircuit<'a, G, SC>
 {
   fn synthesize<CS: ConstraintSystem<<G as Group>::Base>>(
     self,
@@ -396,12 +396,13 @@ mod tests {
     G1: Group<Base = <G2 as Group>::Scalar>,
     G2: Group<Base = <G1 as Group>::Scalar>,
   {
+    let ttc1 = TrivialTestCircuit::default();
     // Initialize the shape and ck for the primary
-    let circuit1: NovaAugmentedCircuit<G2, TrivialTestCircuit<<G2 as Group>::Base>> =
+    let circuit1: NovaAugmentedCircuit<'_, G2, TrivialTestCircuit<<G2 as Group>::Base>> =
       NovaAugmentedCircuit::new(
         primary_params.clone(),
         None,
-        TrivialTestCircuit::default(),
+        &ttc1,
         ro_consts1.clone(),
       );
     let mut cs: ShapeCS<G1> = ShapeCS::new();
@@ -409,12 +410,13 @@ mod tests {
     let (shape1, ck1) = cs.r1cs_shape();
     assert_eq!(cs.num_constraints(), num_constraints_primary);
 
+    let ttc2 = TrivialTestCircuit::default();
     // Initialize the shape and ck for the secondary
-    let circuit2: NovaAugmentedCircuit<G1, TrivialTestCircuit<<G1 as Group>::Base>> =
+    let circuit2: NovaAugmentedCircuit<'_, G1, TrivialTestCircuit<<G1 as Group>::Base>> =
       NovaAugmentedCircuit::new(
         secondary_params.clone(),
         None,
-        TrivialTestCircuit::default(),
+        &ttc2,
         ro_consts2.clone(),
       );
     let mut cs: ShapeCS<G2> = ShapeCS::new();
@@ -434,11 +436,11 @@ mod tests {
       None,
       None,
     );
-    let circuit1: NovaAugmentedCircuit<G2, TrivialTestCircuit<<G2 as Group>::Base>> =
+    let circuit1: NovaAugmentedCircuit<'_, G2, TrivialTestCircuit<<G2 as Group>::Base>> =
       NovaAugmentedCircuit::new(
         primary_params,
         Some(inputs1),
-        TrivialTestCircuit::default(),
+        &ttc1,
         ro_consts1,
       );
     let _ = circuit1.synthesize(&mut cs1);
@@ -458,11 +460,11 @@ mod tests {
       Some(inst1),
       None,
     );
-    let circuit2: NovaAugmentedCircuit<G1, TrivialTestCircuit<<G1 as Group>::Base>> =
+    let circuit2: NovaAugmentedCircuit<'_, G1, TrivialTestCircuit<<G1 as Group>::Base>> =
       NovaAugmentedCircuit::new(
         secondary_params,
         Some(inputs2),
-        TrivialTestCircuit::default(),
+        &ttc2,
         ro_consts2,
       );
     let _ = circuit2.synthesize(&mut cs2);

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -399,12 +399,7 @@ mod tests {
     let ttc1 = TrivialTestCircuit::default();
     // Initialize the shape and ck for the primary
     let circuit1: NovaAugmentedCircuit<'_, G2, TrivialTestCircuit<<G2 as Group>::Base>> =
-      NovaAugmentedCircuit::new(
-        &primary_params,
-        None,
-        &ttc1,
-        ro_consts1.clone(),
-      );
+      NovaAugmentedCircuit::new(&primary_params, None, &ttc1, ro_consts1.clone());
     let mut cs: ShapeCS<G1> = ShapeCS::new();
     let _ = circuit1.synthesize(&mut cs);
     let (shape1, ck1) = cs.r1cs_shape();
@@ -413,12 +408,7 @@ mod tests {
     let ttc2 = TrivialTestCircuit::default();
     // Initialize the shape and ck for the secondary
     let circuit2: NovaAugmentedCircuit<'_, G1, TrivialTestCircuit<<G1 as Group>::Base>> =
-      NovaAugmentedCircuit::new(
-        &secondary_params,
-        None,
-        &ttc2,
-        ro_consts2.clone(),
-      );
+      NovaAugmentedCircuit::new(&secondary_params, None, &ttc2, ro_consts2.clone());
     let mut cs: ShapeCS<G2> = ShapeCS::new();
     let _ = circuit2.synthesize(&mut cs);
     let (shape2, ck2) = cs.r1cs_shape();
@@ -437,12 +427,7 @@ mod tests {
       None,
     );
     let circuit1: NovaAugmentedCircuit<'_, G2, TrivialTestCircuit<<G2 as Group>::Base>> =
-      NovaAugmentedCircuit::new(
-        &primary_params,
-        Some(inputs1),
-        &ttc1,
-        ro_consts1,
-      );
+      NovaAugmentedCircuit::new(&primary_params, Some(inputs1), &ttc1, ro_consts1);
     let _ = circuit1.synthesize(&mut cs1);
     let (inst1, witness1) = cs1.r1cs_instance_and_witness(&shape1, &ck1).unwrap();
     // Make sure that this is satisfiable
@@ -461,12 +446,7 @@ mod tests {
       None,
     );
     let circuit2: NovaAugmentedCircuit<'_, G1, TrivialTestCircuit<<G1 as Group>::Base>> =
-      NovaAugmentedCircuit::new(
-        &secondary_params,
-        Some(inputs2),
-        &ttc2,
-        ro_consts2,
-      );
+      NovaAugmentedCircuit::new(&secondary_params, Some(inputs2), &ttc2, ro_consts2);
     let _ = circuit2.synthesize(&mut cs2);
     let (inst2, witness2) = cs2.r1cs_instance_and_witness(&shape2, &ck2).unwrap();
     // Make sure that it is satisfiable

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -88,7 +88,7 @@ impl<G: Group> NovaAugmentedCircuitInputs<G> {
 /// The augmented circuit F' in Nova that includes a step circuit F
 /// and the circuit for the verifier in Nova's non-interactive folding scheme
 pub struct NovaAugmentedCircuit<'a, G: Group, SC: StepCircuit<G::Base>> {
-  params: NovaAugmentedCircuitParams,
+  params: &'a NovaAugmentedCircuitParams,
   ro_consts: ROConstantsCircuit<G>,
   inputs: Option<NovaAugmentedCircuitInputs<G>>,
   step_circuit: &'a SC, // The function that is applied for each step
@@ -97,7 +97,7 @@ pub struct NovaAugmentedCircuit<'a, G: Group, SC: StepCircuit<G::Base>> {
 impl<'a, G: Group, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> {
   /// Create a new verification circuit for the input relaxed r1cs instances
   pub const fn new(
-    params: NovaAugmentedCircuitParams,
+    params: &'a NovaAugmentedCircuitParams,
     inputs: Option<NovaAugmentedCircuitInputs<G>>,
     step_circuit: &'a SC,
     ro_consts: ROConstantsCircuit<G>,
@@ -400,7 +400,7 @@ mod tests {
     // Initialize the shape and ck for the primary
     let circuit1: NovaAugmentedCircuit<'_, G2, TrivialTestCircuit<<G2 as Group>::Base>> =
       NovaAugmentedCircuit::new(
-        primary_params.clone(),
+        &primary_params,
         None,
         &ttc1,
         ro_consts1.clone(),
@@ -414,7 +414,7 @@ mod tests {
     // Initialize the shape and ck for the secondary
     let circuit2: NovaAugmentedCircuit<'_, G1, TrivialTestCircuit<<G1 as Group>::Base>> =
       NovaAugmentedCircuit::new(
-        secondary_params.clone(),
+        &secondary_params,
         None,
         &ttc2,
         ro_consts2.clone(),
@@ -438,7 +438,7 @@ mod tests {
     );
     let circuit1: NovaAugmentedCircuit<'_, G2, TrivialTestCircuit<<G2 as Group>::Base>> =
       NovaAugmentedCircuit::new(
-        primary_params,
+        &primary_params,
         Some(inputs1),
         &ttc1,
         ro_consts1,
@@ -462,7 +462,7 @@ mod tests {
     );
     let circuit2: NovaAugmentedCircuit<'_, G1, TrivialTestCircuit<<G1 as Group>::Base>> =
       NovaAugmentedCircuit::new(
-        secondary_params,
+        &secondary_params,
         Some(inputs2),
         &ttc2,
         ro_consts2,

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -81,7 +81,7 @@ where
   }
 
   /// Returns coordinates associated with the point.
-  pub fn get_coordinates(
+  pub const fn get_coordinates(
     &self,
   ) -> (
     &AllocatedNum<G::Base>,
@@ -570,7 +570,7 @@ where
   G: Group,
 {
   /// Creates a new AllocatedPointNonInfinity from the specified coordinates
-  pub fn new(x: AllocatedNum<G::Base>, y: AllocatedNum<G::Base>) -> Self {
+  pub const fn new(x: AllocatedNum<G::Base>, y: AllocatedNum<G::Base>) -> Self {
     Self { x, y }
   }
 
@@ -610,7 +610,7 @@ where
   }
 
   /// Returns coordinates associated with the point.
-  pub fn get_coordinates(&self) -> (&AllocatedNum<G::Base>, &AllocatedNum<G::Base>) {
+  pub const fn get_coordinates(&self) -> (&AllocatedNum<G::Base>, &AllocatedNum<G::Base>) {
     (&self.x, &self.y)
   }
 

--- a/src/gadgets/nonnative/util.rs
+++ b/src/gadgets/nonnative/util.rs
@@ -69,7 +69,7 @@ pub struct Num<Scalar: PrimeField> {
 }
 
 impl<Scalar: PrimeField> Num<Scalar> {
-  pub fn new(value: Option<Scalar>, num: LinearCombination<Scalar>) -> Self {
+  pub const fn new(value: Option<Scalar>, num: LinearCombination<Scalar>) -> Self {
     Self { value, num }
   }
   pub fn alloc<CS, F>(mut cs: CS, value: F) -> Result<Self, SynthesisError>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ where
   C2: StepCircuit<G2::Scalar>,
 {
   /// Create a new `PublicParams`
-  pub fn setup(c_primary: C1, c_secondary: C2) -> Self {
+  pub fn setup(c_primary: &C1, c_secondary: &C2) -> Self {
     let augmented_circuit_params_primary =
       NovaAugmentedCircuitParams::new(BN_LIMB_WIDTH, BN_N_LIMBS, true);
     let augmented_circuit_params_secondary =
@@ -100,7 +100,7 @@ where
     let ro_consts_circuit_secondary: ROConstantsCircuit<G1> = ROConstantsCircuit::<G1>::new();
 
     // Initialize ck for the primary
-    let circuit_primary: NovaAugmentedCircuit<G2, C1> = NovaAugmentedCircuit::new(
+    let circuit_primary: NovaAugmentedCircuit<'_, G2, C1> = NovaAugmentedCircuit::new(
       augmented_circuit_params_primary.clone(),
       None,
       c_primary,
@@ -111,7 +111,7 @@ where
     let (r1cs_shape_primary, ck_primary) = cs.r1cs_shape();
 
     // Initialize ck for the secondary
-    let circuit_secondary: NovaAugmentedCircuit<G1, C2> = NovaAugmentedCircuit::new(
+    let circuit_secondary: NovaAugmentedCircuit<'_, G1, C2> = NovaAugmentedCircuit::new(
       augmented_circuit_params_secondary.clone(),
       None,
       c_secondary,
@@ -216,10 +216,10 @@ where
       None,
     );
 
-    let circuit_primary: NovaAugmentedCircuit<G2, C1> = NovaAugmentedCircuit::new(
+    let circuit_primary: NovaAugmentedCircuit<'_, G2, C1> = NovaAugmentedCircuit::new(
       pp.augmented_circuit_params_primary.clone(),
       Some(inputs_primary),
-      c_primary.clone(),
+      c_primary,
       pp.ro_consts_circuit_primary.clone(),
     );
     let _ = circuit_primary.synthesize(&mut cs_primary);
@@ -239,10 +239,10 @@ where
       Some(u_primary.clone()),
       None,
     );
-    let circuit_secondary: NovaAugmentedCircuit<G1, C2> = NovaAugmentedCircuit::new(
+    let circuit_secondary: NovaAugmentedCircuit<'_, G1, C2> = NovaAugmentedCircuit::new(
       pp.augmented_circuit_params_secondary.clone(),
       Some(inputs_secondary),
-      c_secondary.clone(),
+      c_secondary,
       pp.ro_consts_circuit_secondary.clone(),
     );
     let _ = circuit_secondary.synthesize(&mut cs_secondary);
@@ -328,10 +328,10 @@ where
       Some(Commitment::<G2>::decompress(&nifs_secondary.comm_T)?),
     );
 
-    let circuit_primary: NovaAugmentedCircuit<G2, C1> = NovaAugmentedCircuit::new(
+    let circuit_primary: NovaAugmentedCircuit<'_, G2, C1> = NovaAugmentedCircuit::new(
       pp.augmented_circuit_params_primary.clone(),
       Some(inputs_primary),
-      c_primary.clone(),
+      c_primary,
       pp.ro_consts_circuit_primary.clone(),
     );
     let _ = circuit_primary.synthesize(&mut cs_primary);
@@ -365,10 +365,10 @@ where
       Some(Commitment::<G1>::decompress(&nifs_primary.comm_T)?),
     );
 
-    let circuit_secondary: NovaAugmentedCircuit<G1, C2> = NovaAugmentedCircuit::new(
+    let circuit_secondary: NovaAugmentedCircuit<'_, G1, C2> = NovaAugmentedCircuit::new(
       pp.augmented_circuit_params_secondary.clone(),
       Some(inputs_secondary),
-      c_secondary.clone(),
+      c_secondary,
       pp.ro_consts_circuit_secondary.clone(),
     );
     let _ = circuit_secondary.synthesize(&mut cs_secondary);
@@ -865,7 +865,7 @@ mod tests {
     T1: StepCircuit<G1::Scalar>,
     T2: StepCircuit<G2::Scalar>,
   {
-    let pp = PublicParams::<G1, G2, T1, T2>::setup(circuit1, circuit2);
+    let pp = PublicParams::<G1, G2, T1, T2>::setup(&circuit1, &circuit2);
 
     let digest_str = pp
       .digest
@@ -929,7 +929,7 @@ mod tests {
       G2,
       TrivialTestCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(test_circuit1.clone(), test_circuit2.clone());
+    >::setup(&test_circuit1, &test_circuit2);
 
     let num_steps = 1;
 
@@ -985,7 +985,7 @@ mod tests {
       G2,
       TrivialTestCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(circuit_primary.clone(), circuit_secondary.clone());
+    >::setup(&circuit_primary, &circuit_secondary);
 
     let num_steps = 3;
 
@@ -1072,7 +1072,7 @@ mod tests {
       G2,
       TrivialTestCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(circuit_primary.clone(), circuit_secondary.clone());
+    >::setup(&circuit_primary, &circuit_secondary);
 
     let num_steps = 3;
 
@@ -1167,7 +1167,7 @@ mod tests {
       G2,
       TrivialTestCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(circuit_primary.clone(), circuit_secondary.clone());
+    >::setup(&circuit_primary, &circuit_secondary);
 
     let num_steps = 3;
 
@@ -1339,7 +1339,7 @@ mod tests {
       G2,
       FifthRootCheckingCircuit<<G1 as Group>::Scalar>,
       TrivialTestCircuit<<G2 as Group>::Scalar>,
-    >::setup(circuit_primary, circuit_secondary.clone());
+    >::setup(&circuit_primary, &circuit_secondary);
 
     let num_steps = 3;
 
@@ -1417,7 +1417,7 @@ mod tests {
       G2,
       TrivialTestCircuit<<G1 as Group>::Scalar>,
       CubicCircuit<<G2 as Group>::Scalar>,
-    >::setup(test_circuit1.clone(), test_circuit2.clone());
+    >::setup(&test_circuit1, &test_circuit2);
 
     let num_steps = 1;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ where
 
     // Initialize ck for the primary
     let circuit_primary: NovaAugmentedCircuit<'_, G2, C1> = NovaAugmentedCircuit::new(
-      augmented_circuit_params_primary.clone(),
+      &augmented_circuit_params_primary,
       None,
       c_primary,
       ro_consts_circuit_primary.clone(),
@@ -112,7 +112,7 @@ where
 
     // Initialize ck for the secondary
     let circuit_secondary: NovaAugmentedCircuit<'_, G1, C2> = NovaAugmentedCircuit::new(
-      augmented_circuit_params_secondary.clone(),
+      &augmented_circuit_params_secondary,
       None,
       c_secondary,
       ro_consts_circuit_secondary.clone(),
@@ -217,7 +217,7 @@ where
     );
 
     let circuit_primary: NovaAugmentedCircuit<'_, G2, C1> = NovaAugmentedCircuit::new(
-      pp.augmented_circuit_params_primary.clone(),
+      &pp.augmented_circuit_params_primary,
       Some(inputs_primary),
       c_primary,
       pp.ro_consts_circuit_primary.clone(),
@@ -240,7 +240,7 @@ where
       None,
     );
     let circuit_secondary: NovaAugmentedCircuit<'_, G1, C2> = NovaAugmentedCircuit::new(
-      pp.augmented_circuit_params_secondary.clone(),
+      &pp.augmented_circuit_params_secondary,
       Some(inputs_secondary),
       c_secondary,
       pp.ro_consts_circuit_secondary.clone(),
@@ -329,7 +329,7 @@ where
     );
 
     let circuit_primary: NovaAugmentedCircuit<'_, G2, C1> = NovaAugmentedCircuit::new(
-      pp.augmented_circuit_params_primary.clone(),
+      &pp.augmented_circuit_params_primary,
       Some(inputs_primary),
       c_primary,
       pp.ro_consts_circuit_primary.clone(),
@@ -366,7 +366,7 @@ where
     );
 
     let circuit_secondary: NovaAugmentedCircuit<'_, G1, C2> = NovaAugmentedCircuit::new(
-      pp.augmented_circuit_params_secondary.clone(),
+      &pp.augmented_circuit_params_secondary,
       Some(inputs_secondary),
       c_secondary,
       pp.ro_consts_circuit_secondary.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ where
   }
 
   /// Returns the number of constraints in the primary and secondary circuits
-  pub fn num_constraints(&self) -> (usize, usize) {
+  pub const fn num_constraints(&self) -> (usize, usize) {
     (
       self.r1cs_shape_primary.num_cons,
       self.r1cs_shape_secondary.num_cons,
@@ -154,7 +154,7 @@ where
   }
 
   /// Returns the number of variables in the primary and secondary circuits
-  pub fn num_variables(&self) -> (usize, usize) {
+  pub const fn num_variables(&self) -> (usize, usize) {
     (
       self.r1cs_shape_primary.num_vars,
       self.r1cs_shape_secondary.num_vars,

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -177,7 +177,7 @@ where
   G: Group,
   CommitmentKey<G>: CommitmentKeyExtTrait<G, CE = G::CE>,
 {
-  fn protocol_name() -> &'static [u8] {
+  const fn protocol_name() -> &'static [u8] {
     b"IPA"
   }
 

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -31,7 +31,7 @@ pub struct PallasCompressedElementWrapper {
 
 impl PallasCompressedElementWrapper {
   /// Wraps repr into the wrapper
-  pub fn new(repr: [u8; 32]) -> Self {
+  pub const fn new(repr: [u8; 32]) -> Self {
     Self { repr }
   }
 }
@@ -44,7 +44,7 @@ pub struct VestaCompressedElementWrapper {
 
 impl VestaCompressedElementWrapper {
   /// Wraps repr into the wrapper
-  pub fn new(repr: [u8; 32]) -> Self {
+  pub const fn new(repr: [u8; 32]) -> Self {
     Self { repr }
   }
 }

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -10,7 +10,7 @@ pub(crate) struct EqPolynomial<Scalar: PrimeField> {
 
 impl<Scalar: PrimeField> EqPolynomial<Scalar> {
   /// Creates a new polynomial from its succinct specification
-  pub fn new(r: Vec<Scalar>) -> Self {
+  pub const fn new(r: Vec<Scalar>) -> Self {
     EqPolynomial { r }
   }
 
@@ -61,7 +61,7 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
     }
   }
 
-  pub fn get_num_vars(&self) -> usize {
+  pub const fn get_num_vars(&self) -> usize {
     self.num_vars
   }
 


### PR DESCRIPTION
This optimizes redundant memory allocations away.