### PR TITLE
refactor is_sat and modify comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ where
     let r_U_primary =
       RelaxedR1CSInstance::from_r1cs_instance(&pp.ck_primary, &pp.r1cs_shape_primary, &l_u_primary);
 
-    // IVC proof of the secondary circuit
+    // IVC proof for the secondary circuit
     let l_w_secondary = w_secondary;
     let l_u_secondary = u_secondary;
     let r_W_secondary = RelaxedR1CSWitness::<G2>::default(&pp.r1cs_shape_secondary);


### PR DESCRIPTION
Hi there

I found some methods that can be improved.

- replaced **is_sat** equation with `all()`.
- removed unnecessary {}
- unified description

I would appreciate it if you could confirm.
Thank you.