### PR TITLE
Adopt a CSR Representation for Sparse Matrices (Arecibo backport)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,6 @@ once_cell = "1.18.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { version = "0.1.4" }
-proptest = "1.2.0"
-rand = "0.8.5"
 
 [target.wasm32-unknown-unknown.dependencies]
 # see https://github.com/rust-random/rand/pull/948
@@ -52,6 +50,8 @@ hex = "0.4.3"
 pprof = { version = "0.11" }
 cfg-if = "1.0.0"
 sha2 = "0.10.7"
+proptest = "1.2.0"
+rand = "0.8.5"
 
 [[bench]]
 name = "recursive-snark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ once_cell = "1.18.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 pasta-msm = { version = "0.1.4" }
+proptest = "1.2.0"
+rand = "0.8.5"
 
 [target.wasm32-unknown-unknown.dependencies]
 # see https://github.com/rust-random/rand/pull/948
@@ -45,13 +47,11 @@ getrandom = { version = "0.2.0", default-features = false, features = ["js"] }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
-rand = "0.8.4"
 flate2 = "1.0"
 hex = "0.4.3"
 pprof = { version = "0.11" }
 cfg-if = "1.0.0"
 sha2 = "0.10.7"
-proptest = "1.2.0"
 
 [[bench]]
 name = "recursive-snark"

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -129,12 +129,13 @@ where
   }
 }
 
