### PR TITLE
refactor: remove clippy attributes

### DIFF
--- a/src/bellpepper/shape_cs.rs
+++ b/src/bellpepper/shape_cs.rs
@@ -4,7 +4,6 @@ use crate::traits::Group;
 use bellpepper_core::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 use ff::PrimeField;
 
-#[allow(clippy::upper_case_acronyms)]
 /// `ShapeCS` is a `ConstraintSystem` for creating `R1CSShape`s for a circuit.
 pub struct ShapeCS<G: Group>
 where

--- a/src/bellpepper/test_shape_cs.rs
+++ b/src/bellpepper/test_shape_cs.rs
@@ -47,7 +47,6 @@ impl Ord for OrderedVariable {
   }
 }
 
-#[allow(clippy::upper_case_acronyms)]
 /// `TestShapeCS` is a `ConstraintSystem` for creating `R1CSShape`s for a circuit.
 pub struct TestShapeCS<G: Group>
 where

--- a/src/gadgets/utils.rs
+++ b/src/gadgets/utils.rs
@@ -126,15 +126,14 @@ pub fn alloc_bignat_constant<F: PrimeField, CS: ConstraintSystem<F>>(
     n_limbs,
   )?;
   // Now enforce that the limbs are all equal to the constants
-  #[allow(clippy::needless_range_loop)]
-  for i in 0..n_limbs {
+  (0..n_limbs).for_each(|i| {
     cs.enforce(
       || format!("check limb {i}"),
       |lc| lc + &bignat.limbs[i],
       |lc| lc + CS::one(),
       |lc| lc + (limbs[i], CS::one()),
     );
-  }
+  });
   Ok(bignat)
 }
 


### PR DESCRIPTION
Simple PR getting rid of some clippy attributes.

`clippy::upper_case_acronyms` seems to not trigger for `ShapeCS` and `TestShapeCS`, so this just removes the unnecessary allows for those.

Removing `clippy::needless_range_loop` is a bit more opinionated. Used a `for_each()` to get rid of it but conceptually I can see it being easier for some to read a _for i in X_ notation instead, even though the result is the same. I can undo this change, if the _for i in X_ style is preferable here.

The only clippy attribute that can't be gotten rid of is the `upper_case_acronyms` annotation for `NIFS`.