### PR TITLE
Restore digest computation and fix API inconsistency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-snark"
-version = "0.24.0"
+version = "0.26.0"
 authors = ["Srinath Setty <srinath@microsoft.com>"]
 edition = "2021"
 description = "Recursive zkSNARKs without trusted setup"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-snark"
-version = "0.25.0"
+version = "0.24.0"
 authors = ["Srinath Setty <srinath@microsoft.com>"]
 edition = "2021"
 description = "Recursive zkSNARKs without trusted setup"

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -78,16 +78,11 @@ fn bench_compressed_snark(c: &mut Criterion) {
       &c_secondary,
       &[<G1 as Group>::Scalar::from(2u64)],
       &[<G2 as Group>::Scalar::from(2u64)],
-    );
+    )
+    .unwrap();
 
     for i in 0..num_steps {
-      let res = recursive_snark.prove_step(
-        &pp,
-        &c_primary,
-        &c_secondary,
-        &[<G1 as Group>::Scalar::from(2u64)],
-        &[<G2 as Group>::Scalar::from(2u64)],
-      );
+      let res = recursive_snark.prove_step(&pp, &c_primary, &c_secondary);
       assert!(res.is_ok());
 
       // verify the recursive snark at each step of recursion
@@ -165,16 +160,11 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
       &c_secondary,
       &[<G1 as Group>::Scalar::from(2u64)],
       &[<G2 as Group>::Scalar::from(2u64)],
-    );
+    )
+    .unwrap();
 
     for i in 0..num_steps {
-      let res = recursive_snark.prove_step(
-        &pp,
-        &c_primary,
-        &c_secondary,
-        &[<G1 as Group>::Scalar::from(2u64)],
-        &[<G2 as Group>::Scalar::from(2u64)],
-      );
+      let res = recursive_snark.prove_step(&pp, &c_primary, &c_secondary);
       assert!(res.is_ok());
 
       // verify the recursive snark at each step of recursion

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -76,8 +76,8 @@ fn bench_compressed_snark(c: &mut Criterion) {
       &pp,
       &c_primary,
       &c_secondary,
-      vec![<G1 as Group>::Scalar::from(2u64)],
-      vec![<G2 as Group>::Scalar::from(2u64)],
+      &[<G1 as Group>::Scalar::from(2u64)],
+      &[<G2 as Group>::Scalar::from(2u64)],
     );
 
     for i in 0..num_steps {
@@ -85,8 +85,8 @@ fn bench_compressed_snark(c: &mut Criterion) {
         &pp,
         &c_primary,
         &c_secondary,
-        vec![<G1 as Group>::Scalar::from(2u64)],
-        vec![<G2 as Group>::Scalar::from(2u64)],
+        &[<G1 as Group>::Scalar::from(2u64)],
+        &[<G2 as Group>::Scalar::from(2u64)],
       );
       assert!(res.is_ok());
 
@@ -122,8 +122,8 @@ fn bench_compressed_snark(c: &mut Criterion) {
           .verify(
             black_box(&vk),
             black_box(num_steps),
-            black_box(vec![<G1 as Group>::Scalar::from(2u64)]),
-            black_box(vec![<G2 as Group>::Scalar::from(2u64)]),
+            black_box(&[<G1 as Group>::Scalar::from(2u64)]),
+            black_box(&[<G2 as Group>::Scalar::from(2u64)]),
           )
           .is_ok());
       })
@@ -163,8 +163,8 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
       &pp,
       &c_primary,
       &c_secondary,
-      vec![<G1 as Group>::Scalar::from(2u64)],
-      vec![<G2 as Group>::Scalar::from(2u64)],
+      &[<G1 as Group>::Scalar::from(2u64)],
+      &[<G2 as Group>::Scalar::from(2u64)],
     );
 
     for i in 0..num_steps {
@@ -172,8 +172,8 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
         &pp,
         &c_primary,
         &c_secondary,
-        vec![<G1 as Group>::Scalar::from(2u64)],
-        vec![<G2 as Group>::Scalar::from(2u64)],
+        &[<G1 as Group>::Scalar::from(2u64)],
+        &[<G2 as Group>::Scalar::from(2u64)],
       );
       assert!(res.is_ok());
 
