### PR TITLE
Digest simplifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-snark"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Srinath Setty <srinath@microsoft.com>"]
 edition = "2021"
 description = "Recursive zkSNARKs without trusted setup"

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -5,7 +5,6 @@ mod util;
 
 use crate::{
   constants::{BN_LIMB_WIDTH, BN_N_LIMBS},
-  digest::{DigestComputer, SimpleDigestible},
   errors::NovaError,
   gadgets::{
     nonnative::{bignat::nat_to_limbs, util::f_to_nat},
@@ -18,8 +17,6 @@ use crate::{
 };
 use core::{cmp::max, marker::PhantomData};
 use ff::Field;
-use once_cell::sync::OnceCell;
-
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -41,11 +38,7 @@ pub struct R1CSShape<G: Group> {
   pub(crate) A: SparseMatrix<G::Scalar>,
   pub(crate) B: SparseMatrix<G::Scalar>,
   pub(crate) C: SparseMatrix<G::Scalar>,
-  #[serde(skip, default = "OnceCell::new")]
-  pub(crate) digest: OnceCell<G::Scalar>,
 }
-
-impl<G: Group> SimpleDigestible for R1CSShape<G> {}
 
 /// A type that holds a witness for a given R1CS instance
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -141,17 +134,7 @@ impl<G: Group> R1CSShape<G> {
       A,
       B,
       C,
-      digest: OnceCell::new(),
     })
-  }
-
-  /// returned the digest of the `R1CSShape`
-  pub fn digest(&self) -> G::Scalar {
-    self
-      .digest
-      .get_or_try_init(|| DigestComputer::new(self).digest())
-      .cloned()
-      .expect("Failure retrieving digest")
   }
 
   // Checks regularity conditions on the R1CSShape, required in Spartan-class SNARKs
@@ -321,7 +304,6 @@ impl<G: Group> R1CSShape<G> {
         A: self.A.clone(),
         B: self.B.clone(),
         C: self.C.clone(),
-        digest: OnceCell::new(),
       };
     }
 
@@ -357,7 +339,6 @@ impl<G: Group> R1CSShape<G> {
       A: A_padded,
       B: B_padded,
       C: C_padded,
-      digest: OnceCell::new(),
     }
   }
 }

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -670,11 +670,21 @@ pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G>> {
   num_vars: usize,
   vk_ee: EE::VerifierKey,
   S_comm: R1CSShapeSparkCommitment<G>,
+  digest: G::Scalar,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound = "")]
+struct VerifierKeyInternal<G: Group, EE: EvaluationEngineTrait<G>> {
+  num_cons: usize,
+  num_vars: usize,
+  vk_ee: EE::VerifierKey,
+  S_comm: R1CSShapeSparkCommitment<G>,
   #[serde(skip, default = "OnceCell::new")]
   digest: OnceCell<G::Scalar>,
 }
 
-impl<G: Group, EE: EvaluationEngineTrait<G>> SimpleDigestible for VerifierKey<G, EE> {}
+impl<G: Group, EE: EvaluationEngineTrait<G>> SimpleDigestible for VerifierKeyInternal<G, EE> {}
 
 /// A succinct proof of knowledge of a witness to a relaxed R1CS instance
 /// The proof is produced using Spartan's combination of the sum-check and
@@ -842,14 +852,14 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARK<G, EE> {
   }
 }
 
-impl<G: Group, EE: EvaluationEngineTrait<G>> VerifierKey<G, EE> {
+impl<G: Group, EE: EvaluationEngineTrait<G>> VerifierKeyInternal<G, EE> {
   fn new(
     num_cons: usize,
     num_vars: usize,
     S_comm: R1CSShapeSparkCommitment<G>,
     vk_ee: EE::VerifierKey,
   ) -> Self {
-    VerifierKey {
+    VerifierKeyInternal {
       num_cons,
       num_vars,
       S_comm,
@@ -887,14 +897,23 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for Relaxe
     let S_repr = R1CSShapeSparkRepr::new(&S);
     let S_comm = S_repr.commit(ck);
 
-    let vk = VerifierKey::new(S.num_cons, S.num_vars, S_comm.clone(), vk_ee);
+    let vk_internal: VerifierKeyInternal<G, EE> =
+      VerifierKeyInternal::new(S.num_cons, S.num_vars, S_comm.clone(), vk_ee.clone());
 
     let pk = ProverKey {
       pk_ee,
       S,
       S_repr,
+      S_comm: S_comm.clone(),
+      vk_digest: vk_internal.digest(),
+    };
+
+    let vk = VerifierKey {
+      num_cons: vk_internal.num_cons,
+      num_vars: vk_internal.num_vars,
+      vk_ee,
       S_comm,
-      vk_digest: vk.digest(),
+      digest: vk_internal.digest(),
     };
 
     Ok((pk, vk))
@@ -1516,7 +1535,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for Relaxe
     let mut u_vec: Vec<PolyEvalInstance<G>> = Vec::new();
 
     // append the verifier key (including commitment to R1CS matrices) and the RelaxedR1CSInstance to the transcript
-    transcript.absorb(b"vk", &vk.digest());
+    transcript.absorb(b"vk", &vk.digest);
     transcript.absorb(b"U", U);
 
     let comm_Az = Commitment::<G>::decompress(&self.comm_Az)?;


### PR DESCRIPTION
PR #229 introduces simplifications to digest computation, but it makes the verifier compute digests on its own, changing the behavior prior to that PR. This PR restores that functionality with an internal type.