### PR TITLE
Simplifications to trait structures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ bitvec = "1.0"
 byteorder = "1.4.3"
 thiserror = "1.0"
 halo2curves = { version = "0.1.0", features = ["derive_serde"] }
+group = "0.13.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { version = "0.1.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ bincode = "1.3"
 bitvec = "1.0"
 byteorder = "1.4.3"
 thiserror = "1.0"
-halo2curves = { version = "0.1.0", features = ["derive_serde"] }
+halo2curves = { version = "0.4.0", features = ["derive_serde"] }
 group = "0.13.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -233,7 +233,7 @@ where
   pub fn new(num_cons: usize) -> Self {
     Self {
       num_cons,
-      _p: Default::default(),
+      _p: PhantomData,
     }
   }
 }

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -45,7 +45,7 @@ where
   pub fn new(num_cons: usize) -> Self {
     Self {
       num_cons,
-      _p: Default::default(),
+      _p: PhantomData,
     }
   }
 }

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -136,7 +136,7 @@ where
   pub fn new(num_cons: usize) -> Self {
     Self {
       num_cons,
-      _p: Default::default(),
+      _p: PhantomData,
     }
   }
 }

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -34,7 +34,7 @@ impl<Scalar: PrimeField + PrimeFieldBits> Sha256Circuit<Scalar> {
   pub fn new(preimage: Vec<u8>) -> Self {
     Self {
       preimage,
-      _p: Default::default(),
+      _p: PhantomData,
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1087,10 +1087,8 @@ mod tests {
     G1: Group<Base = <G2 as Group>::Scalar>,
     G2: Group<Base = <G1 as Group>::Scalar>,
     // this is due to the reliance on CommitmentKeyExtTrait as a bound in ipa_pc
-    <G1::CE as CommitmentEngineTrait<G1>>::CommitmentKey:
-      CommitmentKeyExtTrait<G1, CE = <G1 as Group>::CE>,
-    <G2::CE as CommitmentEngineTrait<G2>>::CommitmentKey:
-      CommitmentKeyExtTrait<G2, CE = <G2 as Group>::CE>,
+    <G1::CE as CommitmentEngineTrait<G1>>::CommitmentKey: CommitmentKeyExtTrait<G1>,
+    <G2::CE as CommitmentEngineTrait<G2>>::CommitmentKey: CommitmentKeyExtTrait<G2>,
   {
     let circuit_primary = TrivialTestCircuit::default();
     let circuit_secondary = CubicCircuit::default();
@@ -1182,10 +1180,8 @@ mod tests {
     G1: Group<Base = <G2 as Group>::Scalar>,
     G2: Group<Base = <G1 as Group>::Scalar>,
     // this is due to the reliance on CommitmentKeyExtTrait as a bound in ipa_pc
-    <G1::CE as CommitmentEngineTrait<G1>>::CommitmentKey:
-      CommitmentKeyExtTrait<G1, CE = <G1 as Group>::CE>,
-    <G2::CE as CommitmentEngineTrait<G2>>::CommitmentKey:
-      CommitmentKeyExtTrait<G2, CE = <G2 as Group>::CE>,
+    <G1::CE as CommitmentEngineTrait<G1>>::CommitmentKey: CommitmentKeyExtTrait<G1>,
+    <G2::CE as CommitmentEngineTrait<G2>>::CommitmentKey: CommitmentKeyExtTrait<G2>,
   {
     let circuit_primary = TrivialTestCircuit::default();
     let circuit_secondary = CubicCircuit::default();
@@ -1280,10 +1276,8 @@ mod tests {
     G1: Group<Base = <G2 as Group>::Scalar>,
     G2: Group<Base = <G1 as Group>::Scalar>,
     // this is due to the reliance on CommitmentKeyExtTrait as a bound in ipa_pc
-    <G1::CE as CommitmentEngineTrait<G1>>::CommitmentKey:
-      CommitmentKeyExtTrait<G1, CE = <G1 as Group>::CE>,
-    <G2::CE as CommitmentEngineTrait<G2>>::CommitmentKey:
-      CommitmentKeyExtTrait<G2, CE = <G2 as Group>::CE>,
+    <G1::CE as CommitmentEngineTrait<G1>>::CommitmentKey: CommitmentKeyExtTrait<G1>,
+    <G2::CE as CommitmentEngineTrait<G2>>::CommitmentKey: CommitmentKeyExtTrait<G2>,
   {
     // y is a non-deterministic advice representing the fifth root of the input at a step.
     #[derive(Clone, Debug)]

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -72,7 +72,7 @@ impl<G: Group> NIFS<G> {
     Ok((
       Self {
         comm_T: comm_T.compress(),
-        _p: Default::default(),
+        _p: PhantomData,
       },
       (U, W),
     ))

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -10,13 +10,11 @@ use crate::{
 };
 use digest::{ExtendableOutput, Update};
 use ff::{FromUniformBytes, PrimeField};
+use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup, GroupEncoding};
 use num_bigint::BigInt;
 use num_traits::Num;
-use pasta_curves::{
-  self,
-  arithmetic::{CurveAffine, CurveExt},
-  group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup, GroupEncoding},
-};
+// Remove this when https://github.com/zcash/pasta_curves/issues/41 resolves
+use pasta_curves::arithmetic::{CurveAffine, CurveExt};
 use rayon::prelude::*;
 use sha3::Shake256;
 use std::io::Read;

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -50,13 +50,12 @@ where
   G: Group,
   CommitmentKey<G>: CommitmentKeyExtTrait<G>,
 {
-  type CE = G::CE;
   type ProverKey = ProverKey<G>;
   type VerifierKey = VerifierKey<G>;
   type EvaluationArgument = EvaluationArgument<G>;
 
   fn setup(
-    ck: &<Self::CE as CommitmentEngineTrait<G>>::CommitmentKey,
+    ck: &<<G as Group>::CE as CommitmentEngineTrait<G>>::CommitmentKey,
   ) -> (Self::ProverKey, Self::VerifierKey) {
     let pk = ProverKey {
       ck_s: G::CE::setup(b"ipa", 1),

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -48,7 +48,7 @@ pub struct EvaluationEngine<G: Group> {
 impl<G> EvaluationEngineTrait<G> for EvaluationEngine<G>
 where
   G: Group,
-  CommitmentKey<G>: CommitmentKeyExtTrait<G, CE = G::CE>,
+  CommitmentKey<G>: CommitmentKeyExtTrait<G>,
 {
   type CE = G::CE;
   type ProverKey = ProverKey<G>;
@@ -175,7 +175,7 @@ struct InnerProductArgument<G: Group> {
 impl<G> InnerProductArgument<G>
 where
   G: Group,
-  CommitmentKey<G>: CommitmentKeyExtTrait<G, CE = G::CE>,
+  CommitmentKey<G>: CommitmentKeyExtTrait<G>,
 {
   const fn protocol_name() -> &'static [u8] {
     b"IPA"

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -169,7 +169,6 @@ struct InnerProductArgument<G: Group> {
   L_vec: Vec<CompressedCommitment<G>>,
   R_vec: Vec<CompressedCommitment<G>>,
   a_hat: G::Scalar,
-  _p: PhantomData<G>,
 }
 
 impl<G> InnerProductArgument<G>
@@ -290,7 +289,6 @@ where
       L_vec,
       R_vec,
       a_hat: a_vec[0],
-      _p: Default::default(),
     })
   }
 

--- a/src/provider/keccak.rs
+++ b/src/provider/keccak.rs
@@ -55,7 +55,7 @@ impl<G: Group> TranscriptEngineTrait<G> for Keccak256Transcript<G> {
       round: 0u16,
       state: output,
       transcript: keccak_instance,
-      _p: Default::default(),
+      _p: PhantomData,
     }
   }
 

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -203,9 +203,6 @@ impl<G: Group> CommitmentEngineTrait<G> for CommitmentEngine<G> {
 
 /// A trait listing properties of a commitment key that can be managed in a divide-and-conquer fashion
 pub trait CommitmentKeyExtTrait<G: Group> {
-  /// Holds the type of the commitment engine
-  type CE: CommitmentEngineTrait<G>;
-
   /// Splits the commitment key into two pieces at a specified point
   fn split_at(&self, n: usize) -> (Self, Self)
   where
@@ -222,15 +219,13 @@ pub trait CommitmentKeyExtTrait<G: Group> {
 
   /// Reinterprets commitments as commitment keys
   fn reinterpret_commitments_as_ck(
-    c: &[<<<Self as CommitmentKeyExtTrait<G>>::CE as CommitmentEngineTrait<G>>::Commitment as CommitmentTrait<G>>::CompressedCommitment],
+    c: &[<<<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment as CommitmentTrait<G>>::CompressedCommitment],
   ) -> Result<Self, NovaError>
   where
     Self: Sized;
 }
 
-impl<G: Group> CommitmentKeyExtTrait<G> for CommitmentKey<G> {
-  type CE = CommitmentEngine<G>;
-
+impl<G: Group<CE = CommitmentEngine<G>>> CommitmentKeyExtTrait<G> for CommitmentKey<G> {
   fn split_at(&self, n: usize) -> (CommitmentKey<G>, CommitmentKey<G>) {
     (
       CommitmentKey {

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -19,7 +19,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CommitmentKey<G: Group> {
   ck: Vec<G::PreprocessedGroupElement>,
-  _p: PhantomData<G>,
 }
 
 /// A type that holds a commitment
@@ -191,7 +190,6 @@ impl<G: Group> CommitmentEngineTrait<G> for CommitmentEngine<G> {
   fn setup(label: &'static [u8], n: usize) -> Self::CommitmentKey {
     Self::CommitmentKey {
       ck: G::from_label(label, n.next_power_of_two()),
-      _p: Default::default(),
     }
   }
 
@@ -237,11 +235,9 @@ impl<G: Group> CommitmentKeyExtTrait<G> for CommitmentKey<G> {
     (
       CommitmentKey {
         ck: self.ck[0..n].to_vec(),
-        _p: Default::default(),
       },
       CommitmentKey {
         ck: self.ck[n..].to_vec(),
-        _p: Default::default(),
       },
     )
   }
@@ -252,10 +248,7 @@ impl<G: Group> CommitmentKeyExtTrait<G> for CommitmentKey<G> {
       c.extend(other.ck.clone());
       c
     };
-    CommitmentKey {
-      ck,
-      _p: Default::default(),
-    }
+    CommitmentKey { ck }
   }
 
   // combines the left and right halves of `self` using `w1` and `w2` as the weights
@@ -271,10 +264,7 @@ impl<G: Group> CommitmentKeyExtTrait<G> for CommitmentKey<G> {
       })
       .collect();
 
-    CommitmentKey {
-      ck,
-      _p: Default::default(),
-    }
+    CommitmentKey { ck }
   }
 
   /// Scales each element in `self` by `r`
@@ -286,10 +276,7 @@ impl<G: Group> CommitmentKeyExtTrait<G> for CommitmentKey<G> {
       .map(|g| G::vartime_multiscalar_mul(&[*r], &[g]).preprocessed())
       .collect();
 
-    CommitmentKey {
-      ck: ck_scaled,
-      _p: Default::default(),
-    }
+    CommitmentKey { ck: ck_scaled }
   }
 
   /// reinterprets a vector of commitments as a set of generators
@@ -302,9 +289,6 @@ impl<G: Group> CommitmentKeyExtTrait<G> for CommitmentKey<G> {
       .into_par_iter()
       .map(|i| d[i].comm.preprocessed())
       .collect();
-    Ok(CommitmentKey {
-      ck,
-      _p: Default::default(),
-    })
+    Ok(CommitmentKey { ck })
   }
 }

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -134,7 +134,7 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
     Ok(DirectSNARK {
       comm_W: u.comm_W,
       snark,
-      _p: Default::default(),
+      _p: PhantomData,
     })
   }
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -41,7 +41,7 @@ impl<Scalar: PrimeField> IdentityPolynomial<Scalar> {
   pub fn new(ell: usize) -> Self {
     IdentityPolynomial {
       ell,
-      _p: Default::default(),
+      _p: PhantomData,
     }
   }
 

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -644,7 +644,7 @@ impl<G: Group> SumcheckEngine<G> for InnerSumcheckInstance<G> {
 /// A type that represents the prover's key
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> {
+pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G>> {
   pk_ee: EE::ProverKey,
   S: R1CSShape<G>,
   S_repr: R1CSShapeSparkRepr<G>,
@@ -655,7 +655,7 @@ pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> {
 /// A type that represents the verifier's key
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> {
+pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G>> {
   num_cons: usize,
   num_vars: usize,
   vk_ee: EE::VerifierKey,
@@ -668,7 +668,7 @@ pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> {
 /// the commitment to a vector viewed as a polynomial commitment
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> {
+pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G>> {
   // commitment to oracles
   comm_Az: CompressedCommitment<G>,
   comm_Bz: CompressedCommitment<G>,
@@ -721,7 +721,7 @@ pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> 
   eval_arg: EE::EvaluationArgument,
 }
 
-impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARK<G, EE> {
+impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARK<G, EE> {
   fn prove_inner<T1, T2, T3>(
     mem: &mut T1,
     outer: &mut T2,
@@ -829,9 +829,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARK<G, EE>
   }
 }
 
-impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G>
-  for RelaxedR1CSSNARK<G, EE>
-{
+impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for RelaxedR1CSSNARK<G, EE> {
   type ProverKey = ProverKey<G, EE>;
   type VerifierKey = VerifierKey<G, EE>;
 

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 /// A type that represents the prover's key
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> {
+pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G>> {
   pk_ee: EE::ProverKey,
   S: R1CSShape<G>,
   vk_digest: G::Scalar, // digest of the verifier's key
@@ -36,7 +36,7 @@ pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> {
 /// A type that represents the verifier's key
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> {
+pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G>> {
   vk_ee: EE::VerifierKey,
   S: R1CSShape<G>,
   digest: G::Scalar,
@@ -47,7 +47,7 @@ pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> {
 /// the commitment to a vector viewed as a polynomial commitment
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> {
+pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G>> {
   sc_proof_outer: SumcheckProof<G>,
   claims_outer: (G::Scalar, G::Scalar, G::Scalar),
   eval_E: G::Scalar,
@@ -58,9 +58,7 @@ pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> 
   eval_arg: EE::EvaluationArgument,
 }
 
-impl<G: Group, EE: EvaluationEngineTrait<G, CE = G::CE>> RelaxedR1CSSNARKTrait<G>
-  for RelaxedR1CSSNARK<G, EE>
-{
+impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for RelaxedR1CSSNARK<G, EE> {
   type ProverKey = ProverKey<G, EE>;
   type VerifierKey = VerifierKey<G, EE>;
 

--- a/src/traits/commitment.rs
+++ b/src/traits/commitment.rs
@@ -73,9 +73,7 @@ pub trait CommitmentTrait<G: Group>:
 }
 
 /// A trait that ties different pieces of the commitment generation together
-pub trait CommitmentEngineTrait<G: Group>:
-  Clone + Send + Sync + Serialize + for<'de> Deserialize<'de>
-{
+pub trait CommitmentEngineTrait<G: Group>: Clone + Send + Sync {
   /// Holds the type of the commitment key
   type CommitmentKey: Clone + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de>;
 

--- a/src/traits/evaluation.rs
+++ b/src/traits/evaluation.rs
@@ -9,9 +9,6 @@ use serde::{Deserialize, Serialize};
 
 /// A trait that ties different pieces of the commitment evaluation together
 pub trait EvaluationEngineTrait<G: Group>: Clone + Send + Sync {
-  /// A type that holds the associated commitment engine
-  type CE: CommitmentEngineTrait<G>;
-
   /// A type that holds the prover key
   type ProverKey: Clone + Send + Sync + Serialize + for<'de> Deserialize<'de>;
 
@@ -23,15 +20,15 @@ pub trait EvaluationEngineTrait<G: Group>: Clone + Send + Sync {
 
   /// A method to perform any additional setup needed to produce proofs of evaluations
   fn setup(
-    ck: &<Self::CE as CommitmentEngineTrait<G>>::CommitmentKey,
+    ck: &<<G as Group>::CE as CommitmentEngineTrait<G>>::CommitmentKey,
   ) -> (Self::ProverKey, Self::VerifierKey);
 
   /// A method to prove the evaluation of a multilinear polynomial
   fn prove(
-    ck: &<Self::CE as CommitmentEngineTrait<G>>::CommitmentKey,
+    ck: &<<G as Group>::CE as CommitmentEngineTrait<G>>::CommitmentKey,
     pk: &Self::ProverKey,
     transcript: &mut G::TE,
-    comm: &<Self::CE as CommitmentEngineTrait<G>>::Commitment,
+    comm: &<<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment,
     poly: &[G::Scalar],
     point: &[G::Scalar],
     eval: &G::Scalar,
@@ -41,7 +38,7 @@ pub trait EvaluationEngineTrait<G: Group>: Clone + Send + Sync {
   fn verify(
     vk: &Self::VerifierKey,
     transcript: &mut G::TE,
-    comm: &<Self::CE as CommitmentEngineTrait<G>>::Commitment,
+    comm: &<<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment,
     point: &[G::Scalar],
     eval: &G::Scalar,
     arg: &Self::EvaluationArgument,

--- a/src/traits/evaluation.rs
+++ b/src/traits/evaluation.rs
@@ -8,9 +8,7 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 /// A trait that ties different pieces of the commitment evaluation together
-pub trait EvaluationEngineTrait<G: Group>:
-  Clone + Send + Sync + Serialize + for<'de> Deserialize<'de>
-{
+pub trait EvaluationEngineTrait<G: Group>: Clone + Send + Sync {
   /// A type that holds the associated commitment engine
   type CE: CommitmentEngineTrait<G>;
 

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,7 +1,10 @@
 //! This module defines various traits required by the users of the library to implement.
 use crate::errors::NovaError;
 use bellpepper_core::{boolean::AllocatedBit, num::AllocatedNum, ConstraintSystem, SynthesisError};
-use core::fmt::Debug;
+use core::{
+  fmt::Debug,
+  ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
+};
 use ff::{PrimeField, PrimeFieldBits};
 use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
@@ -170,16 +173,29 @@ pub type ROConstantsCircuit<G> =
   <<G as Group>::ROCircuit as ROCircuitTrait<<G as Group>::Base>>::Constants;
 
 /// A helper trait for types with a group operation.
-pub use group::GroupOps;
+pub trait GroupOps<Rhs = Self, Output = Self>:
+  Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + AddAssign<Rhs> + SubAssign<Rhs>
+{
+}
+
+impl<T, Rhs, Output> GroupOps<Rhs, Output> for T where
+  T: Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + AddAssign<Rhs> + SubAssign<Rhs>
+{
+}
 
 /// A helper trait for references with a group operation.
-pub use group::GroupOpsOwned;
+pub trait GroupOpsOwned<Rhs = Self, Output = Self>: for<'r> GroupOps<&'r Rhs, Output> {}
+impl<T, Rhs, Output> GroupOpsOwned<Rhs, Output> for T where T: for<'r> GroupOps<&'r Rhs, Output> {}
 
 /// A helper trait for types implementing group scalar multiplication.
-pub use group::ScalarMul;
+pub trait ScalarMul<Rhs, Output = Self>: Mul<Rhs, Output = Output> + MulAssign<Rhs> {}
+
+impl<T, Rhs, Output> ScalarMul<Rhs, Output> for T where T: Mul<Rhs, Output = Output> + MulAssign<Rhs>
+{}
 
 /// A helper trait for references implementing group scalar multiplication.
-pub use group::ScalarMulOwned;
+pub trait ScalarMulOwned<Rhs, Output = Self>: for<'r> ScalarMul<&'r Rhs, Output> {}
+impl<T, Rhs, Output> ScalarMulOwned<Rhs, Output> for T where T: for<'r> ScalarMul<&'r Rhs, Output> {}
 
 /// This trait allows types to implement how they want to be added to TranscriptEngine
 pub trait TranscriptReprTrait<G: Group>: Send + Sync {

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,10 +1,7 @@
 //! This module defines various traits required by the users of the library to implement.
 use crate::errors::NovaError;
 use bellpepper_core::{boolean::AllocatedBit, num::AllocatedNum, ConstraintSystem, SynthesisError};
-use core::{
-  fmt::Debug,
-  ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
-};
+use core::fmt::Debug;
 use ff::{PrimeField, PrimeFieldBits};
 use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
@@ -173,29 +170,16 @@ pub type ROConstantsCircuit<G> =
   <<G as Group>::ROCircuit as ROCircuitTrait<<G as Group>::Base>>::Constants;
 
 /// A helper trait for types with a group operation.
-pub trait GroupOps<Rhs = Self, Output = Self>:
-  Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + AddAssign<Rhs> + SubAssign<Rhs>
-{
-}
-
-impl<T, Rhs, Output> GroupOps<Rhs, Output> for T where
-  T: Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + AddAssign<Rhs> + SubAssign<Rhs>
-{
-}
+pub use group::GroupOps;
 
 /// A helper trait for references with a group operation.
-pub trait GroupOpsOwned<Rhs = Self, Output = Self>: for<'r> GroupOps<&'r Rhs, Output> {}
-impl<T, Rhs, Output> GroupOpsOwned<Rhs, Output> for T where T: for<'r> GroupOps<&'r Rhs, Output> {}
+pub use group::GroupOpsOwned;
 
 /// A helper trait for types implementing group scalar multiplication.
-pub trait ScalarMul<Rhs, Output = Self>: Mul<Rhs, Output = Output> + MulAssign<Rhs> {}
-
-impl<T, Rhs, Output> ScalarMul<Rhs, Output> for T where T: Mul<Rhs, Output = Output> + MulAssign<Rhs>
-{}
+pub use group::ScalarMul;
 
 /// A helper trait for references implementing group scalar multiplication.
-pub trait ScalarMulOwned<Rhs, Output = Self>: for<'r> ScalarMul<&'r Rhs, Output> {}
-impl<T, Rhs, Output> ScalarMulOwned<Rhs, Output> for T where T: for<'r> ScalarMul<&'r Rhs, Output> {}
+pub use group::ScalarMulOwned;
 
 /// This trait allows types to implement how they want to be added to TranscriptEngine
 pub trait TranscriptReprTrait<G: Group>: Send + Sync {

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -31,11 +31,7 @@ pub trait Group:
   + for<'de> Deserialize<'de>
 {
   /// A type representing an element of the base field of the group
-  type Base: PrimeField
-    + PrimeFieldBits
-    + TranscriptReprTrait<Self>
-    + Serialize
-    + for<'de> Deserialize<'de>;
+  type Base: PrimeFieldBits + TranscriptReprTrait<Self> + Serialize + for<'de> Deserialize<'de>;
 
   /// A type representing an element of the scalar field of the group
   type Scalar: PrimeFieldBits
@@ -47,25 +43,23 @@ pub trait Group:
     + for<'de> Deserialize<'de>;
 
   /// A type representing the compressed version of the group element
-  type CompressedGroupElement: CompressedGroup<GroupElement = Self>
-    + Serialize
-    + for<'de> Deserialize<'de>;
+  type CompressedGroupElement: CompressedGroup<GroupElement = Self>;
 
   /// A type representing preprocessed group element
   type PreprocessedGroupElement: Clone + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de>;
 
   /// A type that represents a circuit-friendly sponge that consumes elements
   /// from the base field and squeezes out elements of the scalar field
-  type RO: ROTrait<Self::Base, Self::Scalar> + Serialize + for<'de> Deserialize<'de>;
+  type RO: ROTrait<Self::Base, Self::Scalar>;
 
   /// An alternate implementation of Self::RO in the circuit model
-  type ROCircuit: ROCircuitTrait<Self::Base> + Serialize + for<'de> Deserialize<'de>;
+  type ROCircuit: ROCircuitTrait<Self::Base>;
 
   /// A type that provides a generic Fiat-Shamir transcript to be used when externalizing proofs
   type TE: TranscriptEngineTrait<Self>;
 
   /// A type that defines a commitment engine over scalars in the group
-  type CE: CommitmentEngineTrait<Self> + Serialize + for<'de> Deserialize<'de>;
+  type CE: CommitmentEngineTrait<Self>;
 
   /// A method to compute a multiexponentation
   fn vartime_multiscalar_mul(
@@ -110,7 +104,7 @@ pub trait CompressedGroup:
   + 'static
 {
   /// A type that holds the decompressed version of the compressed group element
-  type GroupElement: Group + Serialize + for<'de> Deserialize<'de>;
+  type GroupElement: Group;
 
   /// Decompresses the compressed group element
   fn decompress(&self) -> Option<Self::GroupElement>;


### PR DESCRIPTION
The individual commit messages are meant to be meaningful. At a high level:

-  starts leveraging `zkcrypto/group` to simplify trait definitions (see #198, but consider this only reuses the blanket impl of a convenience trait referring to `std::ops`), 
- removes unneeded trait bounds (this is backwards-compatible), 
- removes unneeded `Phantom` types,
- updates `halo2curves` with the recently released package,
- refactors `CommitmentKeyExtTrait` to remove unneeded associated type (this is a breaking change, but I've tested [the changes](https://github.com/lurk-lab/lurk-rs/blob/5ddd40f4be4808d7b460688ab90837122cc46eb4/src/proof/nova.rs#L58-L60), which are minimal),
- refactors `EvaluationEngineTrait` to remove unneeded associated type,