@@ -209,8 +209,8 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
           .verify(
             black_box(&vk),
             black_box(num_steps),
-            black_box(vec![<G1 as Group>::Scalar::from(2u64)]),
-            black_box(vec![<G2 as Group>::Scalar::from(2u64)]),
+            black_box(&[<G1 as Group>::Scalar::from(2u64)]),
+            black_box(&[<G2 as Group>::Scalar::from(2u64)]),
           )
           .is_ok());
       })

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -67,8 +67,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
       &pp,
       &c_primary,
       &c_secondary,
-      vec![<G1 as Group>::Scalar::from(2u64)],
-      vec![<G2 as Group>::Scalar::from(2u64)],
+      &[<G1 as Group>::Scalar::from(2u64)],
+      &[<G2 as Group>::Scalar::from(2u64)],
     );
 
     for i in 0..num_warmup_steps {
@@ -76,8 +76,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
         &pp,
         &c_primary,
         &c_secondary,
-        vec![<G1 as Group>::Scalar::from(2u64)],
-        vec![<G2 as Group>::Scalar::from(2u64)],
+        &[<G1 as Group>::Scalar::from(2u64)],
+        &[<G2 as Group>::Scalar::from(2u64)],
       );
       assert!(res.is_ok());
 
@@ -99,8 +99,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
             black_box(&pp),
             black_box(&c_primary),
             black_box(&c_secondary),
-            black_box(vec![<G1 as Group>::Scalar::from(2u64)]),
-            black_box(vec![<G2 as Group>::Scalar::from(2u64)]),
+            black_box(&[<G1 as Group>::Scalar::from(2u64)]),
+            black_box(&[<G2 as Group>::Scalar::from(2u64)]),
           )
           .is_ok());
       })

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -69,16 +69,11 @@ fn bench_recursive_snark(c: &mut Criterion) {
       &c_secondary,
       &[<G1 as Group>::Scalar::from(2u64)],
       &[<G2 as Group>::Scalar::from(2u64)],
-    );
+    )
+    .unwrap();
 
     for i in 0..num_warmup_steps {
-      let res = recursive_snark.prove_step(
-        &pp,
-        &c_primary,
-        &c_secondary,
-        &[<G1 as Group>::Scalar::from(2u64)],
-        &[<G2 as Group>::Scalar::from(2u64)],
-      );
+      let res = recursive_snark.prove_step(&pp, &c_primary, &c_secondary);
       assert!(res.is_ok());
 
       // verify the recursive snark at each step of recursion
@@ -99,8 +94,6 @@ fn bench_recursive_snark(c: &mut Criterion) {
             black_box(&pp),
             black_box(&c_primary),
             black_box(&c_secondary),
-            black_box(&[<G1 as Group>::Scalar::from(2u64)]),
-            black_box(&[<G2 as Group>::Scalar::from(2u64)]),
           )
           .is_ok());
       })

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -169,15 +169,15 @@ fn bench_recursive_snark(c: &mut Criterion) {
           black_box(&circuit_secondary),
           black_box(&z0_primary),
           black_box(&z0_secondary),
-        );
+        )
+        .unwrap();
+
         // produce a recursive SNARK for a step of the recursion
         assert!(recursive_snark
           .prove_step(
             black_box(&pp),
             black_box(&circuit_primary),
             black_box(&circuit_secondary),
-            black_box(&z0_primary),
-            black_box(&z0_secondary),
           )
           .is_ok());
       })

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -167,8 +167,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
           black_box(&pp),
           black_box(&circuit_primary),
           black_box(&circuit_secondary),
