### PR TITLE
Rename bellperson to bellpepper everywhere.

### DIFF
--- a/src/bellpepper/mod.rs
+++ b/src/bellpepper/mod.rs
@@ -1,6 +1,6 @@
-//! Support for generating R1CS from [Bellperson].
+//! Support for generating R1CS from [Bellpepper].
 //!
-//! [Bellperson]: https://github.com/filecoin-project/bellperson
+//! [Bellpepper]: https://github.com/lurk-lab/bellpepper
 
 pub mod r1cs;
 pub mod shape_cs;
@@ -10,7 +10,7 @@ pub mod test_shape_cs;
 #[cfg(test)]
 mod tests {
   use crate::{
-    bellperson::{
+    bellpepper::{
       r1cs::{NovaShape, NovaWitness},
       shape_cs::ShapeCS,
       solver::SatisfyingAssignment,

--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -1,4 +1,4 @@
-//! Support for generating R1CS using bellperson.
+//! Support for generating R1CS using bellpepper.
 
 #![allow(non_snake_case)]
 

--- a/src/bellpepper/shape_cs.rs
+++ b/src/bellpepper/shape_cs.rs
@@ -1,4 +1,4 @@
-//! Support for generating R1CS shape using bellperson.
+//! Support for generating R1CS shape using bellpepper.
 
 use crate::traits::Group;
 use bellpepper_core::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};

--- a/src/bellpepper/solver.rs
+++ b/src/bellpepper/solver.rs
@@ -1,4 +1,4 @@
-//! Support for generating R1CS witness using bellperson.
+//! Support for generating R1CS witness using bellpepper.
 
 use crate::traits::Group;
 use ff::Field;

--- a/src/bellpepper/test_shape_cs.rs
+++ b/src/bellpepper/test_shape_cs.rs
@@ -1,4 +1,4 @@
-//! Support for generating R1CS shape with using bellperson.
+//! Support for generating R1CS shape using bellpepper.
 //! `TestShapeCS` implements a superset of `ShapeCS`, adding non-trivial namespace support for use in testing.
 
 use std::{

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -368,14 +368,14 @@ impl<'a, G: Group, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::bellperson::{solver::SatisfyingAssignment, test_shape_cs::TestShapeCS};
+  use crate::bellpepper::{solver::SatisfyingAssignment, test_shape_cs::TestShapeCS};
   type PastaG1 = pasta_curves::pallas::Point;
   type PastaG2 = pasta_curves::vesta::Point;
 
   use crate::constants::{BN_LIMB_WIDTH, BN_N_LIMBS};
   use crate::provider;
   use crate::{
-    bellperson::r1cs::{NovaShape, NovaWitness},
+    bellpepper::r1cs::{NovaShape, NovaWitness},
     gadgets::utils::scalar_as_base,
     provider::poseidon::PoseidonConstantsCircuit,
     traits::{circuit::TrivialTestCircuit, ROConstantsTrait},

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -748,7 +748,7 @@ where
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::bellperson::{
+  use crate::bellpepper::{
     r1cs::{NovaShape, NovaWitness},
     {solver::SatisfyingAssignment, test_shape_cs::TestShapeCS},
   };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 #![forbid(unsafe_code)]
 
 // private modules
-mod bellperson;
+mod bellpepper;
 mod circuit;
 mod constants;
 mod nifs;
@@ -25,7 +25,7 @@ pub mod provider;
 pub mod spartan;
 pub mod traits;
 
-use crate::bellperson::{
+use crate::bellpepper::{
   r1cs::{NovaShape, NovaWitness},
   shape_cs::ShapeCS,
   solver::SatisfyingAssignment,

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -128,7 +128,7 @@ mod tests {
 
   type G = pasta_curves::pallas::Point;
 
-  fn synthesize_tiny_r1cs_bellperson<Scalar: PrimeField, CS: ConstraintSystem<Scalar>>(
+  fn synthesize_tiny_r1cs_bellpepper<Scalar: PrimeField, CS: ConstraintSystem<Scalar>>(
     cs: &mut CS,
     x_val: Option<Scalar>,
   ) -> Result<(), SynthesisError> {
@@ -161,11 +161,11 @@ mod tests {
     Ok(())
   }
 
-  fn test_tiny_r1cs_bellperson_with<G>()
+  fn test_tiny_r1cs_bellpepper_with<G>()
   where
     G: Group,
   {
-    use crate::bellperson::{
+    use crate::bellpepper::{
       r1cs::{NovaShape, NovaWitness},
       solver::SatisfyingAssignment,
       test_shape_cs::TestShapeCS,
@@ -173,14 +173,14 @@ mod tests {
 
     // First create the shape
     let mut cs: TestShapeCS<G> = TestShapeCS::new();
-    let _ = synthesize_tiny_r1cs_bellperson(&mut cs, None);
+    let _ = synthesize_tiny_r1cs_bellpepper(&mut cs, None);
     let (shape, ck) = cs.r1cs_shape();
     let ro_consts =
       <<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants::new();
 
     // Now get the instance and assignment for one instance
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();
-    let _ = synthesize_tiny_r1cs_bellperson(&mut cs, Some(G::Scalar::from(5)));
+    let _ = synthesize_tiny_r1cs_bellpepper(&mut cs, Some(G::Scalar::from(5)));
     let (U1, W1) = cs.r1cs_instance_and_witness(&shape, &ck).unwrap();
 
     // Make sure that the first instance is satisfiable
@@ -188,7 +188,7 @@ mod tests {
 
     // Now get the instance and assignment for second instance
     let mut cs: SatisfyingAssignment<G> = SatisfyingAssignment::new();
-    let _ = synthesize_tiny_r1cs_bellperson(&mut cs, Some(G::Scalar::from(135)));
+    let _ = synthesize_tiny_r1cs_bellpepper(&mut cs, Some(G::Scalar::from(135)));
     let (U2, W2) = cs.r1cs_instance_and_witness(&shape, &ck).unwrap();
 
     // Make sure that the second instance is satisfiable
@@ -208,10 +208,10 @@ mod tests {
   }
 
   #[test]
-  fn test_tiny_r1cs_bellperson() {
-    test_tiny_r1cs_bellperson_with::<G>();
+  fn test_tiny_r1cs_bellpepper() {
+    test_tiny_r1cs_bellpepper_with::<G>();
 
-    test_tiny_r1cs_bellperson_with::<crate::provider::bn256_grumpkin::bn256::Point>();
+    test_tiny_r1cs_bellpepper_with::<crate::provider::bn256_grumpkin::bn256::Point>();
   }
 
   #[allow(clippy::too_many_arguments)]

--- a/src/provider/poseidon.rs
+++ b/src/provider/poseidon.rs
@@ -201,7 +201,7 @@ mod tests {
   use super::*;
   use crate::provider::bn256_grumpkin::bn256;
   use crate::{
-    bellperson::solver::SatisfyingAssignment, constants::NUM_CHALLENGE_BITS,
+    bellpepper::solver::SatisfyingAssignment, constants::NUM_CHALLENGE_BITS,
     gadgets::utils::le_bits_to_num, traits::Group,
   };
   use ff::Field;

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -2,7 +2,7 @@
 //! In particular, it supports any SNARK that implements RelaxedR1CSSNARK trait
 //! (e.g., with the SNARKs implemented in ppsnark.rs or snark.rs).
 use crate::{
-  bellperson::{
+  bellpepper::{
     r1cs::{NovaShape, NovaWitness},
     shape_cs::ShapeCS,
     solver::SatisfyingAssignment,


### PR DESCRIPTION
This PR completes the transition from bellperson to bellpepper, renaming all references in code, comments, and files/directories.