### PR TITLE
fine tune step circuit trait to avoid re-implement zi->zi_next logic

### DIFF
--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -259,14 +259,4 @@ where
     }
     Ok(vec![y])
   }
-
-  fn output(&self, z: &[F]) -> Vec<F> {
-    let mut x = z[0];
-    let mut y = x;
-    for _i in 0..self.num_cons {
-      y = x * x;
-      x = y;
-    }
-    vec![y]
-  }
 }

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -71,14 +71,4 @@ where
     }
     Ok(vec![y])
   }
-
-  fn output(&self, z: &[F]) -> Vec<F> {
-    let mut x = z[0];
-    let mut y = x;
-    for _i in 0..self.num_cons {
-      y = x * x;
-      x = y;
-    }
-    vec![y]
-  }
 }

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -162,14 +162,4 @@ where
     }
     Ok(vec![y])
   }
-
-  fn output(&self, z: &[F]) -> Vec<F> {
-    let mut x = z[0];
-    let mut y = x;
-    for _i in 0..self.num_cons {
-      y = x * x;
-      x = y;
-    }
-    vec![y]
-  }
 }

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -25,11 +25,21 @@ use nova_snark::{
   PublicParams, RecursiveSNARK,
 };
 use sha2::{Digest, Sha256};
+use std::marker::PhantomData;
 
 #[derive(Clone, Debug)]
 struct Sha256Circuit<Scalar: PrimeField> {
   preimage: Vec<u8>,
-  digest: Scalar,
+  _p: PhantomData<Scalar>,
+}
+
+impl<Scalar: PrimeField + PrimeFieldBits> Sha256Circuit<Scalar> {
+  pub fn new(preimage: Vec<u8>) -> Self {
+    Self {
+      preimage,
+      _p: Default::default(),
+    }
+  }
 }
 
 impl<Scalar: PrimeField + PrimeFieldBits> StepCircuit<Scalar> for Sha256Circuit<Scalar> {
@@ -110,10 +120,6 @@ impl<Scalar: PrimeField + PrimeFieldBits> StepCircuit<Scalar> for Sha256Circuit<
 
     Ok(z_out)
   }
-
-  fn output(&self, _z: &[Scalar]) -> Vec<Scalar> {
-    vec![self.digest]
-  }
 }
 
 type C1 = Sha256Circuit<<G1 as Group>::Scalar>;
