### PR TITLE
Various refactorings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ sha3 = "0.10"
 rayon = "1.7"
 rand_core = { version = "0.6", default-features = false }
 rand_chacha = "0.3"
-itertools = "0.11"
 subtle = "2.5"
 pasta_curves = { version = "0.5", features = ["repr-c", "serde"] }
 neptune = { version = "11.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/Microsoft/Nova"
 license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
+rust-version="1.67.1"
 
 [dependencies]
 bellpepper-core = { version="0.2.0", default-features = false }

--- a/examples/signature.rs
+++ b/examples/signature.rs
@@ -178,7 +178,7 @@ impl<E: AsRef<[u64]>> Iterator for BitIterator<E> {
 // Synthesize a bit representation into circuit gadgets.
 pub fn synthesize_bits<F: PrimeField, CS: ConstraintSystem<F>>(
   cs: &mut CS,
-  bits: Option<Vec<bool>>,
+  bits: &Option<Vec<bool>>,
 ) -> Result<Vec<AllocatedBit>, SynthesisError> {
   (0..F::NUM_BITS)
     .map(|i| {
@@ -192,10 +192,10 @@ pub fn synthesize_bits<F: PrimeField, CS: ConstraintSystem<F>>(
 
 pub fn verify_signature<G: NovaGroup, CS: ConstraintSystem<G::Base>>(
   cs: &mut CS,
-  pk: AllocatedPoint<G>,
-  r: AllocatedPoint<G>,
-  s_bits: Vec<AllocatedBit>,
-  c_bits: Vec<AllocatedBit>,
+  pk: &AllocatedPoint<G>,
+  r: &AllocatedPoint<G>,
+  s_bits: &[AllocatedBit],
+  c_bits: &[AllocatedBit],
 ) -> Result<(), SynthesisError> {
   let g = AllocatedPoint::<G>::alloc(
     cs.namespace(|| "g"),
@@ -232,9 +232,9 @@ pub fn verify_signature<G: NovaGroup, CS: ConstraintSystem<G::Base>>(
     |lc| lc + (G::Base::from_str_vartime("2").unwrap(), CS::one()),
   );
 
-  let sg = g.scalar_mul(cs.namespace(|| "[s]G"), &s_bits)?;
-  let cpk = pk.scalar_mul(&mut cs.namespace(|| "[c]PK"), &c_bits)?;
-  let rcpk = cpk.add(&mut cs.namespace(|| "R + [c]PK"), &r)?;
+  let sg = g.scalar_mul(cs.namespace(|| "[s]G"), s_bits)?;
+  let cpk = pk.scalar_mul(&mut cs.namespace(|| "[c]PK"), c_bits)?;
+  let rcpk = cpk.add(&mut cs.namespace(|| "R + [c]PK"), r)?;
 
   let (rcpk_x, rcpk_y, _) = rcpk.get_coordinates();
   let (sg_x, sg_y, _) = sg.get_coordinates();
@@ -297,16 +297,16 @@ fn main() {
       .map(|b| *b)
       .collect::<Vec<bool>>();
 
-    synthesize_bits(&mut cs.namespace(|| "s bits"), Some(s_bits)).unwrap()
+    synthesize_bits(&mut cs.namespace(|| "s bits"), &Some(s_bits)).unwrap()
   };
   let c = {
     let c_bits = c.to_le_bits().iter().map(|b| *b).collect::<Vec<bool>>();
 
-    synthesize_bits(&mut cs.namespace(|| "c bits"), Some(c_bits)).unwrap()
+    synthesize_bits(&mut cs.namespace(|| "c bits"), &Some(c_bits)).unwrap()
   };
 
   // Check the signature was signed by the correct sk using the pk
-  verify_signature(&mut cs, pk, r, s, c).unwrap();
+  verify_signature(&mut cs, &pk, &r, &s, &c).unwrap();
 
   assert!(cs.is_satisfied());
 }

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -235,7 +235,7 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
   pub fn fold_with_r1cs<CS: ConstraintSystem<<G as Group>::Base>>(
     &self,
     mut cs: CS,
-    params: AllocatedNum<G::Base>, // hash of R1CSShape of F'
+    params: &AllocatedNum<G::Base>, // hash of R1CSShape of F'
     u: &AllocatedR1CSInstance<G>,
     T: &AllocatedPoint<G>,
     ro_consts: ROConstantsCircuit<G>,
@@ -244,7 +244,7 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
   ) -> Result<AllocatedRelaxedR1CSInstance<G>, SynthesisError> {
     // Compute r:
     let mut ro = G::ROCircuit::new(ro_consts, NUM_FE_FOR_RO);
-    ro.absorb(&params);
+    ro.absorb(params);
     self.absorb_in_ro(cs.namespace(|| "absorb running instance"), &mut ro)?;
     u.absorb_in_ro(&mut ro);
     ro.absorb(&T.x);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -887,14 +887,14 @@ mod tests {
     }
   }
 
-  fn test_pp_digest_with<G1, G2, T1, T2>(circuit1: T1, circuit2: T2, expected: &str)
+  fn test_pp_digest_with<G1, G2, T1, T2>(circuit1: &T1, circuit2: &T2, expected: &str)
   where
     G1: Group<Base = <G2 as Group>::Scalar>,
     G2: Group<Base = <G1 as Group>::Scalar>,
     T1: StepCircuit<G1::Scalar>,
     T2: StepCircuit<G2::Scalar>,
   {
-    let pp = PublicParams::<G1, G2, T1, T2>::setup(&circuit1, &circuit2);
+    let pp = PublicParams::<G1, G2, T1, T2>::setup(circuit1, circuit2);
 
     let digest_str = pp
       .digest
@@ -915,14 +915,14 @@ mod tests {
     let cubic_circuit1 = CubicCircuit::<<G1 as Group>::Scalar>::default();
 
     test_pp_digest_with::<G1, G2, _, _>(
-      trivial_circuit1,
-      trivial_circuit2.clone(),
+      &trivial_circuit1,
+      &trivial_circuit2,
       "39a4ea9dd384346fdeb6b5857c7be56fa035153b616d55311f3191dfbceea603",
     );
 
     test_pp_digest_with::<G1, G2, _, _>(
-      cubic_circuit1,
-      trivial_circuit2,
+      &cubic_circuit1,
+      &trivial_circuit2,
       "3f7b25f589f2da5ab26254beba98faa54f6442ebf5fa5860caf7b08b576cab00",
     );
 
@@ -933,13 +933,13 @@ mod tests {
     let cubic_circuit1_grumpkin = CubicCircuit::<<bn256::Point as Group>::Scalar>::default();
 
     test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _>(
-      trivial_circuit1_grumpkin,
-      trivial_circuit2_grumpkin.clone(),
+      &trivial_circuit1_grumpkin,
+      &trivial_circuit2_grumpkin,
       "967acca1d6b4731cd65d4072c12bbaca9648f24d7bcc2877aee720e4265d4302",
     );
     test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _>(
-      cubic_circuit1_grumpkin,
-      trivial_circuit2_grumpkin,
+      &cubic_circuit1_grumpkin,
+      &trivial_circuit2_grumpkin,
       "44629f26a78bf6c4e3077f940232050d1793d304fdba5e221d0cf66f76a37903",
     );
   }

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -275,7 +275,7 @@ where
     let mut a_vec = W.a_vec.to_vec();
     let mut b_vec = U.b_vec.to_vec();
     let mut ck = ck;
-    for _i in 0..(U.b_vec.len() as f64).log2() as usize {
+    for _i in 0..usize::try_from(U.b_vec.len().ilog2()).unwrap() {
       let (L, R, a_vec_folded, b_vec_folded, ck_folded) =
         prove_inner(&a_vec, &b_vec, &ck, transcript)?;
       L_vec.push(L);

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use core::{cmp::max, marker::PhantomData};
 use ff::Field;
-use itertools::concat;
+
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -193,7 +193,7 @@ impl<G: Group> R1CSShape<G> {
 
     // verify if Az * Bz = u*Cz + E
     let res_eq: bool = {
-      let z = concat(vec![W.W.clone(), vec![U.u], U.X.clone()]);
+      let z = [W.W.clone(), vec![U.u], U.X.clone()].concat();
       let (Az, Bz, Cz) = self.multiply_vec(&z)?;
       assert_eq!(Az.len(), self.num_cons);
       assert_eq!(Bz.len(), self.num_cons);
@@ -232,7 +232,7 @@ impl<G: Group> R1CSShape<G> {
 
     // verify if Az * Bz = u*Cz
     let res_eq: bool = {
-      let z = concat(vec![W.W.clone(), vec![G::Scalar::ONE], U.X.clone()]);
+      let z = [W.W.clone(), vec![G::Scalar::ONE], U.X.clone()].concat();
       let (Az, Bz, Cz) = self.multiply_vec(&z)?;
       assert_eq!(Az.len(), self.num_cons);
       assert_eq!(Bz.len(), self.num_cons);
@@ -266,12 +266,12 @@ impl<G: Group> R1CSShape<G> {
     W2: &R1CSWitness<G>,
   ) -> Result<(Vec<G::Scalar>, Commitment<G>), NovaError> {
     let (AZ_1, BZ_1, CZ_1) = {
-      let Z1 = concat(vec![W1.W.clone(), vec![U1.u], U1.X.clone()]);
+      let Z1 = [W1.W.clone(), vec![U1.u], U1.X.clone()].concat();
       self.multiply_vec(&Z1)?
     };
 
     let (AZ_2, BZ_2, CZ_2) = {
-      let Z2 = concat(vec![W2.W.clone(), vec![G::Scalar::ONE], U2.X.clone()]);
+      let Z2 = [W2.W.clone(), vec![G::Scalar::ONE], U2.X.clone()].concat();
       self.multiply_vec(&Z2)?
     };
 

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -37,8 +37,8 @@ impl<G: Group> PolyEvalWitness<G> {
     if let Some(n) = W.iter().map(|w| w.p.len()).max() {
       W.iter()
         .map(|w| {
-          let mut p = w.p.clone();
-          p.resize(n, G::Scalar::ZERO);
+          let mut p = vec![G::Scalar::ZERO; n];
+          p[..w.p.len()].copy_from_slice(&w.p);
           PolyEvalWitness { p }
         })
         .collect()

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -105,7 +105,7 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
   pub fn new(Z: Vec<Scalar>) -> Self {
     assert_eq!(Z.len(), (2_usize).pow((Z.len() as f64).log2() as u32));
     MultilinearPolynomial {
-      num_vars: (Z.len() as f64).log2() as usize,
+      num_vars: usize::try_from(Z.len().ilog2()).unwrap(),
       Z,
     }
   }

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 use core::{cmp::max, marker::PhantomData};
 use ff::{Field, PrimeField};
-use itertools::concat;
+
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -891,7 +891,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
     transcript.absorb(b"U", U);
 
     // compute the full satisfying assignment by concatenating W.W, U.u, and U.X
-    let z = concat(vec![W.W.clone(), vec![U.u], U.X.clone()]);
+    let z = [W.W.clone(), vec![U.u], U.X.clone()].concat();
 
     // compute Az, Bz, Cz
     let (mut Az, mut Bz, mut Cz) = pk.S.multiply_vec(&z)?;

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -1781,7 +1781,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
             .map(|i| (i + 1, U.X[i]))
             .collect::<Vec<(usize, G::Scalar)>>(),
         );
-        SparsePolynomial::new((vk.num_vars as f64).log2() as usize, poly_X)
+        SparsePolynomial::new(usize::try_from(vk.num_vars.ilog2()).unwrap(), poly_X)
           .evaluate(&r_prod_unpad[1..])
       };
       let eval_Z =

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -112,8 +112,8 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
     let mut z = [W.W.clone(), vec![U.u], U.X.clone()].concat();
 
     let (num_rounds_x, num_rounds_y) = (
-      (pk.S.num_cons as f64).log2() as usize,
-      ((pk.S.num_vars as f64).log2() as usize + 1),
+      usize::try_from(pk.S.num_cons.ilog2()).unwrap(),
+      (usize::try_from(pk.S.num_vars.ilog2()).unwrap() + 1),
     );
 
     // outer sum-check
@@ -350,8 +350,8 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
     transcript.absorb(b"U", U);
 
     let (num_rounds_x, num_rounds_y) = (
-      (vk.S.num_cons as f64).log2() as usize,
-      ((vk.S.num_vars as f64).log2() as usize + 1),
+      usize::try_from(vk.S.num_cons.ilog2()).unwrap(),
+      (usize::try_from(vk.S.num_vars.ilog2()).unwrap() + 1),
     );
 
     // outer sum-check
@@ -405,7 +405,8 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
             .map(|i| (i + 1, U.X[i]))
             .collect::<Vec<(usize, G::Scalar)>>(),
         );
-        SparsePolynomial::new((vk.S.num_vars as f64).log2() as usize, poly_X).evaluate(&r_y[1..])
+        SparsePolynomial::new(usize::try_from(vk.S.num_vars.ilog2()).unwrap(), poly_X)
+          .evaluate(&r_y[1..])
       };
       (G::Scalar::ONE - r_y[0]) * self.eval_W + r_y[0] * eval_X
     };

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -20,7 +20,7 @@ use crate::{
   Commitment, CommitmentKey,
 };
 use ff::Field;
-use itertools::concat;
+
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -109,7 +109,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G
     transcript.absorb(b"U", U);
 
     // compute the full satisfying assignment by concatenating W.W, U.u, and U.X
-    let mut z = concat(vec![W.W.clone(), vec![U.u], U.X.clone()]);
+    let mut z = [W.W.clone(), vec![U.u], U.X.clone()].concat();
 
     let (num_rounds_x, num_rounds_y) = (
       (pk.S.num_cons as f64).log2() as usize,

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -318,17 +318,15 @@ impl<Scalar: PrimeField> UniPoly<Scalar> {
   pub fn from_evals(evals: &[Scalar]) -> Self {
     // we only support degree-2 or degree-3 univariate polynomials
     assert!(evals.len() == 3 || evals.len() == 4);
+    let two_inv = Scalar::from(2).invert().unwrap();
     let coeffs = if evals.len() == 3 {
       // ax^2 + bx + c
-      let two_inv = Scalar::from(2).invert().unwrap();
-
       let c = evals[0];
       let a = two_inv * (evals[2] - evals[1] - evals[1] + c);
       let b = evals[1] - c - a;
       vec![c, b, a]
     } else {
       // ax^3 + bx^2 + cx + d
-      let two_inv = Scalar::from(2).invert().unwrap();
       let six_inv = Scalar::from(6).invert().unwrap();
 
       let d = evals[0];


### PR DESCRIPTION
The individual commit messages should detail the changes:
- remove itertools, only used for a function that's available in the std,
- remove a few needless pass-by-value instances,
- remove the roundtrip to f64 when computing a log2, replaces by the std `ilog2`,
- refactor padding to avoid reallocation,
- tweak a constant definition.