### PR TITLE
chore: Upgrade 'neptune' dependency to version 12.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rand_core = { version = "0.6", default-features = false }
 rand_chacha = "0.3"
 subtle = "2.5"
 pasta_curves = { version = "0.5", features = ["repr-c", "serde"] }
-neptune = { version = "11.1.0", default-features = false }
+neptune = { version = "12.0.0", default-features = false }
 generic-array = "0.14"
 num-bigint = { version = "0.4", features = ["serde", "rand"] }
 num-traits = "0.2"


### PR DESCRIPTION
- Upgrades the `neptune` dependency to the latest version,
- prior version 11.1.0 broke semver and had to be yanked.