@@ -128,68 +134,19 @@ targets = bench_recursive_snark
 criterion_main!(recursive_snark);
 
 fn bench_recursive_snark(c: &mut Criterion) {
-  let bytes_to_scalar = |bytes: [u8; 32]| -> <G1 as Group>::Scalar {
-    let mut bytes_le = bytes;
-    bytes_le.reverse();
-    <G1 as Group>::Scalar::from_repr(bytes_le).unwrap()
-  };
-
-  let decode_hex = |s: &str| -> <G1 as Group>::Scalar {
-    let bytes = (0..s.len())
-      .step_by(2)
-      .map(|i| u8::from_str_radix(&s[i..i + 2], 16))
-      .collect::<Result<Vec<u8>, _>>()
-      .unwrap();
-    let bytes_arr: [u8; 32] = bytes.try_into().unwrap();
-    bytes_to_scalar(bytes_arr)
-  };
-
   // Test vectors
   let circuits = vec![
-    Sha256Circuit {
-      preimage: vec![0u8; 64],
-      digest: decode_hex("12df9ae4958c1957170f9b04c4bc00c27315c5d75a391f4b672f952842bfa5ac"),
-    },
-    Sha256Circuit {
-      preimage: vec![0u8; 128],
-      digest: decode_hex("13abfac9782cb9c13c4508bde596f1914fe2f744f6a661c0c9a16659745c4e1b"),
-    },
-    Sha256Circuit {
-      preimage: vec![0u8; 256],
-      digest: decode_hex("0f5a007b5aef126a58f9bbd937842967c44253e7f97d98b5cd10bfe44d6782c8"),
-    },
-    Sha256Circuit {
-      preimage: vec![0u8; 512],
-      digest: decode_hex("06a6cfaad91d49366f18443cd4e11576ff27c174bb9fe2bc54735a79e3e456e0"),
-    },
-    Sha256Circuit {
-      preimage: vec![0u8; 1024],
-      digest: decode_hex("3763c73508f5fbb36daae8257d6c5c07db08ec5df0549ccf692b9fa218fd0ef7"),
-    },
-    Sha256Circuit {
-      preimage: vec![0u8; 2048],
-      digest: decode_hex("35c18d6c3cf49e42b3ffcb54ea04bdc16617efba0e673abc8c858257955005a5"),
-    },
-    Sha256Circuit {
-      preimage: vec![0u8; 4096],
-      digest: decode_hex("25349112d1bd5ba15e3e2d3effa01af1da02c097ce6208cdf28f34b74d35feb2"),
-    },
-    Sha256Circuit {
-      preimage: vec![0u8; 8192],
-      digest: decode_hex("22bc891155c7d423039a2206ed4a5342755948baeb13a54b61dbead7c3d3b8f6"),
-    },
-    Sha256Circuit {
-      preimage: vec![0u8; 16384],
-      digest: decode_hex("3fda713dc72ddcd42ce625c75f7e41d526d30647278a3dfcda95904e59ade7f1"),
-    },
-    Sha256Circuit {
-      preimage: vec![0u8; 32768],
-      digest: decode_hex("1e2091bd3e3cedffebb7316b52414fff82511cbd232561874a4ae11ae2040ac1"),
-    },
-    Sha256Circuit {
-      preimage: vec![0u8; 65536],
-      digest: decode_hex("0c33953975c438ce357912f27b0fbcf98bae6eb68a1a913386672ee406a4f479"),
-    },
+    Sha256Circuit::new(vec![0u8; 1 << 6]),
+    Sha256Circuit::new(vec![0u8; 1 << 7]),
+    Sha256Circuit::new(vec![0u8; 1 << 8]),
+    Sha256Circuit::new(vec![0u8; 1 << 9]),
+    Sha256Circuit::new(vec![0u8; 1 << 10]),
+    Sha256Circuit::new(vec![0u8; 1 << 11]),
+    Sha256Circuit::new(vec![0u8; 1 << 12]),
+    Sha256Circuit::new(vec![0u8; 1 << 13]),
+    Sha256Circuit::new(vec![0u8; 1 << 14]),
+    Sha256Circuit::new(vec![0u8; 1 << 15]),
+    Sha256Circuit::new(vec![0u8; 1 << 16]),
   ];
 
   for circuit_primary in circuits {

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -127,18 +127,6 @@ where
 
     z_out
   }
-
-  fn output(&self, z: &[F]) -> Vec<F> {
-    // sanity check
-    debug_assert_eq!(z[0], self.seq[0].x_i);
-    debug_assert_eq!(z[1], self.seq[0].y_i);
-
-    // compute output using advice
-    vec![
-      self.seq[self.seq.len() - 1].x_i_plus_1,
-      self.seq[self.seq.len() - 1].y_i_plus_1,
-    ]
-  }
 }
 
 fn main() {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -53,4 +53,7 @@ pub enum NovaError {
   /// returned when the consistency with public IO and assignment used fails
   #[error("IncorrectWitness")]
   IncorrectWitness,
+  /// return when error during synthesis
+  #[error("SynthesisError")]
+  SynthesisError,
 }

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -55,11 +55,11 @@ impl<G: Group> AllocatedR1CSInstance<G> {
 
   /// Absorb the provided instance in the RO
   pub fn absorb_in_ro(&self, ro: &mut G::ROCircuit) {
-    ro.absorb(self.W.x.clone());
-    ro.absorb(self.W.y.clone());
-    ro.absorb(self.W.is_infinity.clone());
-    ro.absorb(self.X0.clone());
-    ro.absorb(self.X1.clone());
+    ro.absorb(&self.W.x);
+    ro.absorb(&self.W.y);
+    ro.absorb(&self.W.is_infinity);
+    ro.absorb(&self.X0);
+    ro.absorb(&self.X1);
   }
 }
 
@@ -189,13 +189,13 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
     mut cs: CS,
     ro: &mut G::ROCircuit,
   ) -> Result<(), SynthesisError> {
-    ro.absorb(self.W.x.clone());
-    ro.absorb(self.W.y.clone());
-    ro.absorb(self.W.is_infinity.clone());
-    ro.absorb(self.E.x.clone());
-    ro.absorb(self.E.y.clone());
-    ro.absorb(self.E.is_infinity.clone());
-    ro.absorb(self.u.clone());
+    ro.absorb(&self.W.x);
+    ro.absorb(&self.W.y);
+    ro.absorb(&self.W.is_infinity);
+    ro.absorb(&self.E.x);
+    ro.absorb(&self.E.y);
+    ro.absorb(&self.E.is_infinity);
+    ro.absorb(&self.u);
 
     // Analyze X0 as limbs
     let X0_bn = self
@@ -210,7 +210,7 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
 
     // absorb each of the limbs of X[0]
     for limb in X0_bn.into_iter() {
-      ro.absorb(limb);
+      ro.absorb(&limb);
     }
 
     // Analyze X1 as limbs
@@ -226,7 +226,7 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
 
     // absorb each of the limbs of X[1]
     for limb in X1_bn.into_iter() {
-      ro.absorb(limb);
+      ro.absorb(&limb);
     }
 
     Ok(())
@@ -246,12 +246,12 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
   ) -> Result<AllocatedRelaxedR1CSInstance<G>, SynthesisError> {
     // Compute r:
     let mut ro = G::ROCircuit::new(ro_consts, NUM_FE_FOR_RO);
-    ro.absorb(params);
+    ro.absorb(&params);
     self.absorb_in_ro(cs.namespace(|| "absorb running instance"), &mut ro)?;
     u.absorb_in_ro(&mut ro);
-    ro.absorb(T.x.clone());
-    ro.absorb(T.y.clone());
-    ro.absorb(T.is_infinity.clone());
+    ro.absorb(&T.x);
+    ro.absorb(&T.y);
+    ro.absorb(&T.is_infinity);
     let r_bits = ro.squeeze(cs.namespace(|| "r bits"), NUM_CHALLENGE_BITS)?;
     let r = le_bits_to_num(cs.namespace(|| "r"), &r_bits)?;
 

--- a/src/provider/poseidon.rs
+++ b/src/provider/poseidon.rs
@@ -138,9 +138,9 @@ where
   }
 
   /// Absorb a new number into the state of the oracle
