### PR TITLE
Simplify type aliases in tests, map_or expressions, and other simplifications

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,2 @@
+type-complexity-threshold = 9999
+too-many-arguments-threshold = 20

--- a/src/bellpepper/shape_cs.rs
+++ b/src/bellpepper/shape_cs.rs
@@ -10,7 +10,6 @@ pub struct ShapeCS<G: Group>
 where
   G::Scalar: PrimeField,
 {
-  #[allow(clippy::type_complexity)]
   /// All constraints added to the `ShapeCS`.
   pub constraints: Vec<(
     LinearCombination<G::Scalar>,

--- a/src/bellpepper/test_shape_cs.rs
+++ b/src/bellpepper/test_shape_cs.rs
@@ -55,7 +55,6 @@ where
 {
   named_objects: HashMap<String, NamedObject>,
   current_namespace: Vec<String>,
-  #[allow(clippy::type_complexity)]
   /// All constraints added to the `TestShapeCS`.
   pub constraints: Vec<(
     LinearCombination<G::Scalar>,

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -58,7 +58,7 @@ impl<'a, F: PrimeField, T: Digestible> DigestComputer<'a, F, T> {
     digest
   }
 
-  /// Create a new DigestComputer
+  /// Create a new `DigestComputer`
   pub fn new(inner: &'a T) -> Self {
     DigestComputer {
       inner,

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -36,17 +36,11 @@ impl<G: Group> AllocatedR1CSInstance<G> {
     // Check that the incoming instance has exactly 2 io
     let W = AllocatedPoint::alloc(
       cs.namespace(|| "allocate W"),
-      u.get().map_or(None, |u| Some(u.comm_W.to_coordinates())),
+      u.map(|u| u.comm_W.to_coordinates()),
     )?;
 
-    let X0 = alloc_scalar_as_base::<G, _>(
-      cs.namespace(|| "allocate X[0]"),
-      u.get().map_or(None, |u| Some(u.X[0])),
-    )?;
-    let X1 = alloc_scalar_as_base::<G, _>(
-      cs.namespace(|| "allocate X[1]"),
-      u.get().map_or(None, |u| Some(u.X[1])),
-    )?;
+    let X0 = alloc_scalar_as_base::<G, _>(cs.namespace(|| "allocate X[0]"), u.map(|u| u.X[0]))?;
+    let X1 = alloc_scalar_as_base::<G, _>(cs.namespace(|| "allocate X[1]"), u.map(|u| u.X[1]))?;
 
     Ok(AllocatedR1CSInstance { W, X0, X1 })
   }
@@ -80,24 +74,17 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
   ) -> Result<Self, SynthesisError> {
     let W = AllocatedPoint::alloc(
       cs.namespace(|| "allocate W"),
-      inst
-        .get()
-        .map_or(None, |inst| Some(inst.comm_W.to_coordinates())),
+      inst.map(|inst| inst.comm_W.to_coordinates()),
     )?;
 
     let E = AllocatedPoint::alloc(
       cs.namespace(|| "allocate E"),
-      inst
-        .get()
-        .map_or(None, |inst| Some(inst.comm_E.to_coordinates())),
+      inst.map(|inst| inst.comm_E.to_coordinates()),
     )?;
 
     // u << |G::Base| despite the fact that u is a scalar.
     // So we parse all of its bytes as a G::Base element
-    let u = alloc_scalar_as_base::<G, _>(
-      cs.namespace(|| "allocate u"),
-      inst.get().map_or(None, |inst| Some(inst.u)),
-    )?;
+    let u = alloc_scalar_as_base::<G, _>(cs.namespace(|| "allocate u"), inst.map(|inst| inst.u))?;
 
     // Allocate X0 and X1. If the input instance is None, then allocate default values 0.
     let X0 = BigNat::alloc_from_nat(
@@ -231,7 +218,6 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
   }
 
   /// Folds self with a relaxed r1cs instance and returns the result
-  #[allow(clippy::too_many_arguments)]
   pub fn fold_with_r1cs<CS: ConstraintSystem<<G as Group>::Base>>(
     &self,
     mut cs: CS,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -812,12 +812,9 @@ mod tests {
   use core::fmt::Write;
 
   use super::*;
-  type EE1<G1> = provider::ipa_pc::EvaluationEngine<G1>;
-  type EE2<G2> = provider::ipa_pc::EvaluationEngine<G2>;
-  type S1<G1> = spartan::snark::RelaxedR1CSSNARK<G1, EE1<G1>>;
-  type S2<G2> = spartan::snark::RelaxedR1CSSNARK<G2, EE2<G2>>;
-  type S1Prime<G1> = spartan::ppsnark::RelaxedR1CSSNARK<G1, EE1<G1>>;
-  type S2Prime<G2> = spartan::ppsnark::RelaxedR1CSSNARK<G2, EE2<G2>>;
+  type EE<G> = provider::ipa_pc::EvaluationEngine<G>;
+  type S<G1> = spartan::snark::RelaxedR1CSSNARK<G1, EE<G1>>;
+  type SPrime<G1> = spartan::ppsnark::RelaxedR1CSSNARK<G1, EE<G1>>;
 
   use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use core::marker::PhantomData;
@@ -1157,10 +1154,10 @@ mod tests {
     assert_eq!(zn_secondary, vec![<G2 as Group>::Scalar::from(2460515u64)]);
 
     // produce the prover and verifier keys for compressed snark
-    let (pk, vk) = CompressedSNARK::<_, _, _, _, S1<G1>, S2<G2>>::setup(&pp).unwrap();
+    let (pk, vk) = CompressedSNARK::<_, _, _, _, S<G1>, S<G2>>::setup(&pp).unwrap();
 
     // produce a compressed SNARK
-    let res = CompressedSNARK::<_, _, _, _, S1<G1>, S2<G2>>::prove(&pp, &pk, &recursive_snark);
+    let res = CompressedSNARK::<_, _, _, _, S<G1>, S<G2>>::prove(&pp, &pk, &recursive_snark);
     assert!(res.is_ok());
     let compressed_snark = res.unwrap();
 
@@ -1253,11 +1250,11 @@ mod tests {
     // run the compressed snark with Spark compiler
 
     // produce the prover and verifier keys for compressed snark
-    let (pk, vk) = CompressedSNARK::<_, _, _, _, S1Prime<G1>, S2Prime<G2>>::setup(&pp).unwrap();
+    let (pk, vk) = CompressedSNARK::<_, _, _, _, SPrime<G1>, SPrime<G2>>::setup(&pp).unwrap();
 
     // produce a compressed SNARK
     let res =
-      CompressedSNARK::<_, _, _, _, S1Prime<G1>, S2Prime<G2>>::prove(&pp, &pk, &recursive_snark);
+      CompressedSNARK::<_, _, _, _, SPrime<G1>, SPrime<G2>>::prove(&pp, &pk, &recursive_snark);
     assert!(res.is_ok());
     let compressed_snark = res.unwrap();
 
@@ -1404,10 +1401,10 @@ mod tests {
     assert!(res.is_ok());
 
     // produce the prover and verifier keys for compressed snark
-    let (pk, vk) = CompressedSNARK::<_, _, _, _, S1<G1>, S2<G2>>::setup(&pp).unwrap();
+    let (pk, vk) = CompressedSNARK::<_, _, _, _, S<G1>, S<G2>>::setup(&pp).unwrap();
 
     // produce a compressed SNARK
-    let res = CompressedSNARK::<_, _, _, _, S1<G1>, S2<G2>>::prove(&pp, &pk, &recursive_snark);
+    let res = CompressedSNARK::<_, _, _, _, S<G1>, S<G2>>::prove(&pp, &pk, &recursive_snark);
     assert!(res.is_ok());
     let compressed_snark = res.unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
   missing_docs
 )]
 #![allow(non_snake_case)]
-#![allow(clippy::type_complexity)]
 #![forbid(unsafe_code)]
 
 // private modules

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -1,6 +1,5 @@
 //! This module implements a non-interactive folding scheme
 #![allow(non_snake_case)]
-#![allow(clippy::type_complexity)]
 
 use crate::{
   constants::{NUM_CHALLENGE_BITS, NUM_FE_FOR_RO},
@@ -30,7 +29,6 @@ impl<G: Group> NIFS<G> {
   /// a folded Relaxed R1CS instance-witness tuple `(U, W)` of the same shape `shape`,
   /// with the guarantee that the folded witness `W` satisfies the folded instance `U`
   /// if and only if `W1` satisfies `U1` and `W2` satisfies `U2`.
-  #[allow(clippy::too_many_arguments)]
   pub fn prove(
     ck: &CommitmentKey<G>,
     ro_consts: &ROConstants<G>,
@@ -208,7 +206,6 @@ mod tests {
     test_tiny_r1cs_bellpepper_with::<crate::provider::bn256_grumpkin::bn256::Point>();
   }
 
-  #[allow(clippy::too_many_arguments)]
   fn execute_sequence<G>(
     ck: &CommitmentKey<G>,
     ro_consts: &<<G as Group>::RO as ROTrait<<G as Group>::Base, <G as Group>::Scalar>>::Constants,

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -1,5 +1,4 @@
 //! This module implements `EvaluationEngine` using an IPA-based polynomial commitment scheme
-#![allow(clippy::too_many_arguments)]
 use crate::{
   errors::NovaError,
   provider::pedersen::CommitmentKeyExtTrait,

--- a/src/provider/secp_secq.rs
+++ b/src/provider/secp_secq.rs
@@ -1,4 +1,4 @@
-//! This module implements the Nova traits for secp::Point, secp::Scalar, secq::Point, secq::Scalar.
+//! This module implements the Nova traits for `secp::Point`, `secp::Scalar`, `secq::Point`, `secq::Scalar`.
 use crate::{
   impl_traits,
   provider::{

--- a/src/r1cs.rs
+++ b/src/r1cs.rs
@@ -1,5 +1,4 @@
 //! This module defines R1CS related types and a folding scheme for Relaxed R1CS
-#![allow(clippy::type_complexity)]
 use crate::{
   constants::{BN_LIMB_WIDTH, BN_N_LIMBS},
   digest::{DigestComputer, SimpleDigestible},

--- a/src/spartan/polys/univariate.rs
+++ b/src/spartan/polys/univariate.rs
@@ -1,6 +1,6 @@
 //! Main components:
-//! - UniPoly: an univariate dense polynomial in coefficient form (big endian),
-//! - CompressedUniPoly: a univariate dense polynomial, compressed (omitted linear term), in coefficient form (little endian),
+//! - `UniPoly`: an univariate dense polynomial in coefficient form (big endian),
+//! - `CompressedUniPoly`: a univariate dense polynomial, compressed (omitted linear term), in coefficient form (little endian),
 use ff::PrimeField;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::too_many_arguments)]
-#![allow(clippy::type_complexity)]
 use crate::errors::NovaError;
 use crate::spartan::polys::{
   multilinear::MultilinearPolynomial,

--- a/src/traits/circuit.rs
+++ b/src/traits/circuit.rs
@@ -12,7 +12,7 @@ pub trait StepCircuit<F: PrimeField>: Send + Sync + Clone {
   fn arity(&self) -> usize;
 
   /// Sythesize the circuit for a computation step and return variable
-  /// that corresponds to the output of the step z_{i+1}
+  /// that corresponds to the output of the step `z_{i+1}`
   fn synthesize<CS: ConstraintSystem<F>>(
     &self,
     cs: &mut CS,


### PR DESCRIPTION
This backports the following small PRs from [Arecibo](https://github.com/lurk-lab/arecibo/):
- https://github.com/lurk-lab/arecibo/pull/54
- https://github.com/lurk-lab/arecibo/pull/55