-          black_box(z0_primary.clone()),
-          black_box(z0_secondary.clone()),
+          black_box(&z0_primary),
+          black_box(&z0_secondary),
         );
         // produce a recursive SNARK for a step of the recursion
         assert!(recursive_snark
@@ -176,8 +176,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
             black_box(&pp),
             black_box(&circuit_primary),
             black_box(&circuit_secondary),
-            black_box(z0_primary.clone()),
-            black_box(z0_secondary.clone()),
+            black_box(&z0_primary),
+            black_box(&z0_secondary),
           )
           .is_ok());
       })

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -207,23 +207,19 @@ fn main() {
     type C2 = TrivialCircuit<<G2 as Group>::Scalar>;
     // produce a recursive SNARK
     println!("Generating a RecursiveSNARK...");
-    let mut recursive_snark: RecursiveSNARK<G1, G2, C1, C2> = RecursiveSNARK::<G1, G2, C1, C2>::new(
-      &pp,
-      &minroot_circuits[0],
-      &circuit_secondary,
-      &z0_primary,
-      &z0_secondary,
-    );
-
-    for (i, circuit_primary) in minroot_circuits.iter().take(num_steps).enumerate() {
-      let start = Instant::now();
-      let res = recursive_snark.prove_step(
+    let mut recursive_snark: RecursiveSNARK<G1, G2, C1, C2> =
+      RecursiveSNARK::<G1, G2, C1, C2>::new(
         &pp,
-        circuit_primary,
+        &minroot_circuits[0],
         &circuit_secondary,
         &z0_primary,
         &z0_secondary,
-      );
+      )
+      .unwrap();
+
+    for (i, circuit_primary) in minroot_circuits.iter().take(num_steps).enumerate() {
+      let start = Instant::now();
+      let res = recursive_snark.prove_step(&pp, circuit_primary, &circuit_secondary);
       assert!(res.is_ok());
       println!(
         "RecursiveSNARK::prove_step {}: {:?}, took {:?} ",

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -211,8 +211,8 @@ fn main() {
       &pp,
       &minroot_circuits[0],
       &circuit_secondary,
-      z0_primary.clone(),
-      z0_secondary.clone(),
+      &z0_primary,
+      &z0_secondary,
     );
 
     for (i, circuit_primary) in minroot_circuits.iter().take(num_steps).enumerate() {
@@ -221,8 +221,8 @@ fn main() {
         &pp,
         circuit_primary,
         &circuit_secondary,
-        z0_primary.clone(),
-        z0_secondary.clone(),
+        &z0_primary,
+        &z0_secondary,
       );
       assert!(res.is_ok());
       println!(
@@ -274,7 +274,7 @@ fn main() {
     // verify the compressed SNARK
     println!("Verifying a CompressedSNARK...");
     let start = Instant::now();
-    let res = compressed_snark.verify(&vk, num_steps, z0_primary, z0_secondary);
+    let res = compressed_snark.verify(&vk, num_steps, &z0_primary, &z0_secondary);
     println!(
       "CompressedSNARK::verify: {:?}, took {:?}",
       res.is_ok(),

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -5,6 +5,7 @@ mod util;
 
 use crate::{
   constants::{BN_LIMB_WIDTH, BN_N_LIMBS},
+  digest::{DigestComputer, SimpleDigestible},
   errors::NovaError,
   gadgets::{
     nonnative::{bignat::nat_to_limbs, util::f_to_nat},
@@ -17,6 +18,8 @@ use crate::{
 };
 use core::{cmp::max, marker::PhantomData};
 use ff::Field;
+use once_cell::sync::OnceCell;
+
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -38,7 +41,11 @@ pub struct R1CSShape<G: Group> {
   pub(crate) A: SparseMatrix<G::Scalar>,
   pub(crate) B: SparseMatrix<G::Scalar>,
   pub(crate) C: SparseMatrix<G::Scalar>,
+  #[serde(skip, default = "OnceCell::new")]
+  pub(crate) digest: OnceCell<G::Scalar>,
 }
+
+impl<G: Group> SimpleDigestible for R1CSShape<G> {}
 
 /// A type that holds a witness for a given R1CS instance
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -134,7 +141,17 @@ impl<G: Group> R1CSShape<G> {
       A,
       B,
       C,
+      digest: OnceCell::new(),
     })
+  }
+
+  /// returned the digest of the `R1CSShape`
+  pub fn digest(&self) -> G::Scalar {
+    self
+      .digest
+      .get_or_try_init(|| DigestComputer::new(self).digest())
+      .cloned()
+      .expect("Failure retrieving digest")
   }
 
   // Checks regularity conditions on the R1CSShape, required in Spartan-class SNARKs
@@ -304,6 +321,7 @@ impl<G: Group> R1CSShape<G> {
         A: self.A.clone(),
         B: self.B.clone(),
         C: self.C.clone(),
+        digest: OnceCell::new(),
       };
     }
 
@@ -339,6 +357,7 @@ impl<G: Group> R1CSShape<G> {
       A: A_padded,
       B: B_padded,
       C: C_padded,
+      digest: OnceCell::new(),
     }
   }
 }


### PR DESCRIPTION
Restores digest functionality prior to #238

Makes public interfaces of RecursiveSNARK and CompressedSNARK take references rather than copies (in the prior version, some methods took references whereas others took copies, which is confusing from an API usage perspective).