-  fn absorb(&mut self, e: AllocatedNum<Scalar>) {
+  fn absorb(&mut self, e: &AllocatedNum<Scalar>) {
     assert!(!self.squeezed, "Cannot absorb after squeezing");
-    self.state.push(e);
+    self.state.push(e.clone());
   }
 
   /// Compute a challenge by hashing the current state
@@ -233,7 +233,7 @@ mod tests {
       num_gadget
         .inputize(&mut cs.namespace(|| format!("input {i}")))
         .unwrap();
-      ro_gadget.absorb(num_gadget);
+      ro_gadget.absorb(&num_gadget);
     }
     let num = ro.squeeze(NUM_CHALLENGE_BITS);
     let num2_bits = ro_gadget.squeeze(&mut cs, NUM_CHALLENGE_BITS).unwrap();

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -201,7 +201,9 @@ mod tests {
 
       Ok(vec![y])
     }
+  }
 
+  impl<F: PrimeField> CubicCircuit<F> {
     fn output(&self, z: &[F]) -> Vec<F> {
       vec![z[0] * z[0] * z[0] + z[0] + F::from(5u64)]
     }

--- a/src/traits/circuit.rs
+++ b/src/traits/circuit.rs
@@ -8,7 +8,7 @@ pub trait StepCircuit<F: PrimeField>: Send + Sync + Clone {
   /// Return the the number of inputs or outputs of each step
   /// (this method is called only at circuit synthesis time)
   /// `synthesize` and `output` methods are expected to take as
-  /// input a vector of size equal to arity and output a vector of size equal to arity  
+  /// input a vector of size equal to arity and output a vector of size equal to arity
   fn arity(&self) -> usize;
 
   /// Sythesize the circuit for a computation step and return variable
@@ -18,9 +18,6 @@ pub trait StepCircuit<F: PrimeField>: Send + Sync + Clone {
     cs: &mut CS,
     z: &[AllocatedNum<F>],
   ) -> Result<Vec<AllocatedNum<F>>, SynthesisError>;
-
-  /// return the output of the step when provided with the step's input
-  fn output(&self, z: &[F]) -> Vec<F>;
 }
 
 /// A trivial step circuit that simply returns the input
@@ -43,9 +40,5 @@ where
     z: &[AllocatedNum<F>],
   ) -> Result<Vec<AllocatedNum<F>>, SynthesisError> {
     Ok(z.to_vec())
-  }
-
-  fn output(&self, z: &[F]) -> Vec<F> {
-    z.to_vec()
   }
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -159,7 +159,7 @@ pub trait ROCircuitTrait<Base: PrimeField> {
   fn new(constants: Self::Constants, num_absorbs: usize) -> Self;
 
   /// Adds a scalar to the internal state
-  fn absorb(&mut self, e: AllocatedNum<Base>);
+  fn absorb(&mut self, e: &AllocatedNum<Base>);
 
   /// Returns a challenge of `num_bits` by hashing the internal state
   fn squeeze<CS>(&mut self, cs: CS, num_bits: usize) -> Result<Vec<AllocatedBit>, SynthesisError>


### PR DESCRIPTION
## Change scope
- fine tune step circuit to optional `output` function, which potentially lead to duplicate logic with synthesis function.
- optimize RO trait to take reference, further optimize memory usage.