### PR TITLE
fix: remove a duplicate `R1CSShape` in the `RelaxedR1CSSNARK`'s chosen `ProverKey` (Arecibo backport)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -675,6 +675,7 @@ where
         S1::prove(
           &pp.ck_primary,
           &pk.pk_primary,
+          &pp.r1cs_shape_primary,
           &recursive_snark.r_U_primary,
           &recursive_snark.r_W_primary,
         )
@@ -683,6 +684,7 @@ where
         S2::prove(
           &pp.ck_secondary,
           &pk.pk_secondary,
+          &pp.r1cs_shape_secondary,
           &f_U_secondary,
           &f_W_secondary,
         )

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -155,13 +155,14 @@ impl<G: Group> R1CSShape<G> {
   }
 
   // Checks regularity conditions on the R1CSShape, required in Spartan-class SNARKs
-  // Panics if num_cons, num_vars, or num_io are not powers of two, or if num_io > num_vars
+  // Returns false if num_cons, num_vars, or num_io are not powers of two, or if num_io > num_vars
   #[inline]
-  pub(crate) fn check_regular_shape(&self) {
-    assert_eq!(self.num_cons.next_power_of_two(), self.num_cons);
-    assert_eq!(self.num_vars.next_power_of_two(), self.num_vars);
-    assert_eq!(self.num_io.next_power_of_two(), self.num_io);
-    assert!(self.num_io < self.num_vars);
+  pub(crate) fn is_regular_shape(&self) -> bool {
+    let cons_valid = self.num_cons.next_power_of_two() == self.num_cons;
+    let vars_valid = self.num_vars.next_power_of_two() == self.num_vars;
+    let io_valid = self.num_io.next_power_of_two() == self.num_io;
+    let io_lt_vars = self.num_io < self.num_vars;
+    cons_valid && vars_valid && io_valid && io_lt_vars
   }
 
   pub fn multiply_vec(
@@ -637,7 +638,7 @@ mod tests {
 
   fn test_pad_tiny_r1cs_with<G: Group>() {
     let padded_r1cs = tiny_r1cs::<G>(3).pad();
-    padded_r1cs.check_regular_shape();
+    assert!(padded_r1cs.is_regular_shape());
 
     let expected_r1cs = tiny_r1cs::<G>(4);
 

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -129,7 +129,7 @@ impl<G: Group, S: RelaxedR1CSSNARKTrait<G>, C: StepCircuit<G::Scalar>> DirectSNA
     );
 
     // prove the instance using Spartan
-    let snark = S::prove(&pk.ck, &pk.pk, &u_relaxed, &w_relaxed)?;
+    let snark = S::prove(&pk.ck, &pk.pk, &pk.S, &u_relaxed, &w_relaxed)?;
 
     Ok(DirectSNARK {
       comm_W: u.comm_W,

--- a/src/traits/snark.rs
+++ b/src/traits/snark.rs
@@ -28,6 +28,7 @@ pub trait RelaxedR1CSSNARKTrait<G: Group>:
   fn prove(
     ck: &CommitmentKey<G>,
     pk: &Self::ProverKey,
+    S: &R1CSShape<G>,
     U: &RelaxedR1CSInstance<G>,
     W: &RelaxedR1CSWitness<G>,
   ) -> Result<Self, NovaError>;


### PR DESCRIPTION
As explained by @zaverucha in https://github.com/microsoft/Spartan2/pull/2 (with edits for precision):

The `R1CSShape` object was being stored in both:
- the `ProverKey` of the `spartan::direct::DirectSNARK`, which generically employs any instance of `RelaxedR1CSSNARKTrait`,
- the `ProverKey` of each of the two `RelaxedR1CSSNARKTrait` implementations in `spartan::{snark, ppsnark}::RelaxedR1CSSNARK`,
- the `PublicParams` that are passed to the proof method of `crate::CompressedSNARK<G1, G2, C1, C2, S1, S2>`, which generically employs any instance of `RelaxedR1CSSNARKTrait`.

IOW, `RelaxedR1CSSNARKTrait` is always accessed through generic structs (`DirectSNARK`, `CompressedSNARK`) which already have a copy of the relevant `R1CSShape`. We store it once in the top level object (`DirectSNARK`'s `ProverKey` or `PublicParams`) and pass it to the Spartan implementation. The prover pads the `R1CSShape` (for the benefit of the IPA) on-the-fly.

This saves memory and makes serialization of the `ProverKey` about twice as fast. Both are significant when there are a large number of constraints.

Backports https://github.com/lurk-lab/arecibo/pull/66

Impact on performance within the measurement error range:
```
group                                                        arecibo_66           main
-----                                                        ----------           ----
CompressedSNARK-Commitments-StepCircuitSize-0/Prove          1.00       7.5±0.12s 1.00       7.5±0.14s
CompressedSNARK-Commitments-StepCircuitSize-0/Verify         1.00   189.0±14.24ms 1.00    188.1±9.19ms
CompressedSNARK-Commitments-StepCircuitSize-121253/Prove     1.01      20.2±0.16s 1.00      20.0±0.42s
CompressedSNARK-Commitments-StepCircuitSize-121253/Verify    1.00   531.8±11.98ms 1.01   536.7±21.06ms
CompressedSNARK-Commitments-StepCircuitSize-22949/Prove      1.00      11.4±0.12s 1.01      11.6±0.35s
CompressedSNARK-Commitments-StepCircuitSize-22949/Verify     1.00   298.0±16.23ms 1.01   300.5±14.35ms
CompressedSNARK-Commitments-StepCircuitSize-252325/Prove     1.00      36.0±1.07s 1.00      36.2±1.01s
CompressedSNARK-Commitments-StepCircuitSize-252325/Verify    1.00   827.5±23.45ms 1.00   831.6±38.99ms
CompressedSNARK-Commitments-StepCircuitSize-55717/Prove      1.00      19.8±0.47s 1.01      20.0±0.50s
CompressedSNARK-Commitments-StepCircuitSize-55717/Verify     1.01   543.7±39.55ms 1.00   536.0±24.43ms
CompressedSNARK-Commitments-StepCircuitSize-6565/Prove       1.00      11.2±0.25s 1.00      11.3±0.25s
CompressedSNARK-Commitments-StepCircuitSize-6565/Verify      1.00   296.2±10.35ms 1.01   298.0±17.18ms
CompressedSNARK-StepCircuitSize-0/Prove                      1.05   789.4±42.53ms 1.00    753.9±8.23ms
CompressedSNARK-StepCircuitSize-0/Verify                     1.00     31.4±0.68ms 1.01     31.7±1.22ms
CompressedSNARK-StepCircuitSize-1038757/Prove                1.00      24.4±0.64s 1.00      24.3±0.59s
CompressedSNARK-StepCircuitSize-1038757/Verify               1.04   850.5±48.90ms 1.00   816.7±29.39ms
CompressedSNARK-StepCircuitSize-121253/Prove                 1.02       3.4±0.11s 1.00       3.3±0.05s
CompressedSNARK-StepCircuitSize-121253/Verify                1.00    127.3±8.46ms 1.00    126.8±3.52ms
CompressedSNARK-StepCircuitSize-22949/Prove                  1.00   1113.1±9.89ms 1.01  1126.1±15.84ms
CompressedSNARK-StepCircuitSize-22949/Verify                 1.01     49.0±2.81ms 1.00     48.6±1.77ms
CompressedSNARK-StepCircuitSize-252325/Prove                 1.02       6.2±0.23s 1.00       6.1±0.21s
CompressedSNARK-StepCircuitSize-252325/Verify                1.00   240.6±14.40ms 1.02   244.7±23.88ms
CompressedSNARK-StepCircuitSize-514469/Prove                 1.01      12.6±0.19s 1.00      12.5±0.19s
CompressedSNARK-StepCircuitSize-514469/Verify                1.03   502.2±15.04ms 1.00   485.9±13.17ms
CompressedSNARK-StepCircuitSize-55717/Prove                  1.02  1873.3±65.45ms 1.00  1843.1±26.30ms
CompressedSNARK-StepCircuitSize-55717/Verify                 1.03     73.5±3.58ms 1.00     71.4±3.43ms
CompressedSNARK-StepCircuitSize-6565/Prove                   1.00   765.1±14.72ms 1.00    762.0±8.86ms
CompressedSNARK-StepCircuitSize-6565/Verify                  1.01     32.0±1.47ms 1.00     31.7±0.69ms
```