+/// cargo run --release --example minroot
 fn main() {
   println!("Nova-based VDF with MinRoot delay function");
   println!("=========================================================");
 
   let num_steps = 10;
-  for num_iters_per_step in [1024, 2048, 4096, 8192, 16384, 32768, 65535] {
+  for num_iters_per_step in [1024, 2048, 4096, 8192, 16384, 32768, 65536] {
     // number of iterations of MinRoot per Nova's recursive step
     let circuit_primary = MinRootCircuit {
       seq: vec![

--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -5,7 +5,7 @@
 use super::{shape_cs::ShapeCS, solver::SatisfyingAssignment, test_shape_cs::TestShapeCS};
 use crate::{
   errors::NovaError,
-  r1cs::{R1CSInstance, R1CSShape, R1CSWitness, R1CS},
+  r1cs::{sparse::SparseMatrix, R1CSInstance, R1CSShape, R1CSWitness, R1CS},
   traits::Group,
   CommitmentKey,
 };
@@ -52,13 +52,12 @@ macro_rules! impl_nova_shape {
       G::Scalar: PrimeField,
     {
       fn r1cs_shape(&self) -> (R1CSShape<G>, CommitmentKey<G>) {
-        let mut A: Vec<(usize, usize, G::Scalar)> = Vec::new();
-        let mut B: Vec<(usize, usize, G::Scalar)> = Vec::new();
-        let mut C: Vec<(usize, usize, G::Scalar)> = Vec::new();
+        let mut A = SparseMatrix::<G::Scalar>::empty();
+        let mut B = SparseMatrix::<G::Scalar>::empty();
+        let mut C = SparseMatrix::<G::Scalar>::empty();
 
         let mut num_cons_added = 0;
         let mut X = (&mut A, &mut B, &mut C, &mut num_cons_added);
-
         let num_inputs = self.num_inputs();
         let num_constraints = self.num_constraints();
         let num_vars = self.num_aux();
@@ -72,15 +71,14 @@ macro_rules! impl_nova_shape {
             &constraint.2,
           );
         }
-
         assert_eq!(num_cons_added, num_constraints);
 
-        let S: R1CSShape<G> = {
-          // Don't count One as an input for shape's purposes.
-          let res = R1CSShape::new(num_constraints, num_vars, num_inputs - 1, &A, &B, &C);
-          res.unwrap()
-        };
+        A.cols = num_vars + num_inputs;
+        B.cols = num_vars + num_inputs;
+        C.cols = num_vars + num_inputs;
 
+        // Don't count One as an input for shape's purposes.
+        let S = R1CSShape::new(num_constraints, num_vars, num_inputs - 1, A, B, C).unwrap();
         let ck = R1CS::<G>::commitment_key(&S);
 
         (S, ck)
@@ -94,9 +92,9 @@ impl_nova_shape!(TestShapeCS);
 
 fn add_constraint<S: PrimeField>(
   X: &mut (
-    &mut Vec<(usize, usize, S)>,
-    &mut Vec<(usize, usize, S)>,
-    &mut Vec<(usize, usize, S)>,
+    &mut SparseMatrix<S>,
+    &mut SparseMatrix<S>,
+    &mut SparseMatrix<S>,
     &mut usize,
   ),
   num_vars: usize,
@@ -106,29 +104,40 @@ fn add_constraint<S: PrimeField>(
 ) {
   let (A, B, C, nn) = X;
   let n = **nn;
-  let one = S::ONE;
+  assert_eq!(n + 1, A.indptr.len(), "A: invalid shape");
+  assert_eq!(n + 1, B.indptr.len(), "B: invalid shape");
+  assert_eq!(n + 1, C.indptr.len(), "C: invalid shape");
 
-  let add_constraint_component = |index: Index, coeff, V: &mut Vec<_>| {
+  let add_constraint_component = |index: Index, coeff: &S, M: &mut SparseMatrix<S>| {
     match index {
       Index::Input(idx) => {
         // Inputs come last, with input 0, reprsenting 'one',
         // at position num_vars within the witness vector.
-        let i = idx + num_vars;
-        V.push((n, i, one * coeff))
+        let idx = idx + num_vars;
+        M.data.push(*coeff);
+        M.indices.push(idx);
       }
-      Index::Aux(idx) => V.push((n, idx, one * coeff)),
+      Index::Aux(idx) => {
+        M.data.push(*coeff);
+        M.indices.push(idx);
+      }
     }
   };
 
   for (index, coeff) in a_lc.iter() {
     add_constraint_component(index.0, coeff, A);
   }
+  A.indptr.push(A.indices.len());
+
   for (index, coeff) in b_lc.iter() {
     add_constraint_component(index.0, coeff, B)
   }
+  B.indptr.push(B.indices.len());
+
   for (index, coeff) in c_lc.iter() {
     add_constraint_component(index.0, coeff, C)
   }
+  C.indptr.push(C.indices.len());
 
   **nn += 1;
 }

--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -5,7 +5,7 @@
 use super::{shape_cs::ShapeCS, solver::SatisfyingAssignment, test_shape_cs::TestShapeCS};
 use crate::{
   errors::NovaError,
-  r1cs::{sparse::SparseMatrix, R1CSInstance, R1CSShape, R1CSWitness, R1CS},
+  r1cs::{R1CSInstance, R1CSShape, R1CSWitness, SparseMatrix, R1CS},
   traits::Group,
   CommitmentKey,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -906,13 +906,13 @@ mod tests {
     test_pp_digest_with::<G1, G2, _, _>(
       &trivial_circuit1,
       &trivial_circuit2,
-      "fe14a77d74cb8b8bb13105cea9c5b98b621b42c8d61da8f2adce8b9dd0d51b03",
+      "117ac6f33d66d377346e420f0d8caa09f8f4ec7db0c336dcc65995bf3058bf01",
     );
 
     test_pp_digest_with::<G1, G2, _, _>(
       &cubic_circuit1,
       &trivial_circuit2,
-      "21ac840e52c75a62823cfdda4ca77aae2f07e4b6f5aa0eba80135492b2fbd003",
+      "583c9964e180332e63a59450870a72b4cbf663ce0d274ac5bd0d052d4cd92903",
     );
 
     let trivial_circuit1_grumpkin = TrivialCircuit::<<bn256::Point as Group>::Scalar>::default();
@@ -922,12 +922,12 @@ mod tests {
     test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _>(
       &trivial_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
-      "0b25debdc99cef04b6d113a9a2814de89b3fad239aea90b29f2bdb27d95afa02",
+      "fb6805b7197f41ae2af71dc0130d4bfd1d28fa63b8221741b597dfbb2e48d603",
     );
     test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _>(
       &cubic_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
-      "0747f68f8d1c4bac4c3fb82689a1488b5835bbc97d6f6023fbe2760bb0053b00",
+      "684b2f7151031a79310f6fb553ab1480e290d73731fa34e74c27e004d589f102",
     );
 
     let trivial_circuit1_secp = TrivialCircuit::<<secp256k1::Point as Group>::Scalar>::default();
@@ -937,12 +937,12 @@ mod tests {
     test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _>(
       &trivial_circuit1_secp,
       &trivial_circuit2_secp,
-      "0cf0880fa8debe42b7789474f6787062f8118ef251450dd5a7a4b5430f4bb902",
+      "dbffd48ae0d05f3aeb217e971fbf3b2b7a759668221f6d6cb9032cfa0445aa01",
     );
     test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _>(
       &cubic_circuit1_secp,
       &trivial_circuit2_secp,
-      "623a1dd99f3c906e79397f3de0dc1565b35fcb69abf2da51847bc9879a0a6000",
+      "24e4e8044310e3167196276cc66b4f71b5d0e3e57701dddb17695ae968fba802",
     );
   }
 

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -311,12 +311,13 @@ mod tests {
 
     // create a shape object
     let rows = num_cons;
-    let cols = num_vars + num_io + 1;
+    let num_inputs = num_io + 1;
+    let cols = num_vars + num_inputs;
     let S = {
       let res = R1CSShape::new(
         num_cons,
         num_vars,
-        num_io,
+        num_inputs - 1,
         SparseMatrix::new(&A, rows, cols),
         SparseMatrix::new(&B, rows, cols),
         SparseMatrix::new(&C, rows, cols),

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -113,7 +113,7 @@ impl<G: Group> NIFS<G> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{r1cs::R1CS, traits::Group};
+  use crate::{r1cs::sparse::SparseMatrix, r1cs::R1CS, traits::Group};
   use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use ff::{Field, PrimeField};
   use rand::rngs::OsRng;
@@ -310,8 +310,17 @@ mod tests {
     };
 
     // create a shape object
+    let rows = num_cons;
+    let cols = num_vars + num_io + 1;
     let S = {
-      let res = R1CSShape::new(num_cons, num_vars, num_io, &A, &B, &C);
+      let res = R1CSShape::new(
+        num_cons,
+        num_vars,
+        num_io,
+        SparseMatrix::new(&A, rows, cols),
+        SparseMatrix::new(&B, rows, cols),
+        SparseMatrix::new(&C, rows, cols),
+      );
       assert!(res.is_ok());
       res.unwrap()
     };

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -113,7 +113,7 @@ impl<G: Group> NIFS<G> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::{r1cs::sparse::SparseMatrix, r1cs::R1CS, traits::Group};
+  use crate::{r1cs::SparseMatrix, r1cs::R1CS, traits::Group};
   use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use ff::{Field, PrimeField};
   use rand::rngs::OsRng;

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -1,5 +1,6 @@
 //! This module defines R1CS related types and a folding scheme for Relaxed R1CS
 mod sparse;
+#[cfg(test)]
 mod util;
 
 use crate::{

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -1,5 +1,5 @@
 //! This module defines R1CS related types and a folding scheme for Relaxed R1CS
-pub mod sparse;
+mod sparse;
 mod util;
 
 use crate::{
@@ -22,7 +22,7 @@ use once_cell::sync::OnceCell;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use self::sparse::SparseMatrix;
+pub(crate) use self::sparse::SparseMatrix;
 
 /// Public parameters for a given R1CS
 #[derive(Clone, Serialize, Deserialize)]

--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -1,0 +1,227 @@
+//! # Sparse Matrices
+//!
+//! This module defines a custom implementation of CSR/CSC sparse matrices.
+//! Specifically, we implement sparse matrix / dense vector multiplication
+//! to compute the `A z`, `B z`, and `C z` in Nova.
+use ff::PrimeField;
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// CSR format sparse matrix, We follow the names used by scipy.
+/// Detailed explanation here: https://stackoverflow.com/questions/52299420/scipy-csr-matrix-understand-indptr
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SparseMatrix<F: PrimeField> {
+  /// all non-zero values in the matrix
+  pub data: Vec<F>,
+  /// column indices
+  pub indices: Vec<usize>,
+  /// row information
+  pub indptr: Vec<usize>,
+  /// number of columns
+  pub cols: usize,
+}
+
+impl<F: PrimeField> SparseMatrix<F> {
+  /// 0x0 empty matrix
+  pub fn empty() -> Self {
+    SparseMatrix {
+      data: vec![],
+      indices: vec![],
+      indptr: vec![0],
+      cols: 0,
+    }
+  }
+
+  /// Construct from the COO representation; Vec<usize(row), usize(col), F>.
+  /// We assume that the rows are sorted during construction.
+  pub fn new(matrix: &[(usize, usize, F)], rows: usize, cols: usize) -> Self {
+    let mut new_matrix = vec![vec![]; rows];
+    for (row, col, val) in matrix {
+      new_matrix[*row].push((*col, *val));
+    }
+
+    for row in new_matrix.iter() {
+      assert!(row.windows(2).all(|w| w[0].0 < w[1].0));
+    }
+
+    let mut indptr = vec![0; rows + 1];
+    for (i, col) in new_matrix.iter().enumerate() {
+      indptr[i + 1] = indptr[i] + col.len();
+    }
+
+    let mut indices = vec![];
+    let mut data = vec![];
+    for col in new_matrix {
+      let (idx, val): (Vec<_>, Vec<_>) = col.into_iter().unzip();
+      indices.extend(idx);
+      data.extend(val);
+    }
+
+    SparseMatrix {
+      data,
+      indices,
+      indptr,
+      cols,
+    }
+  }
+
+  /// Retrieves the data for row slice [i..j] from `ptrs`.
+  /// We assume that `ptrs` is indexed from `indptrs` and do not check if the
+  /// returned slice is actually a valid row.
+  pub fn get_row_unchecked(&self, ptrs: &[usize; 2]) -> impl Iterator<Item = (&F, &usize)> {
+    self.data[ptrs[0]..ptrs[1]]
+      .iter()
+      .zip(&self.indices[ptrs[0]..ptrs[1]])
+  }
+
+  /// Multiply by a dense vector; uses rayon/gpu.
+  pub fn multiply_vec(&self, vector: &[F]) -> Vec<F> {
+    assert_eq!(self.cols, vector.len(), "invalid shape");
+
+    self.multiply_vec_unchecked(vector)
+  }
+
+  /// Multiply by a dense vector; uses rayon/gpu.
+  /// This does not check that the shape of the matrix/vector are compatible.
+  pub fn multiply_vec_unchecked(&self, vector: &[F]) -> Vec<F> {
+    self
+      .indptr
+      .par_windows(2)
+      .map(|ptrs| {
+        self
+          .get_row_unchecked(ptrs.try_into().unwrap())
+          .map(|(val, col_idx)| *val * vector[*col_idx])
+          .sum()
+      })
+      .collect()
+  }
+
+  /// number of non-zero entries
+  pub fn len(&self) -> usize {
+    *self.indptr.last().unwrap()
+  }
+
+  /// empty matrix
+  pub fn is_empty(&self) -> bool {
+    self.len() == 0
+  }
+
+  /// returns a custom iterator
+  pub fn iter(&self) -> Iter<'_, F> {
+    let mut row = 0;
+    while self.indptr[row + 1] == 0 {
+      row += 1;
+    }
+    Iter {
+      matrix: self,
+      row,
+      i: 0,
+      nnz: *self.indptr.last().unwrap(),
+    }
+  }
+}
+
+/// Iterator for sparse matrix
+pub struct Iter<'a, F: PrimeField> {
+  matrix: &'a SparseMatrix<F>,
+  row: usize,
+  i: usize,
+  nnz: usize,
+}
+
+impl<'a, F: PrimeField> Iterator for Iter<'a, F> {
+  type Item = (usize, usize, F);
+
+  fn next(&mut self) -> Option<Self::Item> {
+    // are we at the end?
+    if self.i == self.nnz {
+      return None;
+    }
+
+    // compute current item
+    let curr_item = (
+      self.row,
+      self.matrix.indices[self.i],
+      self.matrix.data[self.i],
+    );
+
+    // advance the iterator
+    self.i += 1;
+    // edge case at the end
+    if self.i == self.nnz {
+      return Some(curr_item);
+    }
+    // if `i` has moved to next row
+    while self.i >= self.matrix.indptr[self.row + 1] {
+      self.row += 1;
+    }
+
+    Some(curr_item)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::{r1cs::util::FWrap, traits::Group};
+
+  use super::SparseMatrix;
+  use pasta_curves::pallas::Point as G;
+  use proptest::{
+    prelude::*,
+    strategy::{BoxedStrategy, Just, Strategy},
+  };
+
+  type Fr = <G as Group>::Scalar;
+
+  #[test]
+  fn test_matrix_creation() {
+    let matrix_data = vec![
+      (0, 1, Fr::from(2)),
+      (1, 2, Fr::from(3)),
+      (2, 0, Fr::from(4)),
+    ];
+    let sparse_matrix = SparseMatrix::<Fr>::new(&matrix_data, 3, 3);
+
+    assert_eq!(
+      sparse_matrix.data,
+      vec![Fr::from(2), Fr::from(3), Fr::from(4)]
+    );
+    assert_eq!(sparse_matrix.indices, vec![1, 2, 0]);
+    assert_eq!(sparse_matrix.indptr, vec![0, 1, 2, 3]);
+  }
+
+  #[test]
+  fn test_matrix_vector_multiplication() {
+    let matrix_data = vec![
+      (0, 1, Fr::from(2)),
+      (0, 2, Fr::from(7)),
+      (1, 2, Fr::from(3)),
+      (2, 0, Fr::from(4)),
+    ];
+    let sparse_matrix = SparseMatrix::<Fr>::new(&matrix_data, 3, 3);
+    let vector = vec![Fr::from(1), Fr::from(2), Fr::from(3)];
+
+    let result = sparse_matrix.multiply_vec(&vector);
+
+    assert_eq!(result, vec![Fr::from(25), Fr::from(9), Fr::from(4)]);
+  }
+
+  fn coo_strategy() -> BoxedStrategy<Vec<(usize, usize, FWrap<Fr>)>> {
+    let coo_strategy = any::<FWrap<Fr>>().prop_flat_map(|f| (0usize..100, 0usize..100, Just(f)));
+    proptest::collection::vec(coo_strategy, 10).boxed()
+  }
+
+  proptest! {
+      #[test]
+      fn test_matrix_iter(mut coo_matrix in coo_strategy()) {
+        // process the randomly generated coo matrix
+        coo_matrix.sort_by_key(|(row, col, _val)| (*row, *col));
+        coo_matrix.dedup_by_key(|(row, col, _val)| (*row, *col));
+        let coo_matrix = coo_matrix.into_iter().map(|(row, col, val)| { (row, col, val.0) }).collect::<Vec<_>>();
+
+        let matrix = SparseMatrix::new(&coo_matrix, 100, 100);
+
+        prop_assert_eq!(coo_matrix, matrix.iter().collect::<Vec<_>>());
+    }
+  }
+}

--- a/src/r1cs/util.rs
+++ b/src/r1cs/util.rs
@@ -1,0 +1,26 @@
+use ff::PrimeField;
+#[cfg(not(target_arch = "wasm32"))]
+use proptest::prelude::*;
+
+/// Wrapper struct around a field element that implements additional traits
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FWrap<F: PrimeField>(pub F);
+
+impl<F: PrimeField> Copy for FWrap<F> {}
+
+#[cfg(not(target_arch = "wasm32"))]
+/// Trait implementation for generating `FWrap<F>` instances with proptest
+impl<F: PrimeField> Arbitrary for FWrap<F> {
+  type Parameters = ();
+  type Strategy = BoxedStrategy<Self>;
+
+  fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+    use rand::rngs::StdRng;
+    use rand_core::SeedableRng;
+
+    let strategy = any::<[u8; 32]>()
+      .prop_map(|seed| FWrap(F::random(StdRng::from_seed(seed))))
+      .no_shrink();
+    strategy.boxed()
+  }
+}

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -133,14 +133,13 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     let (mut row, mut col) = (vec![0usize; N], vec![0usize; N]);
 
     for (i, (r, c, _)) in S.A.iter().chain(S.B.iter()).chain(S.C.iter()).enumerate() {
-      row[i] = *r;
-      col[i] = *c;
+      row[i] = r;
+      col[i] = c;
     }
-
     let val_A = {
       let mut val = vec![G::Scalar::ZERO; N];
       for (i, (_, _, v)) in S.A.iter().enumerate() {
-        val[i] = *v;
+        val[i] = v;
       }
       val
     };
@@ -148,7 +147,7 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     let val_B = {
       let mut val = vec![G::Scalar::ZERO; N];
       for (i, (_, _, v)) in S.B.iter().enumerate() {
-        val[S.A.len() + i] = *v;
+        val[S.A.len() + i] = v;
       }
       val
     };
@@ -156,7 +155,7 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
     let val_C = {
       let mut val = vec![G::Scalar::ZERO; N];
       for (i, (_, _, v)) in S.C.iter().enumerate() {
-        val[S.A.len() + S.B.len() + i] = *v;
+        val[S.A.len() + S.B.len() + i] = v;
       }
       val
     };
@@ -275,7 +274,7 @@ impl<G: Group> R1CSShapeSparkRepr<G> {
         .iter()
         .chain(S.B.iter())
         .chain(S.C.iter())
-        .map(|(r, c, _)| (mem_row[*r], mem_col[*c]))
+        .map(|(r, c, _)| (mem_row[r], mem_col[c]))
         .enumerate()
       {
         E_row[i] = val_r;

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -7,7 +7,7 @@
 use crate::{
   digest::{DigestComputer, SimpleDigestible},
   errors::NovaError,
-  r1cs::{sparse::SparseMatrix, R1CSShape, RelaxedR1CSInstance, RelaxedR1CSWitness},
+  r1cs::{R1CSShape, RelaxedR1CSInstance, RelaxedR1CSWitness, SparseMatrix},
   spartan::{
     polys::{eq::EqPolynomial, multilinear::MultilinearPolynomial, multilinear::SparsePolynomial},
     powers,


### PR DESCRIPTION
Shifts the sparse matrix representation from COO (Coordinate List) to CSR (Compressed Sparse Row).

> [!NOTE]  
> ### COO vs. [CSR](https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_row_(CSR,_CRS_or_Yale_format))
> In brief, while COO represents a sparse matrix as a list of (row, column, value) tuples, CSR takes a different approach. It makes use of three one-dimensional arrays to store the non-zero elements, the extents of the rows, and the column indices of the elements. The real charm of CSR lies in the contiguity of value representation for the same rows, making it amenable to auto-vectorizers.

The change shows a small 5-10% improvement on recursive proofs, where a matrix-vector product is used in committing to R1CS matrices (and that's on an M2 machine .. on most x86s, more significative benefits are the norm).

```
group                                                        coo-to-csr                             main
-----                                                        ----------                             ----
CompressedSNARK-Commitments-StepCircuitSize-0/Prove          1.00       6.2±0.03s          1.00       6.1±0.03s
CompressedSNARK-Commitments-StepCircuitSize-0/Verify         1.00    135.0±1.64ms          1.01    135.7±0.97ms
CompressedSNARK-Commitments-StepCircuitSize-121253/Prove     1.00      15.5±0.08s          1.01      15.7±0.07s
CompressedSNARK-Commitments-StepCircuitSize-121253/Verify    1.00    337.3±4.90ms          1.01    340.5±3.28ms
CompressedSNARK-Commitments-StepCircuitSize-22949/Prove      1.00       9.2±0.14s          1.00       9.3±0.14s
CompressedSNARK-Commitments-StepCircuitSize-22949/Verify     1.00    194.7±2.51ms          1.01    196.7±4.07ms
CompressedSNARK-Commitments-StepCircuitSize-252325/Prove     1.00      27.2±0.11s          1.01      27.6±0.08s
CompressedSNARK-Commitments-StepCircuitSize-252325/Verify    1.02   527.1±15.70ms          1.00    519.2±8.87ms
CompressedSNARK-Commitments-StepCircuitSize-55717/Prove      1.01      15.5±0.07s          1.00      15.3±0.15s
CompressedSNARK-Commitments-StepCircuitSize-55717/Verify     1.00    335.7±4.52ms          1.01    339.4±6.36ms
CompressedSNARK-Commitments-StepCircuitSize-6565/Prove       1.00       9.0±0.12s          1.04       9.4±0.32s
CompressedSNARK-Commitments-StepCircuitSize-6565/Verify      1.00    195.1±3.30ms          1.01    196.3±2.11ms
CompressedSNARK-StepCircuitSize-0/Prove                      1.00    619.0±4.70ms          1.01    625.5±5.86ms
CompressedSNARK-StepCircuitSize-0/Verify                     1.00     24.8±0.29ms          1.00     24.8±0.34ms
CompressedSNARK-StepCircuitSize-1038757/Prove                1.02      19.2±0.27s          1.00      18.7±0.07s
CompressedSNARK-StepCircuitSize-1038757/Verify               1.00    530.3±7.85ms          1.00    529.8±3.81ms
CompressedSNARK-StepCircuitSize-121253/Prove                 1.00       2.7±0.03s          1.01       2.8±0.12s
CompressedSNARK-StepCircuitSize-121253/Verify                1.01     88.0±1.56ms          1.00     86.9±1.85ms
CompressedSNARK-StepCircuitSize-22949/Prove                  1.00   931.5±13.86ms          1.00   928.6±10.21ms
CompressedSNARK-StepCircuitSize-22949/Verify                 1.02     34.6±0.46ms          1.00     33.9±0.73ms
CompressedSNARK-StepCircuitSize-252325/Prove                 1.00       4.9±0.02s          1.01       5.0±0.02s
CompressedSNARK-StepCircuitSize-252325/Verify                1.00    161.6±2.03ms          1.00    161.1±2.64ms
CompressedSNARK-StepCircuitSize-514469/Prove                 1.00       9.8±0.04s          1.00       9.8±0.03s
CompressedSNARK-StepCircuitSize-514469/Verify                1.00    321.6±4.50ms          1.01    324.6±3.69ms
CompressedSNARK-StepCircuitSize-55717/Prove                  1.00  1536.6±46.55ms          1.01  1546.5±49.04ms
CompressedSNARK-StepCircuitSize-55717/Verify                 1.03     52.8±2.06ms          1.00     51.5±1.11ms
CompressedSNARK-StepCircuitSize-6565/Prove                   1.00    628.3±4.12ms          1.00    626.4±3.69ms
CompressedSNARK-StepCircuitSize-6565/Verify                  1.02     25.0±0.27ms          1.00     24.6±0.23ms
RecursiveSNARK-StepCircuitSize-0/Prove                       1.00     37.1±0.16ms          1.12     41.4±0.10ms
RecursiveSNARK-StepCircuitSize-0/Verify                      1.00     23.5±0.13ms          1.03     24.3±0.20ms
RecursiveSNARK-StepCircuitSize-1038757/Prove                 1.00   1151.1±7.55ms          1.01   1167.4±8.91ms
RecursiveSNARK-StepCircuitSize-1038757/Verify                1.02   984.3±14.26ms          1.00   968.6±11.56ms
RecursiveSNARK-StepCircuitSize-121253/Prove                  1.00    154.7±3.34ms          1.06    163.8±1.60ms
RecursiveSNARK-StepCircuitSize-121253/Verify                 1.00    127.8±0.73ms          1.00    127.7±2.27ms
RecursiveSNARK-StepCircuitSize-22949/Prove                   1.00     63.3±0.82ms          1.06     67.4±0.23ms
RecursiveSNARK-StepCircuitSize-22949/Verify                  1.00     43.8±0.30ms          1.03     45.0±0.45ms
RecursiveSNARK-StepCircuitSize-252325/Prove                  1.00    280.6±2.54ms          1.05    295.4±5.68ms
RecursiveSNARK-StepCircuitSize-252325/Verify                 1.01    241.8±2.64ms          1.00    239.3±2.13ms
RecursiveSNARK-StepCircuitSize-514469/Prove                  1.00    530.9±3.55ms          1.03    548.2±6.10ms
RecursiveSNARK-StepCircuitSize-514469/Verify                 1.00    432.1±2.60ms          1.11    478.4±3.81ms
RecursiveSNARK-StepCircuitSize-55717/Prove                   1.00     93.0±0.73ms          1.07     99.6±1.14ms
RecursiveSNARK-StepCircuitSize-55717/Verify                  1.00     72.6±0.80ms          1.02     74.2±0.96ms
RecursiveSNARK-StepCircuitSize-6565/Prove                    1.00     44.7±0.27ms          1.10     49.0±0.48ms
RecursiveSNARK-StepCircuitSize-6565/Verify                   1.00     29.4±0.27ms          1.01     29.8±0.17ms
```

Complete bench run:
https://gist.github.com/huitseeker/63bae83503c61b0cf643f58ccf0a7dad

## Credits
https://github.com/lurk-lab/arecibo/pull/38
Work mostly done by @winston-h-zhang, I'm just the ferryman.