### PR TITLE
Refine comments

### DIFF
--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -1,7 +1,7 @@
 //! This module implements RelaxedR1CSSNARKTrait using Spartan that is generic
 //! over the polynomial commitment and evaluation argument (i.e., a PCS)
 //! We provide two implementations, one in snark.rs (which does not use any preprocessing)
-//! and another in ppsnark.rs (which uses preprocessing to keep the verifier's state small if the PCS scheme provides a succinct verifier)
+//! and another in ppsnark.rs (which uses preprocessing to keep the verifier's state small if the PCS provides a succinct verifier)
 //! We also provide direct.rs that allows proving a step circuit directly with either of the two SNARKs.
 //!
 //! In polynomial.rs we also provide foundational types and functions for manipulating multilinear polynomials.

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -134,7 +134,6 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
     let n = self.len() / 2;
 
     let (left, right) = self.Z.split_at_mut(n);
-    let (right, _) = right.split_at(n);
 
     left
       .par_iter_mut()

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -16,7 +16,7 @@ use crate::spartan::math::Math;
 ///
 /// The polynomial is defined by the formula:
 /// $$
-/// \tilde{eq}(x, e) = \prod_{i=0}^m(e_i * x_i + (1 - e_i) * (1 - x_i))
+/// \tilde{eq}(x, e) = \prod_{i=1}^m(e_i * x_i + (1 - e_i) * (1 - x_i))
 /// $$
 ///
 /// Each element in the vector `r` corresponds to a component $e_i$, representing a bit from the binary representation of an input value $e$.
@@ -88,7 +88,7 @@ impl<Scalar: PrimeField> EqPolynomial<Scalar> {
 ///
 /// The implementation follows
 /// $$
-/// \tilde{Z}(x_1, ..., x_m) = \sum_{e\in {0,1}^m}Z(e)\cdot \prod_{i=0}^m(x_i\cdot e_i)\cdot (1-e_i)
+/// \tilde{Z}(x_1, ..., x_m) = \sum_{e\in {0,1}^m}Z(e) \cdot \prod_{i=1}^m(x_i \cdot e_i + (1-x_i) \cdot (1-e_i))
 /// $$
 ///
 /// Vector $Z$ indicates $Z(e)$ where $e$ ranges from $0$ to $2^m-1$.

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -47,8 +47,13 @@ impl<Scalar: PrimeField> IdentityPolynomial<Scalar> {
 
   pub fn evaluate(&self, r: &[Scalar]) -> Scalar {
     assert_eq!(self.ell, r.len());
-    (0..self.ell)
-      .map(|i| Scalar::from(2_usize.pow((self.ell - i - 1) as u32) as u64) * r[i])
+    let mut power_of_two = 1_u64;
+    (0..self.ell).rev()
+      .map(|i| {
+        let result = Scalar::from(power_of_two) * r[i];
+        power_of_two *= 2;
+        result
+      })
       .fold(Scalar::ZERO, |acc, item| acc + item)
   }
 }

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -288,7 +288,7 @@ pub trait SumcheckEngine<G: Group> {
   /// the size of the polynomials
   fn size(&self) -> usize;
 
-  /// returns evaluation points at 0, 2, d-1 (where d is the degree of the sum-check polynomial)
+  /// returns evaluation points at 0, 2, 3 (where 3 is the degree of the sum-check polynomial)
   fn evaluation_points(&self) -> Vec<Vec<G::Scalar>>;
 
   /// bounds a variable in the constituent polynomials


### PR DESCRIPTION
Dropped `let (right, _) = right.split_at(n);` since `MultilinearPolynomial::new ` ensures even length. 