### PR TITLE
Move to actual Group trait

### DIFF
--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -4,11 +4,9 @@ use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use core::marker::PhantomData;
 use criterion::*;
 use ff::PrimeField;
+use group::Group;
 use nova_snark::{
-  traits::{
-    circuit::{StepCircuit, TrivialCircuit},
-    GroupExt,
-  },
+  traits::circuit::{StepCircuit, TrivialCircuit},
   CompressedSNARK, PublicParams, RecursiveSNARK,
 };
 use std::time::Duration;
@@ -23,8 +21,8 @@ type S2 = nova_snark::spartan::snark::RelaxedR1CSSNARK<G2, EE2>;
 // SNARKs with computational commitments
 type SS1 = nova_snark::spartan::ppsnark::RelaxedR1CSSNARK<G1, EE1>;
 type SS2 = nova_snark::spartan::ppsnark::RelaxedR1CSSNARK<G2, EE2>;
-type C1 = NonTrivialCircuit<<G1 as GroupExt>::Scalar>;
-type C2 = TrivialCircuit<<G2 as GroupExt>::Scalar>;
+type C1 = NonTrivialCircuit<<G1 as Group>::Scalar>;
+type C2 = TrivialCircuit<<G2 as Group>::Scalar>;
 
 // To run these benchmarks, first download `criterion` with `cargo install cargo install cargo-criterion`.
 // Then `cargo criterion --bench compressed-snark`. The results are located in `target/criterion/data/<name-of-benchmark>`.
@@ -76,8 +74,8 @@ fn bench_compressed_snark(c: &mut Criterion) {
       &pp,
       &c_primary,
       &c_secondary,
-      &[<G1 as GroupExt>::Scalar::from(2u64)],
-      &[<G2 as GroupExt>::Scalar::from(2u64)],
+      &[<G1 as Group>::Scalar::from(2u64)],
+      &[<G2 as Group>::Scalar::from(2u64)],
     )
     .unwrap();
 
@@ -89,8 +87,8 @@ fn bench_compressed_snark(c: &mut Criterion) {
       let res = recursive_snark.verify(
         &pp,
         i + 1,
-        &[<G1 as GroupExt>::Scalar::from(2u64)],
-        &[<G2 as GroupExt>::Scalar::from(2u64)],
+        &[<G1 as Group>::Scalar::from(2u64)],
+        &[<G2 as Group>::Scalar::from(2u64)],
       );
       assert!(res.is_ok());
     }
@@ -117,8 +115,8 @@ fn bench_compressed_snark(c: &mut Criterion) {
           .verify(
             black_box(&vk),
             black_box(num_steps),
-            black_box(&[<G1 as GroupExt>::Scalar::from(2u64)]),
-            black_box(&[<G2 as GroupExt>::Scalar::from(2u64)]),
+            black_box(&[<G1 as Group>::Scalar::from(2u64)]),
+            black_box(&[<G2 as Group>::Scalar::from(2u64)]),
           )
           .is_ok());
       })
@@ -158,8 +156,8 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
       &pp,
       &c_primary,
       &c_secondary,
-      &[<G1 as GroupExt>::Scalar::from(2u64)],
-      &[<G2 as GroupExt>::Scalar::from(2u64)],
+      &[<G1 as Group>::Scalar::from(2u64)],
+      &[<G2 as Group>::Scalar::from(2u64)],
     )
     .unwrap();
 
@@ -171,8 +169,8 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
       let res = recursive_snark.verify(
         &pp,
         i + 1,
-        &[<G1 as GroupExt>::Scalar::from(2u64)],
-        &[<G2 as GroupExt>::Scalar::from(2u64)],
+        &[<G1 as Group>::Scalar::from(2u64)],
+        &[<G2 as Group>::Scalar::from(2u64)],
       );
       assert!(res.is_ok());
     }
@@ -199,8 +197,8 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
           .verify(
             black_box(&vk),
             black_box(num_steps),
-            black_box(&[<G1 as GroupExt>::Scalar::from(2u64)]),
-            black_box(&[<G2 as GroupExt>::Scalar::from(2u64)]),
+            black_box(&[<G1 as Group>::Scalar::from(2u64)]),
+            black_box(&[<G2 as Group>::Scalar::from(2u64)]),
           )
           .is_ok());
       })

--- a/benches/compressed-snark.rs
+++ b/benches/compressed-snark.rs
@@ -7,7 +7,7 @@ use ff::PrimeField;
 use nova_snark::{
   traits::{
     circuit::{StepCircuit, TrivialCircuit},
-    Group,
+    GroupExt,
   },
   CompressedSNARK, PublicParams, RecursiveSNARK,
 };
@@ -23,8 +23,8 @@ type S2 = nova_snark::spartan::snark::RelaxedR1CSSNARK<G2, EE2>;
 // SNARKs with computational commitments
 type SS1 = nova_snark::spartan::ppsnark::RelaxedR1CSSNARK<G1, EE1>;
 type SS2 = nova_snark::spartan::ppsnark::RelaxedR1CSSNARK<G2, EE2>;
-type C1 = NonTrivialCircuit<<G1 as Group>::Scalar>;
-type C2 = TrivialCircuit<<G2 as Group>::Scalar>;
+type C1 = NonTrivialCircuit<<G1 as GroupExt>::Scalar>;
+type C2 = TrivialCircuit<<G2 as GroupExt>::Scalar>;
 
 // To run these benchmarks, first download `criterion` with `cargo install cargo install cargo-criterion`.
 // Then `cargo criterion --bench compressed-snark`. The results are located in `target/criterion/data/<name-of-benchmark>`.
@@ -76,8 +76,8 @@ fn bench_compressed_snark(c: &mut Criterion) {
       &pp,
       &c_primary,
       &c_secondary,
-      &[<G1 as Group>::Scalar::from(2u64)],
-      &[<G2 as Group>::Scalar::from(2u64)],
+      &[<G1 as GroupExt>::Scalar::from(2u64)],
+      &[<G2 as GroupExt>::Scalar::from(2u64)],
     )
     .unwrap();
 
@@ -89,8 +89,8 @@ fn bench_compressed_snark(c: &mut Criterion) {
       let res = recursive_snark.verify(
         &pp,
         i + 1,
-        &[<G1 as Group>::Scalar::from(2u64)],
-        &[<G2 as Group>::Scalar::from(2u64)],
+        &[<G1 as GroupExt>::Scalar::from(2u64)],
+        &[<G2 as GroupExt>::Scalar::from(2u64)],
       );
       assert!(res.is_ok());
     }
@@ -117,8 +117,8 @@ fn bench_compressed_snark(c: &mut Criterion) {
           .verify(
             black_box(&vk),
             black_box(num_steps),
-            black_box(&[<G1 as Group>::Scalar::from(2u64)]),
-            black_box(&[<G2 as Group>::Scalar::from(2u64)]),
+            black_box(&[<G1 as GroupExt>::Scalar::from(2u64)]),
+            black_box(&[<G2 as GroupExt>::Scalar::from(2u64)]),
           )
           .is_ok());
       })
@@ -158,8 +158,8 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
       &pp,
       &c_primary,
       &c_secondary,
-      &[<G1 as Group>::Scalar::from(2u64)],
-      &[<G2 as Group>::Scalar::from(2u64)],
+      &[<G1 as GroupExt>::Scalar::from(2u64)],
+      &[<G2 as GroupExt>::Scalar::from(2u64)],
     )
     .unwrap();
 
@@ -171,8 +171,8 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
       let res = recursive_snark.verify(
         &pp,
         i + 1,
-        &[<G1 as Group>::Scalar::from(2u64)],
-        &[<G2 as Group>::Scalar::from(2u64)],
+        &[<G1 as GroupExt>::Scalar::from(2u64)],
+        &[<G2 as GroupExt>::Scalar::from(2u64)],
       );
       assert!(res.is_ok());
     }
@@ -199,8 +199,8 @@ fn bench_compressed_snark_with_computational_commitments(c: &mut Criterion) {
           .verify(
             black_box(&vk),
             black_box(num_steps),
-            black_box(&[<G1 as Group>::Scalar::from(2u64)]),
-            black_box(&[<G2 as Group>::Scalar::from(2u64)]),
+            black_box(&[<G1 as GroupExt>::Scalar::from(2u64)]),
+            black_box(&[<G2 as GroupExt>::Scalar::from(2u64)]),
           )
           .is_ok());
       })

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -6,15 +6,15 @@ use ff::PrimeField;
 use nova_snark::{
   traits::{
     circuit::{StepCircuit, TrivialCircuit},
-    Group,
+    GroupExt,
   },
   PublicParams,
 };
 
 type G1 = pasta_curves::pallas::Point;
 type G2 = pasta_curves::vesta::Point;
-type C1 = NonTrivialCircuit<<G1 as Group>::Scalar>;
-type C2 = TrivialCircuit<<G2 as Group>::Scalar>;
+type C1 = NonTrivialCircuit<<G1 as GroupExt>::Scalar>;
+type C2 = TrivialCircuit<<G2 as GroupExt>::Scalar>;
 
 criterion_group! {
 name = compute_digest;

--- a/benches/compute-digest.rs
+++ b/benches/compute-digest.rs
@@ -3,18 +3,16 @@ use std::{marker::PhantomData, time::Duration};
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ff::PrimeField;
+use group::Group;
 use nova_snark::{
-  traits::{
-    circuit::{StepCircuit, TrivialCircuit},
-    GroupExt,
-  },
+  traits::circuit::{StepCircuit, TrivialCircuit},
   PublicParams,
 };
 
 type G1 = pasta_curves::pallas::Point;
 type G2 = pasta_curves::vesta::Point;
-type C1 = NonTrivialCircuit<<G1 as GroupExt>::Scalar>;
-type C2 = TrivialCircuit<<G2 as GroupExt>::Scalar>;
+type C1 = NonTrivialCircuit<<G1 as Group>::Scalar>;
+type C2 = TrivialCircuit<<G2 as Group>::Scalar>;
 
 criterion_group! {
 name = compute_digest;

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -4,19 +4,17 @@ use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use core::marker::PhantomData;
 use criterion::*;
 use ff::PrimeField;
+use group::Group;
 use nova_snark::{
-  traits::{
-    circuit::{StepCircuit, TrivialCircuit},
-    GroupExt,
-  },
+  traits::circuit::{StepCircuit, TrivialCircuit},
   PublicParams, RecursiveSNARK,
 };
 use std::time::Duration;
 
 type G1 = pasta_curves::pallas::Point;
 type G2 = pasta_curves::vesta::Point;
-type C1 = NonTrivialCircuit<<G1 as GroupExt>::Scalar>;
-type C2 = TrivialCircuit<<G2 as GroupExt>::Scalar>;
+type C1 = NonTrivialCircuit<<G1 as Group>::Scalar>;
+type C2 = TrivialCircuit<<G2 as Group>::Scalar>;
 
 // To run these benchmarks, first download `criterion` with `cargo install cargo install cargo-criterion`.
 // Then `cargo criterion --bench recursive-snark`. The results are located in `target/criterion/data/<name-of-benchmark>`.
@@ -67,8 +65,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
       &pp,
       &c_primary,
       &c_secondary,
-      &[<G1 as GroupExt>::Scalar::from(2u64)],
-      &[<G2 as GroupExt>::Scalar::from(2u64)],
+      &[<G1 as Group>::Scalar::from(2u64)],
+      &[<G2 as Group>::Scalar::from(2u64)],
     )
     .unwrap();
 
@@ -80,8 +78,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
       let res = recursive_snark.verify(
         &pp,
         i + 1,
-        &[<G1 as GroupExt>::Scalar::from(2u64)],
-        &[<G2 as GroupExt>::Scalar::from(2u64)],
+        &[<G1 as Group>::Scalar::from(2u64)],
+        &[<G2 as Group>::Scalar::from(2u64)],
       );
       assert!(res.is_ok());
     }
@@ -106,8 +104,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
           .verify(
             black_box(&pp),
             black_box(num_warmup_steps),
-            black_box(&[<G1 as GroupExt>::Scalar::from(2u64)]),
-            black_box(&[<G2 as GroupExt>::Scalar::from(2u64)]),
+            black_box(&[<G1 as Group>::Scalar::from(2u64)]),
+            black_box(&[<G2 as Group>::Scalar::from(2u64)]),
           )
           .is_ok());
       });

--- a/benches/recursive-snark.rs
+++ b/benches/recursive-snark.rs
@@ -7,7 +7,7 @@ use ff::PrimeField;
 use nova_snark::{
   traits::{
     circuit::{StepCircuit, TrivialCircuit},
-    Group,
+    GroupExt,
   },
   PublicParams, RecursiveSNARK,
 };
@@ -15,8 +15,8 @@ use std::time::Duration;
 
 type G1 = pasta_curves::pallas::Point;
 type G2 = pasta_curves::vesta::Point;
-type C1 = NonTrivialCircuit<<G1 as Group>::Scalar>;
-type C2 = TrivialCircuit<<G2 as Group>::Scalar>;
+type C1 = NonTrivialCircuit<<G1 as GroupExt>::Scalar>;
+type C2 = TrivialCircuit<<G2 as GroupExt>::Scalar>;
 
 // To run these benchmarks, first download `criterion` with `cargo install cargo install cargo-criterion`.
 // Then `cargo criterion --bench recursive-snark`. The results are located in `target/criterion/data/<name-of-benchmark>`.
@@ -67,8 +67,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
       &pp,
       &c_primary,
       &c_secondary,
-      &[<G1 as Group>::Scalar::from(2u64)],
-      &[<G2 as Group>::Scalar::from(2u64)],
+      &[<G1 as GroupExt>::Scalar::from(2u64)],
+      &[<G2 as GroupExt>::Scalar::from(2u64)],
     )
     .unwrap();
 
@@ -80,8 +80,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
       let res = recursive_snark.verify(
         &pp,
         i + 1,
-        &[<G1 as Group>::Scalar::from(2u64)],
-        &[<G2 as Group>::Scalar::from(2u64)],
+        &[<G1 as GroupExt>::Scalar::from(2u64)],
+        &[<G2 as GroupExt>::Scalar::from(2u64)],
       );
       assert!(res.is_ok());
     }
@@ -106,8 +106,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
           .verify(
             black_box(&pp),
             black_box(num_warmup_steps),
-            black_box(&[<G1 as Group>::Scalar::from(2u64)]),
-            black_box(&[<G2 as Group>::Scalar::from(2u64)]),
+            black_box(&[<G1 as GroupExt>::Scalar::from(2u64)]),
+            black_box(&[<G2 as GroupExt>::Scalar::from(2u64)]),
           )
           .is_ok());
       });

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -14,11 +14,9 @@ use bellpepper_core::{
 use core::time::Duration;
 use criterion::*;
 use ff::{PrimeField, PrimeFieldBits};
+use group::Group;
 use nova_snark::{
-  traits::{
-    circuit::{StepCircuit, TrivialCircuit},
-    GroupExt,
-  },
+  traits::circuit::{StepCircuit, TrivialCircuit},
   PublicParams, RecursiveSNARK,
 };
 use sha2::{Digest, Sha256};
@@ -119,8 +117,8 @@ impl<Scalar: PrimeField + PrimeFieldBits> StepCircuit<Scalar> for Sha256Circuit<
   }
 }
 
-type C1 = Sha256Circuit<<G1 as GroupExt>::Scalar>;
-type C2 = TrivialCircuit<<G2 as GroupExt>::Scalar>;
+type C1 = Sha256Circuit<<G1 as Group>::Scalar>;
+type C2 = TrivialCircuit<<G2 as Group>::Scalar>;
 
 criterion_group! {
 name = recursive_snark;
@@ -158,8 +156,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
     let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc);
 
     let circuit_secondary = TrivialCircuit::default();
-    let z0_primary = vec![<G1 as GroupExt>::Scalar::from(2u64)];
-    let z0_secondary = vec![<G2 as GroupExt>::Scalar::from(2u64)];
+    let z0_primary = vec![<G1 as Group>::Scalar::from(2u64)];
+    let z0_secondary = vec![<G2 as Group>::Scalar::from(2u64)];
 
     group.bench_function("Prove", |b| {
       b.iter(|| {

--- a/benches/sha256.rs
+++ b/benches/sha256.rs
@@ -17,7 +17,7 @@ use ff::{PrimeField, PrimeFieldBits};
 use nova_snark::{
   traits::{
     circuit::{StepCircuit, TrivialCircuit},
-    Group,
+    GroupExt,
   },
   PublicParams, RecursiveSNARK,
 };
@@ -119,8 +119,8 @@ impl<Scalar: PrimeField + PrimeFieldBits> StepCircuit<Scalar> for Sha256Circuit<
   }
 }
 
-type C1 = Sha256Circuit<<G1 as Group>::Scalar>;
-type C2 = TrivialCircuit<<G2 as Group>::Scalar>;
+type C1 = Sha256Circuit<<G1 as GroupExt>::Scalar>;
+type C2 = TrivialCircuit<<G2 as GroupExt>::Scalar>;
 
 criterion_group! {
 name = recursive_snark;
@@ -158,8 +158,8 @@ fn bench_recursive_snark(c: &mut Criterion) {
     let pp = PublicParams::<G1, G2, C1, C2>::setup(&circuit_primary, &ttc);
 
     let circuit_secondary = TrivialCircuit::default();
-    let z0_primary = vec![<G1 as Group>::Scalar::from(2u64)];
-    let z0_secondary = vec![<G2 as Group>::Scalar::from(2u64)];
+    let z0_primary = vec![<G1 as GroupExt>::Scalar::from(2u64)];
+    let z0_secondary = vec![<G2 as GroupExt>::Scalar::from(2u64)];
 
     group.bench_function("Prove", |b| {
       b.iter(|| {

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -9,7 +9,7 @@ use flate2::{write::ZlibEncoder, Compression};
 use nova_snark::{
   traits::{
     circuit::{StepCircuit, TrivialCircuit},
-    Group,
+    GroupExt,
   },
   CompressedSNARK, PublicParams, RecursiveSNARK,
 };
@@ -140,10 +140,10 @@ fn main() {
     let circuit_primary = MinRootCircuit {
       seq: vec![
         MinRootIteration {
-          x_i: <G1 as Group>::Scalar::zero(),
-          y_i: <G1 as Group>::Scalar::zero(),
-          x_i_plus_1: <G1 as Group>::Scalar::zero(),
-          y_i_plus_1: <G1 as Group>::Scalar::zero(),
+          x_i: <G1 as GroupExt>::Scalar::zero(),
+          y_i: <G1 as GroupExt>::Scalar::zero(),
+          x_i_plus_1: <G1 as GroupExt>::Scalar::zero(),
+          y_i_plus_1: <G1 as GroupExt>::Scalar::zero(),
         };
         num_iters_per_step
       ],
@@ -159,8 +159,8 @@ fn main() {
     let pp = PublicParams::<
       G1,
       G2,
-      MinRootCircuit<<G1 as Group>::Scalar>,
-      TrivialCircuit<<G2 as Group>::Scalar>,
+      MinRootCircuit<<G1 as GroupExt>::Scalar>,
+      TrivialCircuit<<G2 as GroupExt>::Scalar>,
     >::setup(&circuit_primary, &circuit_secondary);
     println!("PublicParams::setup, took {:?} ", start.elapsed());
 
@@ -185,8 +185,8 @@ fn main() {
     // produce non-deterministic advice
     let (z0_primary, minroot_iterations) = MinRootIteration::new(
       num_iters_per_step * num_steps,
-      &<G1 as Group>::Scalar::zero(),
-      &<G1 as Group>::Scalar::one(),
+      &<G1 as GroupExt>::Scalar::zero(),
+      &<G1 as GroupExt>::Scalar::one(),
     );
     let minroot_circuits = (0..num_steps)
       .map(|i| MinRootCircuit {
@@ -201,10 +201,10 @@ fn main() {
       })
       .collect::<Vec<_>>();
 
-    let z0_secondary = vec![<G2 as Group>::Scalar::zero()];
+    let z0_secondary = vec![<G2 as GroupExt>::Scalar::zero()];
 
-    type C1 = MinRootCircuit<<G1 as Group>::Scalar>;
-    type C2 = TrivialCircuit<<G2 as Group>::Scalar>;
+    type C1 = MinRootCircuit<<G1 as GroupExt>::Scalar>;
+    type C2 = TrivialCircuit<<G2 as GroupExt>::Scalar>;
     // produce a recursive SNARK
     println!("Generating a RecursiveSNARK...");
     let mut recursive_snark: RecursiveSNARK<G1, G2, C1, C2> =

--- a/examples/minroot.rs
+++ b/examples/minroot.rs
@@ -6,11 +6,9 @@ type G2 = pasta_curves::vesta::Point;
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use ff::PrimeField;
 use flate2::{write::ZlibEncoder, Compression};
+use group::Group;
 use nova_snark::{
-  traits::{
-    circuit::{StepCircuit, TrivialCircuit},
-    GroupExt,
-  },
+  traits::circuit::{StepCircuit, TrivialCircuit},
   CompressedSNARK, PublicParams, RecursiveSNARK,
 };
 use num_bigint::BigUint;
@@ -140,10 +138,10 @@ fn main() {
     let circuit_primary = MinRootCircuit {
       seq: vec![
         MinRootIteration {
-          x_i: <G1 as GroupExt>::Scalar::zero(),
-          y_i: <G1 as GroupExt>::Scalar::zero(),
-          x_i_plus_1: <G1 as GroupExt>::Scalar::zero(),
-          y_i_plus_1: <G1 as GroupExt>::Scalar::zero(),
+          x_i: <G1 as Group>::Scalar::zero(),
+          y_i: <G1 as Group>::Scalar::zero(),
+          x_i_plus_1: <G1 as Group>::Scalar::zero(),
+          y_i_plus_1: <G1 as Group>::Scalar::zero(),
         };
         num_iters_per_step
       ],
@@ -159,8 +157,8 @@ fn main() {
     let pp = PublicParams::<
       G1,
       G2,
-      MinRootCircuit<<G1 as GroupExt>::Scalar>,
-      TrivialCircuit<<G2 as GroupExt>::Scalar>,
+      MinRootCircuit<<G1 as Group>::Scalar>,
+      TrivialCircuit<<G2 as Group>::Scalar>,
     >::setup(&circuit_primary, &circuit_secondary);
     println!("PublicParams::setup, took {:?} ", start.elapsed());
 
@@ -185,8 +183,8 @@ fn main() {
     // produce non-deterministic advice
     let (z0_primary, minroot_iterations) = MinRootIteration::new(
       num_iters_per_step * num_steps,
-      &<G1 as GroupExt>::Scalar::zero(),
-      &<G1 as GroupExt>::Scalar::one(),
+      &<G1 as Group>::Scalar::zero(),
+      &<G1 as Group>::Scalar::one(),
     );
     let minroot_circuits = (0..num_steps)
       .map(|i| MinRootCircuit {
@@ -201,10 +199,10 @@ fn main() {
       })
       .collect::<Vec<_>>();
 
-    let z0_secondary = vec![<G2 as GroupExt>::Scalar::zero()];
+    let z0_secondary = vec![<G2 as Group>::Scalar::zero()];
 
-    type C1 = MinRootCircuit<<G1 as GroupExt>::Scalar>;
-    type C2 = TrivialCircuit<<G2 as GroupExt>::Scalar>;
+    type C1 = MinRootCircuit<<G1 as Group>::Scalar>;
+    type C2 = TrivialCircuit<<G2 as Group>::Scalar>;
     // produce a recursive SNARK
     println!("Generating a RecursiveSNARK...");
     let mut recursive_snark: RecursiveSNARK<G1, G2, C1, C2> =

--- a/examples/signature.rs
+++ b/examples/signature.rs
@@ -6,7 +6,7 @@ use ff::{
   derive::byteorder::{ByteOrder, LittleEndian},
   Field, PrimeField, PrimeFieldBits,
 };
-use nova_snark::{gadgets::ecc::AllocatedPoint, traits::Group as NovaGroup};
+use nova_snark::{gadgets::ecc::AllocatedPoint, traits::GroupExt as NovaGroup};
 use num_bigint::BigUint;
 use pasta_curves::{
   arithmetic::CurveAffine,

--- a/src/bellpepper/mod.rs
+++ b/src/bellpepper/mod.rs
@@ -15,7 +15,7 @@ mod tests {
       shape_cs::ShapeCS,
       solver::SatisfyingAssignment,
     },
-    traits::Group,
+    traits::GroupExt,
   };
   use bellpepper_core::{num::AllocatedNum, ConstraintSystem};
   use ff::PrimeField;
@@ -42,7 +42,7 @@ mod tests {
 
   fn test_alloc_bit_with<G>()
   where
-    G: Group,
+    G: GroupExt,
   {
     // First create the shape
     let mut cs: ShapeCS<G> = ShapeCS::new();

--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -6,14 +6,14 @@ use super::{shape_cs::ShapeCS, solver::SatisfyingAssignment, test_shape_cs::Test
 use crate::{
   errors::NovaError,
   r1cs::{R1CSInstance, R1CSShape, R1CSWitness, SparseMatrix, R1CS},
-  traits::Group,
+  traits::GroupExt,
   CommitmentKey,
 };
 use bellpepper_core::{Index, LinearCombination};
 use ff::PrimeField;
 
 /// `NovaWitness` provide a method for acquiring an `R1CSInstance` and `R1CSWitness` from implementers.
-pub trait NovaWitness<G: Group> {
+pub trait NovaWitness<G: GroupExt> {
   /// Return an instance and witness, given a shape and ck.
   fn r1cs_instance_and_witness(
     &self,
@@ -23,12 +23,12 @@ pub trait NovaWitness<G: Group> {
 }
 
 /// `NovaShape` provides methods for acquiring `R1CSShape` and `CommitmentKey` from implementers.
-pub trait NovaShape<G: Group> {
+pub trait NovaShape<G: GroupExt> {
   /// Return an appropriate `R1CSShape` and `CommitmentKey` structs.
   fn r1cs_shape(&self) -> (R1CSShape<G>, CommitmentKey<G>);
 }
 
-impl<G: Group> NovaWitness<G> for SatisfyingAssignment<G> {
+impl<G: GroupExt> NovaWitness<G> for SatisfyingAssignment<G> {
   fn r1cs_instance_and_witness(
     &self,
     shape: &R1CSShape<G>,
@@ -47,7 +47,7 @@ impl<G: Group> NovaWitness<G> for SatisfyingAssignment<G> {
 
 macro_rules! impl_nova_shape {
   ( $name:ident) => {
-    impl<G: Group> NovaShape<G> for $name<G>
+    impl<G: GroupExt> NovaShape<G> for $name<G>
     where
       G::Scalar: PrimeField,
     {

--- a/src/bellpepper/shape_cs.rs
+++ b/src/bellpepper/shape_cs.rs
@@ -1,11 +1,11 @@
 //! Support for generating R1CS shape using bellpepper.
 
-use crate::traits::Group;
+use crate::traits::GroupExt;
 use bellpepper_core::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 use ff::PrimeField;
 
 /// `ShapeCS` is a `ConstraintSystem` for creating `R1CSShape`s for a circuit.
-pub struct ShapeCS<G: Group>
+pub struct ShapeCS<G: GroupExt>
 where
   G::Scalar: PrimeField,
 {
@@ -19,7 +19,7 @@ where
   aux: usize,
 }
 
-impl<G: Group> ShapeCS<G> {
+impl<G: GroupExt> ShapeCS<G> {
   /// Create a new, default `ShapeCS`,
   pub fn new() -> Self {
     ShapeCS::default()
@@ -41,7 +41,7 @@ impl<G: Group> ShapeCS<G> {
   }
 }
 
-impl<G: Group> Default for ShapeCS<G> {
+impl<G: GroupExt> Default for ShapeCS<G> {
   fn default() -> Self {
     ShapeCS {
       constraints: vec![],
@@ -51,7 +51,7 @@ impl<G: Group> Default for ShapeCS<G> {
   }
 }
 
-impl<G: Group> ConstraintSystem<G::Scalar> for ShapeCS<G> {
+impl<G: GroupExt> ConstraintSystem<G::Scalar> for ShapeCS<G> {
   type Root = Self;
 
   fn alloc<F, A, AR>(&mut self, _annotation: A, _f: F) -> Result<Variable, SynthesisError>

--- a/src/bellpepper/solver.rs
+++ b/src/bellpepper/solver.rs
@@ -1,19 +1,19 @@
 //! Support for generating R1CS witness using bellpepper.
 
-use crate::traits::Group;
+use crate::traits::GroupExt;
 use ff::Field;
 
 use bellpepper_core::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 
 /// A `ConstraintSystem` which calculates witness values for a concrete instance of an R1CS circuit.
-pub struct SatisfyingAssignment<G: Group> {
+pub struct SatisfyingAssignment<G: GroupExt> {
   // Assignments of variables
   pub(crate) input_assignment: Vec<G::Scalar>,
   pub(crate) aux_assignment: Vec<G::Scalar>,
 }
 use std::fmt;
 
-impl<G: Group> fmt::Debug for SatisfyingAssignment<G> {
+impl<G: GroupExt> fmt::Debug for SatisfyingAssignment<G> {
   fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
     fmt
       .debug_struct("SatisfyingAssignment")
@@ -23,13 +23,13 @@ impl<G: Group> fmt::Debug for SatisfyingAssignment<G> {
   }
 }
 
-impl<G: Group> PartialEq for SatisfyingAssignment<G> {
+impl<G: GroupExt> PartialEq for SatisfyingAssignment<G> {
   fn eq(&self, other: &SatisfyingAssignment<G>) -> bool {
     self.input_assignment == other.input_assignment && self.aux_assignment == other.aux_assignment
   }
 }
 
-impl<G: Group> ConstraintSystem<G::Scalar> for SatisfyingAssignment<G> {
+impl<G: GroupExt> ConstraintSystem<G::Scalar> for SatisfyingAssignment<G> {
   type Root = Self;
 
   fn new() -> Self {
@@ -143,7 +143,7 @@ impl<G: Group> ConstraintSystem<G::Scalar> for SatisfyingAssignment<G> {
 }
 
 #[allow(dead_code)]
-impl<G: Group> SatisfyingAssignment<G> {
+impl<G: GroupExt> SatisfyingAssignment<G> {
   pub fn scalar_inputs(&self) -> Vec<G::Scalar> {
     self.input_assignment.clone()
   }

--- a/src/bellpepper/test_shape_cs.rs
+++ b/src/bellpepper/test_shape_cs.rs
@@ -6,7 +6,7 @@ use std::{
   collections::{BTreeMap, HashMap},
 };
 
-use crate::traits::Group;
+use crate::traits::GroupExt;
 use bellpepper_core::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
 use core::fmt::Write;
 use ff::{Field, PrimeField};
@@ -48,7 +48,7 @@ impl Ord for OrderedVariable {
 }
 
 /// `TestShapeCS` is a `ConstraintSystem` for creating `R1CSShape`s for a circuit.
-pub struct TestShapeCS<G: Group>
+pub struct TestShapeCS<G: GroupExt>
 where
   G::Scalar: PrimeField + Field,
 {
@@ -91,7 +91,7 @@ fn proc_lc<Scalar: PrimeField>(
   map
 }
 
-impl<G: Group> TestShapeCS<G>
+impl<G: GroupExt> TestShapeCS<G>
 where
   G::Scalar: PrimeField,
 {
@@ -216,7 +216,7 @@ where
   }
 }
 
-impl<G: Group> Default for TestShapeCS<G>
+impl<G: GroupExt> Default for TestShapeCS<G>
 where
   G::Scalar: PrimeField,
 {
@@ -233,7 +233,7 @@ where
   }
 }
 
-impl<G: Group> ConstraintSystem<G::Scalar> for TestShapeCS<G>
+impl<G: GroupExt> ConstraintSystem<G::Scalar> for TestShapeCS<G>
 where
   G::Scalar: PrimeField,
 {

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -15,7 +15,7 @@ use crate::{
   },
   r1cs::{R1CSInstance, RelaxedR1CSInstance},
   traits::{
-    circuit::StepCircuit, commitment::CommitmentTrait, Group, ROCircuitTrait, ROConstantsCircuit,
+    circuit::StepCircuit, commitment::CommitmentTrait, GroupExt, ROCircuitTrait, ROConstantsCircuit,
   },
   Commitment,
 };
@@ -47,7 +47,7 @@ impl NovaAugmentedCircuitParams {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct NovaAugmentedCircuitInputs<G: Group> {
+pub struct NovaAugmentedCircuitInputs<G: GroupExt> {
   params: G::Scalar,
   i: G::Base,
   z0: Vec<G::Base>,
@@ -57,7 +57,7 @@ pub struct NovaAugmentedCircuitInputs<G: Group> {
   T: Option<Commitment<G>>,
 }
 
-impl<G: Group> NovaAugmentedCircuitInputs<G> {
+impl<G: GroupExt> NovaAugmentedCircuitInputs<G> {
   /// Create new inputs/witness for the verification circuit
   pub fn new(
     params: G::Scalar,
@@ -82,14 +82,14 @@ impl<G: Group> NovaAugmentedCircuitInputs<G> {
 
 /// The augmented circuit F' in Nova that includes a step circuit F
 /// and the circuit for the verifier in Nova's non-interactive folding scheme
-pub struct NovaAugmentedCircuit<'a, G: Group, SC: StepCircuit<G::Base>> {
+pub struct NovaAugmentedCircuit<'a, G: GroupExt, SC: StepCircuit<G::Base>> {
   params: &'a NovaAugmentedCircuitParams,
   ro_consts: ROConstantsCircuit<G>,
   inputs: Option<NovaAugmentedCircuitInputs<G>>,
   step_circuit: &'a SC, // The function that is applied for each step
 }
 
-impl<'a, G: Group, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> {
+impl<'a, G: GroupExt, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> {
   /// Create a new verification circuit for the input relaxed r1cs instances
   pub const fn new(
     params: &'a NovaAugmentedCircuitParams,
@@ -106,7 +106,7 @@ impl<'a, G: Group, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> {
   }
 
   /// Allocate all witnesses and return
-  fn alloc_witness<CS: ConstraintSystem<<G as Group>::Base>>(
+  fn alloc_witness<CS: ConstraintSystem<G::Base>>(
     &self,
     mut cs: CS,
     arity: usize,
@@ -177,7 +177,7 @@ impl<'a, G: Group, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> {
   }
 
   /// Synthesizes base case and returns the new relaxed `R1CSInstance`
-  fn synthesize_base_case<CS: ConstraintSystem<<G as Group>::Base>>(
+  fn synthesize_base_case<CS: ConstraintSystem<<G as GroupExt>::Base>>(
     &self,
     mut cs: CS,
     u: AllocatedR1CSInstance<G>,
@@ -203,7 +203,7 @@ impl<'a, G: Group, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> {
 
   /// Synthesizes non base case and returns the new relaxed `R1CSInstance`
   /// And a boolean indicating if all checks pass
-  fn synthesize_non_base_case<CS: ConstraintSystem<<G as Group>::Base>>(
+  fn synthesize_non_base_case<CS: ConstraintSystem<G::Base>>(
     &self,
     mut cs: CS,
     params: &AllocatedNum<G::Base>,
@@ -253,9 +253,9 @@ impl<'a, G: Group, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> {
   }
 }
 
-impl<'a, G: Group, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> {
+impl<'a, G: GroupExt, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> {
   /// synthesize circuit giving constraint system
-  pub fn synthesize<CS: ConstraintSystem<<G as Group>::Base>>(
+  pub fn synthesize<CS: ConstraintSystem<<G as GroupExt>::Base>>(
     self,
     cs: &mut CS,
   ) -> Result<Vec<AllocatedNum<G::Base>>, SynthesisError> {
@@ -383,12 +383,12 @@ mod tests {
     num_constraints_primary: usize,
     num_constraints_secondary: usize,
   ) where
-    G1: Group<Base = <G2 as Group>::Scalar>,
-    G2: Group<Base = <G1 as Group>::Scalar>,
+    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
   {
     let tc1 = TrivialCircuit::default();
     // Initialize the shape and ck for the primary
-    let circuit1: NovaAugmentedCircuit<'_, G2, TrivialCircuit<<G2 as Group>::Base>> =
+    let circuit1: NovaAugmentedCircuit<'_, G2, TrivialCircuit<<G2 as GroupExt>::Base>> =
       NovaAugmentedCircuit::new(primary_params, None, &tc1, ro_consts1.clone());
     let mut cs: TestShapeCS<G1> = TestShapeCS::new();
     let _ = circuit1.synthesize(&mut cs);
@@ -397,7 +397,7 @@ mod tests {
 
     let tc2 = TrivialCircuit::default();
     // Initialize the shape and ck for the secondary
-    let circuit2: NovaAugmentedCircuit<'_, G1, TrivialCircuit<<G1 as Group>::Base>> =
+    let circuit2: NovaAugmentedCircuit<'_, G1, TrivialCircuit<<G1 as GroupExt>::Base>> =
       NovaAugmentedCircuit::new(secondary_params, None, &tc2, ro_consts2.clone());
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
     let _ = circuit2.synthesize(&mut cs);
@@ -405,7 +405,7 @@ mod tests {
     assert_eq!(cs.num_constraints(), num_constraints_secondary);
 
     // Execute the base case for the primary
-    let zero1 = <<G2 as Group>::Base as Field>::ZERO;
+    let zero1 = <<G2 as GroupExt>::Base as Field>::ZERO;
     let mut cs1: SatisfyingAssignment<G1> = SatisfyingAssignment::new();
     let inputs1: NovaAugmentedCircuitInputs<G2> = NovaAugmentedCircuitInputs::new(
       scalar_as_base::<G1>(zero1), // pass zero for testing
@@ -416,7 +416,7 @@ mod tests {
       None,
       None,
     );
-    let circuit1: NovaAugmentedCircuit<'_, G2, TrivialCircuit<<G2 as Group>::Base>> =
+    let circuit1: NovaAugmentedCircuit<'_, G2, TrivialCircuit<<G2 as GroupExt>::Base>> =
       NovaAugmentedCircuit::new(primary_params, Some(inputs1), &tc1, ro_consts1);
     let _ = circuit1.synthesize(&mut cs1);
     let (inst1, witness1) = cs1.r1cs_instance_and_witness(&shape1, &ck1).unwrap();
@@ -424,7 +424,7 @@ mod tests {
     assert!(shape1.is_sat(&ck1, &inst1, &witness1).is_ok());
 
     // Execute the base case for the secondary
-    let zero2 = <<G1 as Group>::Base as Field>::ZERO;
+    let zero2 = <<G1 as GroupExt>::Base as Field>::ZERO;
     let mut cs2: SatisfyingAssignment<G2> = SatisfyingAssignment::new();
     let inputs2: NovaAugmentedCircuitInputs<G1> = NovaAugmentedCircuitInputs::new(
       scalar_as_base::<G2>(zero2), // pass zero for testing
@@ -435,7 +435,7 @@ mod tests {
       Some(inst1),
       None,
     );
-    let circuit2: NovaAugmentedCircuit<'_, G1, TrivialCircuit<<G1 as Group>::Base>> =
+    let circuit2: NovaAugmentedCircuit<'_, G1, TrivialCircuit<<G1 as GroupExt>::Base>> =
       NovaAugmentedCircuit::new(secondary_params, Some(inputs2), &tc2, ro_consts2);
     let _ = circuit2.synthesize(&mut cs2);
     let (inst2, witness2) = cs2.r1cs_instance_and_witness(&shape2, &ck2).unwrap();

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -14,10 +14,8 @@ use crate::{
     },
   },
   r1cs::{R1CSInstance, RelaxedR1CSInstance},
-  traits::{
-    circuit::StepCircuit, commitment::CommitmentTrait, GroupExt, ROCircuitTrait, ROConstantsCircuit,
-  },
-  Commitment,
+  traits::{circuit::StepCircuit, GroupExt, ROCircuitTrait, ROConstantsCircuit},
+  Commitment, CommitmentTrait,
 };
 use bellpepper::gadgets::Assignment;
 use bellpepper_core::{
@@ -177,7 +175,7 @@ impl<'a, G: GroupExt, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> 
   }
 
   /// Synthesizes base case and returns the new relaxed `R1CSInstance`
-  fn synthesize_base_case<CS: ConstraintSystem<<G as GroupExt>::Base>>(
+  fn synthesize_base_case<CS: ConstraintSystem<G::Base>>(
     &self,
     mut cs: CS,
     u: AllocatedR1CSInstance<G>,
@@ -255,7 +253,7 @@ impl<'a, G: GroupExt, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> 
 
 impl<'a, G: GroupExt, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> {
   /// synthesize circuit giving constraint system
-  pub fn synthesize<CS: ConstraintSystem<<G as GroupExt>::Base>>(
+  pub fn synthesize<CS: ConstraintSystem<G::Base>>(
     self,
     cs: &mut CS,
   ) -> Result<Vec<AllocatedNum<G::Base>>, SynthesisError> {
@@ -362,9 +360,6 @@ impl<'a, G: GroupExt, SC: StepCircuit<G::Base>> NovaAugmentedCircuit<'a, G, SC> 
 mod tests {
   use super::*;
   use crate::bellpepper::{solver::SatisfyingAssignment, test_shape_cs::TestShapeCS};
-  type PastaG1 = pasta_curves::pallas::Point;
-  type PastaG2 = pasta_curves::vesta::Point;
-
   use crate::constants::{BN_LIMB_WIDTH, BN_N_LIMBS};
   use crate::provider;
   use crate::{
@@ -373,6 +368,10 @@ mod tests {
     provider::poseidon::PoseidonConstantsCircuit,
     traits::circuit::TrivialCircuit,
   };
+
+  use group::Group;
+  type PastaG1 = pasta_curves::pallas::Point;
+  type PastaG2 = pasta_curves::vesta::Point;
 
   // In the following we use 1 to refer to the primary, and 2 to refer to the secondary circuit
   fn test_recursive_circuit_with<G1, G2>(
@@ -383,8 +382,8 @@ mod tests {
     num_constraints_primary: usize,
     num_constraints_secondary: usize,
   ) where
-    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+    G1: GroupExt<Base = <G2 as Group>::Scalar>,
+    G2: GroupExt<Base = <G1 as Group>::Scalar>,
   {
     let tc1 = TrivialCircuit::default();
     // Initialize the shape and ck for the primary

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -81,6 +81,7 @@ impl<'a, F: PrimeField, T: Digestible> DigestComputer<'a, F, T> {
 #[cfg(test)]
 mod tests {
   use ff::Field;
+  use group::Group;
   use once_cell::sync::OnceCell;
   use pasta_curves::pallas;
   use serde::{Deserialize, Serialize};
@@ -123,15 +124,15 @@ mod tests {
 
     // let's set up a struct with a weird digest field to make sure the digest computation does not depend of it
     let oc = OnceCell::new();
-    oc.set(<G as GroupExt>::Scalar::ONE).unwrap();
+    oc.set(<G as Group>::Scalar::ONE).unwrap();
 
     let s2: S<G> = S { i: 42, digest: oc };
 
     assert_eq!(
-      DigestComputer::<<G as GroupExt>::Scalar, _>::new(&s1)
+      DigestComputer::<<G as Group>::Scalar, _>::new(&s1)
         .digest()
         .unwrap(),
-      DigestComputer::<<G as GroupExt>::Scalar, _>::new(&s2)
+      DigestComputer::<<G as Group>::Scalar, _>::new(&s2)
         .digest()
         .unwrap()
     );
@@ -140,7 +141,7 @@ mod tests {
     // equality will not result in `s1.digest() == s2.digest`
     assert_ne!(
       s2.digest(),
-      DigestComputer::<<G as GroupExt>::Scalar, _>::new(&s2)
+      DigestComputer::<<G as Group>::Scalar, _>::new(&s2)
         .digest()
         .unwrap()
     );
@@ -152,7 +153,7 @@ mod tests {
 
     // let's set up a struct with a weird digest field to confuse deserializers
     let oc = OnceCell::new();
-    oc.set(<G as GroupExt>::Scalar::ONE).unwrap();
+    oc.set(<G as Group>::Scalar::ONE).unwrap();
 
     let bad_s: S<G> = S { i: 42, digest: oc };
     // this justifies the adjective "bad"

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -85,20 +85,20 @@ mod tests {
   use pasta_curves::pallas;
   use serde::{Deserialize, Serialize};
 
-  use crate::traits::Group;
+  use crate::traits::GroupExt;
 
   use super::{DigestComputer, SimpleDigestible};
 
   #[derive(Serialize, Deserialize)]
-  struct S<G: Group> {
+  struct S<G: GroupExt> {
     i: usize,
     #[serde(skip, default = "OnceCell::new")]
     digest: OnceCell<G::Scalar>,
   }
 
-  impl<G: Group> SimpleDigestible for S<G> {}
+  impl<G: GroupExt> SimpleDigestible for S<G> {}
 
-  impl<G: Group> S<G> {
+  impl<G: GroupExt> S<G> {
     fn new(i: usize) -> Self {
       S {
         i,
@@ -123,15 +123,15 @@ mod tests {
 
     // let's set up a struct with a weird digest field to make sure the digest computation does not depend of it
     let oc = OnceCell::new();
-    oc.set(<G as Group>::Scalar::ONE).unwrap();
+    oc.set(<G as GroupExt>::Scalar::ONE).unwrap();
 
     let s2: S<G> = S { i: 42, digest: oc };
 
     assert_eq!(
-      DigestComputer::<<G as Group>::Scalar, _>::new(&s1)
+      DigestComputer::<<G as GroupExt>::Scalar, _>::new(&s1)
         .digest()
         .unwrap(),
-      DigestComputer::<<G as Group>::Scalar, _>::new(&s2)
+      DigestComputer::<<G as GroupExt>::Scalar, _>::new(&s2)
         .digest()
         .unwrap()
     );
@@ -140,7 +140,7 @@ mod tests {
     // equality will not result in `s1.digest() == s2.digest`
     assert_ne!(
       s2.digest(),
-      DigestComputer::<<G as Group>::Scalar, _>::new(&s2)
+      DigestComputer::<<G as GroupExt>::Scalar, _>::new(&s2)
         .digest()
         .unwrap()
     );
@@ -152,7 +152,7 @@ mod tests {
 
     // let's set up a struct with a weird digest field to confuse deserializers
     let oc = OnceCell::new();
-    oc.set(<G as Group>::Scalar::ONE).unwrap();
+    oc.set(<G as GroupExt>::Scalar::ONE).unwrap();
 
     let bad_s: S<G> = S { i: 42, digest: oc };
     // this justifies the adjective "bad"

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -757,6 +757,7 @@ mod tests {
     secp_secq::{secp256k1, secq256k1},
   };
   use ff::{Field, PrimeFieldBits};
+  use group::Group;
   use pasta_curves::{arithmetic::CurveAffine, group::Curve, pallas, vesta};
   use rand::rngs::OsRng;
 
@@ -993,8 +994,8 @@ mod tests {
 
   fn test_ecc_circuit_ops_with<G1, G2>()
   where
-    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+    G1: GroupExt<Base = <G2 as Group>::Scalar>,
+    G2: GroupExt<Base = <G1 as Group>::Scalar>,
   {
     // First create the shape
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
@@ -1049,8 +1050,8 @@ mod tests {
 
   fn test_ecc_circuit_add_equal_with<G1, G2>()
   where
-    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+    G1: GroupExt<Base = <G2 as Group>::Scalar>,
+    G2: GroupExt<Base = <G1 as Group>::Scalar>,
   {
     // First create the shape
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();
@@ -1109,8 +1110,8 @@ mod tests {
 
   fn test_ecc_circuit_add_negation_with<G1, G2>()
   where
-    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+    G1: GroupExt<Base = <G2 as Group>::Scalar>,
+    G2: GroupExt<Base = <G1 as Group>::Scalar>,
   {
     // First create the shape
     let mut cs: TestShapeCS<G2> = TestShapeCS::new();

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -13,7 +13,7 @@ use crate::{
     },
   },
   r1cs::{R1CSInstance, RelaxedR1CSInstance},
-  traits::{commitment::CommitmentTrait, Group, ROCircuitTrait, ROConstantsCircuit},
+  traits::{commitment::CommitmentTrait, GroupExt, ROCircuitTrait, ROConstantsCircuit},
 };
 use bellpepper::gadgets::{boolean::Boolean, num::AllocatedNum, Assignment};
 use bellpepper_core::{ConstraintSystem, SynthesisError};
@@ -21,15 +21,15 @@ use ff::Field;
 
 /// An Allocated R1CS Instance
 #[derive(Clone)]
-pub struct AllocatedR1CSInstance<G: Group> {
+pub struct AllocatedR1CSInstance<G: GroupExt> {
   pub(crate) W: AllocatedPoint<G>,
   pub(crate) X0: AllocatedNum<G::Base>,
   pub(crate) X1: AllocatedNum<G::Base>,
 }
 
-impl<G: Group> AllocatedR1CSInstance<G> {
+impl<G: GroupExt> AllocatedR1CSInstance<G> {
   /// Takes the r1cs instance and creates a new allocated r1cs instance
-  pub fn alloc<CS: ConstraintSystem<<G as Group>::Base>>(
+  pub fn alloc<CS: ConstraintSystem<G::Base>>(
     mut cs: CS,
     u: Option<&R1CSInstance<G>>,
   ) -> Result<Self, SynthesisError> {
@@ -56,7 +56,7 @@ impl<G: Group> AllocatedR1CSInstance<G> {
 }
 
 /// An Allocated Relaxed R1CS Instance
-pub struct AllocatedRelaxedR1CSInstance<G: Group> {
+pub struct AllocatedRelaxedR1CSInstance<G: GroupExt> {
   pub(crate) W: AllocatedPoint<G>,
   pub(crate) E: AllocatedPoint<G>,
   pub(crate) u: AllocatedNum<G::Base>,
@@ -64,9 +64,9 @@ pub struct AllocatedRelaxedR1CSInstance<G: Group> {
   pub(crate) X1: BigNat<G::Base>,
 }
 
-impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
+impl<G: GroupExt> AllocatedRelaxedR1CSInstance<G> {
   /// Allocates the given `RelaxedR1CSInstance` as a witness of the circuit
-  pub fn alloc<CS: ConstraintSystem<<G as Group>::Base>>(
+  pub fn alloc<CS: ConstraintSystem<G::Base>>(
     mut cs: CS,
     inst: Option<&RelaxedR1CSInstance<G>>,
     limb_width: usize,
@@ -106,7 +106,7 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
 
   /// Allocates the hardcoded default `RelaxedR1CSInstance` in the circuit.
   /// W = E = 0, u = 0, X0 = X1 = 0
-  pub fn default<CS: ConstraintSystem<<G as Group>::Base>>(
+  pub fn default<CS: ConstraintSystem<G::Base>>(
     mut cs: CS,
     limb_width: usize,
     n_limbs: usize,
@@ -135,7 +135,7 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
 
   /// Allocates the R1CS Instance as a `RelaxedR1CSInstance` in the circuit.
   /// E = 0, u = 1
-  pub fn from_r1cs_instance<CS: ConstraintSystem<<G as Group>::Base>>(
+  pub fn from_r1cs_instance<CS: ConstraintSystem<G::Base>>(
     mut cs: CS,
     inst: AllocatedR1CSInstance<G>,
     limb_width: usize,
@@ -169,7 +169,7 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
   }
 
   /// Absorb the provided instance in the RO
-  pub fn absorb_in_ro<CS: ConstraintSystem<<G as Group>::Base>>(
+  pub fn absorb_in_ro<CS: ConstraintSystem<G::Base>>(
     &self,
     mut cs: CS,
     ro: &mut G::ROCircuit,
@@ -218,7 +218,7 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
   }
 
   /// Folds self with a relaxed r1cs instance and returns the result
-  pub fn fold_with_r1cs<CS: ConstraintSystem<<G as Group>::Base>>(
+  pub fn fold_with_r1cs<CS: ConstraintSystem<G::Base>>(
     &self,
     mut cs: CS,
     params: &AllocatedNum<G::Base>, // hash of R1CSShape of F'
@@ -315,7 +315,7 @@ impl<G: Group> AllocatedRelaxedR1CSInstance<G> {
   }
 
   /// If the condition is true then returns this otherwise it returns the other
-  pub fn conditionally_select<CS: ConstraintSystem<<G as Group>::Base>>(
+  pub fn conditionally_select<CS: ConstraintSystem<<G as GroupExt>::Base>>(
     &self,
     mut cs: CS,
     other: &AllocatedRelaxedR1CSInstance<G>,

--- a/src/gadgets/utils.rs
+++ b/src/gadgets/utils.rs
@@ -1,6 +1,6 @@
 //! This module implements various low-level gadgets
 use super::nonnative::bignat::{nat_to_limbs, BigNat};
-use crate::traits::Group;
+use crate::traits::GroupExt;
 use bellpepper::gadgets::Assignment;
 use bellpepper_core::{
   boolean::{AllocatedBit, Boolean},
@@ -74,9 +74,9 @@ pub fn alloc_scalar_as_base<G, CS>(
   input: Option<G::Scalar>,
 ) -> Result<AllocatedNum<G::Base>, SynthesisError>
 where
-  G: Group,
-  <G as Group>::Scalar: PrimeFieldBits,
-  CS: ConstraintSystem<<G as Group>::Base>,
+  G: GroupExt,
+  G::Scalar: PrimeFieldBits,
+  CS: ConstraintSystem<G::Base>,
 {
   AllocatedNum::alloc(cs.namespace(|| "allocate scalar as base"), || {
     let input_bits = input.unwrap_or(G::Scalar::ZERO).clone().to_le_bits();
@@ -93,7 +93,7 @@ where
 }
 
 /// interepret scalar as base
-pub fn scalar_as_base<G: Group>(input: G::Scalar) -> G::Base {
+pub fn scalar_as_base<G: GroupExt>(input: G::Scalar) -> G::Base {
   let input_bits = input.to_le_bits();
   let mut mult = G::Base::ONE;
   let mut val = G::Base::ZERO;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ use core::marker::PhantomData;
 use errors::NovaError;
 use ff::Field;
 use gadgets::utils::scalar_as_base;
+use group::Group;
 use nifs::NIFS;
 use r1cs::{R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness};
 use serde::{Deserialize, Serialize};
@@ -55,8 +56,8 @@ use traits::{
 #[serde(bound = "")]
 pub struct PublicParams<G1, G2, C1, C2>
 where
-  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+  G1: GroupExt<Base = <G2 as Group>::Scalar>,
+  G2: GroupExt<Base = <G1 as Group>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
@@ -79,8 +80,8 @@ where
 
 impl<G1, G2, C1, C2> SimpleDigestible for PublicParams<G1, G2, C1, C2>
 where
-  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+  G1: GroupExt<Base = <G2 as Group>::Scalar>,
+  G2: GroupExt<Base = <G1 as Group>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
@@ -88,8 +89,8 @@ where
 
 impl<G1, G2, C1, C2> PublicParams<G1, G2, C1, C2>
 where
-  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+  G1: GroupExt<Base = <G2 as Group>::Scalar>,
+  G2: GroupExt<Base = <G1 as Group>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
@@ -181,8 +182,8 @@ where
 #[serde(bound = "")]
 pub struct RecursiveSNARK<G1, G2, C1, C2>
 where
-  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+  G1: GroupExt<Base = <G2 as Group>::Scalar>,
+  G2: GroupExt<Base = <G1 as Group>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
@@ -203,8 +204,8 @@ where
 
 impl<G1, G2, C1, C2> RecursiveSNARK<G1, G2, C1, C2>
 where
-  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+  G1: GroupExt<Base = <G2 as Group>::Scalar>,
+  G2: GroupExt<Base = <G1 as Group>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
@@ -295,13 +296,13 @@ where
     let zi_primary = zi_primary
       .iter()
       .map(|v| v.get_value().ok_or(NovaError::SynthesisError))
-      .collect::<Result<Vec<<G1 as GroupExt>::Scalar>, NovaError>>()
+      .collect::<Result<Vec<<G1 as Group>::Scalar>, NovaError>>()
       .expect("Nova error synthesis");
 
     let zi_secondary = zi_secondary
       .iter()
       .map(|v| v.get_value().ok_or(NovaError::SynthesisError))
-      .collect::<Result<Vec<<G2 as GroupExt>::Scalar>, NovaError>>()
+      .collect::<Result<Vec<<G2 as Group>::Scalar>, NovaError>>()
       .expect("Nova error synthesis");
 
     Ok(Self {
@@ -416,11 +417,11 @@ where
     self.zi_primary = zi_primary
       .iter()
       .map(|v| v.get_value().ok_or(NovaError::SynthesisError))
-      .collect::<Result<Vec<<G1 as GroupExt>::Scalar>, NovaError>>()?;
+      .collect::<Result<Vec<<G1 as Group>::Scalar>, NovaError>>()?;
     self.zi_secondary = zi_secondary
       .iter()
       .map(|v| v.get_value().ok_or(NovaError::SynthesisError))
-      .collect::<Result<Vec<<G2 as GroupExt>::Scalar>, NovaError>>()?;
+      .collect::<Result<Vec<<G2 as Group>::Scalar>, NovaError>>()?;
 
     self.l_u_secondary = l_u_secondary;
     self.l_w_secondary = l_w_secondary;
@@ -549,8 +550,8 @@ where
 #[serde(bound = "")]
 pub struct ProverKey<G1, G2, C1, C2, S1, S2>
 where
-  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+  G1: GroupExt<Base = <G2 as Group>::Scalar>,
+  G2: GroupExt<Base = <G1 as Group>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
   S1: RelaxedR1CSSNARKTrait<G1>,
@@ -567,8 +568,8 @@ where
 #[serde(bound = "")]
 pub struct VerifierKey<G1, G2, C1, C2, S1, S2>
 where
-  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+  G1: GroupExt<Base = <G2 as Group>::Scalar>,
+  G2: GroupExt<Base = <G1 as Group>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
   S1: RelaxedR1CSSNARKTrait<G1>,
@@ -590,8 +591,8 @@ where
 #[serde(bound = "")]
 pub struct CompressedSNARK<G1, G2, C1, C2, S1, S2>
 where
-  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+  G1: GroupExt<Base = <G2 as Group>::Scalar>,
+  G2: GroupExt<Base = <G1 as Group>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
   S1: RelaxedR1CSSNARKTrait<G1>,
@@ -614,8 +615,8 @@ where
 
 impl<G1, G2, C1, C2, S1, S2> CompressedSNARK<G1, G2, C1, C2, S1, S2>
 where
-  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+  G1: GroupExt<Base = <G2 as Group>::Scalar>,
+  G2: GroupExt<Base = <G1 as Group>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
   S1: RelaxedR1CSSNARKTrait<G1>,
@@ -827,6 +828,7 @@ mod tests {
   use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
   use core::marker::PhantomData;
   use ff::PrimeField;
+  use group::Group;
   use traits::circuit::TrivialCircuit;
 
   #[derive(Clone, Debug, Default)]
@@ -885,8 +887,8 @@ mod tests {
 
   fn test_pp_digest_with<G1, G2, T1, T2>(circuit1: &T1, circuit2: &T2, expected: &str)
   where
-    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+    G1: GroupExt<Base = <G2 as Group>::Scalar>,
+    G2: GroupExt<Base = <G1 as Group>::Scalar>,
     T1: StepCircuit<G1::Scalar>,
     T2: StepCircuit<G2::Scalar>,
   {
@@ -908,9 +910,9 @@ mod tests {
   fn test_pp_digest() {
     type G1 = pasta_curves::pallas::Point;
     type G2 = pasta_curves::vesta::Point;
-    let trivial_circuit1 = TrivialCircuit::<<G1 as GroupExt>::Scalar>::default();
-    let trivial_circuit2 = TrivialCircuit::<<G2 as GroupExt>::Scalar>::default();
-    let cubic_circuit1 = CubicCircuit::<<G1 as GroupExt>::Scalar>::default();
+    let trivial_circuit1 = TrivialCircuit::<<G1 as Group>::Scalar>::default();
+    let trivial_circuit2 = TrivialCircuit::<<G2 as Group>::Scalar>::default();
+    let cubic_circuit1 = CubicCircuit::<<G1 as Group>::Scalar>::default();
 
     test_pp_digest_with::<G1, G2, _, _>(
       &trivial_circuit1,
@@ -924,10 +926,9 @@ mod tests {
       "583c9964e180332e63a59450870a72b4cbf663ce0d274ac5bd0d052d4cd92903",
     );
 
-    let trivial_circuit1_grumpkin = TrivialCircuit::<<bn256::Point as GroupExt>::Scalar>::default();
-    let trivial_circuit2_grumpkin =
-      TrivialCircuit::<<grumpkin::Point as GroupExt>::Scalar>::default();
-    let cubic_circuit1_grumpkin = CubicCircuit::<<bn256::Point as GroupExt>::Scalar>::default();
+    let trivial_circuit1_grumpkin = TrivialCircuit::<<bn256::Point as Group>::Scalar>::default();
+    let trivial_circuit2_grumpkin = TrivialCircuit::<<grumpkin::Point as Group>::Scalar>::default();
+    let cubic_circuit1_grumpkin = CubicCircuit::<<bn256::Point as Group>::Scalar>::default();
 
     test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _>(
       &trivial_circuit1_grumpkin,
@@ -940,9 +941,9 @@ mod tests {
       "684b2f7151031a79310f6fb553ab1480e290d73731fa34e74c27e004d589f102",
     );
 
-    let trivial_circuit1_secp = TrivialCircuit::<<secp256k1::Point as GroupExt>::Scalar>::default();
-    let trivial_circuit2_secp = TrivialCircuit::<<secq256k1::Point as GroupExt>::Scalar>::default();
-    let cubic_circuit1_secp = CubicCircuit::<<secp256k1::Point as GroupExt>::Scalar>::default();
+    let trivial_circuit1_secp = TrivialCircuit::<<secp256k1::Point as Group>::Scalar>::default();
+    let trivial_circuit2_secp = TrivialCircuit::<<secq256k1::Point as Group>::Scalar>::default();
+    let cubic_circuit1_secp = CubicCircuit::<<secp256k1::Point as Group>::Scalar>::default();
 
     test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _>(
       &trivial_circuit1_secp,
@@ -958,18 +959,18 @@ mod tests {
 
   fn test_ivc_trivial_with<G1, G2>()
   where
-    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+    G1: GroupExt<Base = <G2 as Group>::Scalar>,
+    G2: GroupExt<Base = <G1 as Group>::Scalar>,
   {
-    let test_circuit1 = TrivialCircuit::<<G1 as GroupExt>::Scalar>::default();
-    let test_circuit2 = TrivialCircuit::<<G2 as GroupExt>::Scalar>::default();
+    let test_circuit1 = TrivialCircuit::<<G1 as Group>::Scalar>::default();
+    let test_circuit2 = TrivialCircuit::<<G2 as Group>::Scalar>::default();
 
     // produce public parameters
     let pp = PublicParams::<
       G1,
       G2,
-      TrivialCircuit<<G1 as GroupExt>::Scalar>,
-      TrivialCircuit<<G2 as GroupExt>::Scalar>,
+      TrivialCircuit<<G1 as Group>::Scalar>,
+      TrivialCircuit<<G2 as Group>::Scalar>,
     >::setup(&test_circuit1, &test_circuit2);
 
     let num_steps = 1;
@@ -979,8 +980,8 @@ mod tests {
       &pp,
       &test_circuit1,
       &test_circuit2,
-      &[<G1 as GroupExt>::Scalar::ZERO],
-      &[<G2 as GroupExt>::Scalar::ZERO],
+      &[<G1 as Group>::Scalar::ZERO],
+      &[<G2 as Group>::Scalar::ZERO],
     )
     .unwrap();
 
@@ -992,8 +993,8 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      &[<G1 as GroupExt>::Scalar::ZERO],
-      &[<G2 as GroupExt>::Scalar::ZERO],
+      &[<G1 as Group>::Scalar::ZERO],
+      &[<G2 as Group>::Scalar::ZERO],
     );
     assert!(res.is_ok());
   }
@@ -1010,8 +1011,8 @@ mod tests {
 
   fn test_ivc_nontrivial_with<G1, G2>()
   where
-    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+    G1: GroupExt<Base = <G2 as Group>::Scalar>,
+    G2: GroupExt<Base = <G1 as Group>::Scalar>,
   {
     let circuit_primary = TrivialCircuit::default();
     let circuit_secondary = CubicCircuit::default();
@@ -1020,8 +1021,8 @@ mod tests {
     let pp = PublicParams::<
       G1,
       G2,
-      TrivialCircuit<<G1 as GroupExt>::Scalar>,
-      CubicCircuit<<G2 as GroupExt>::Scalar>,
+      TrivialCircuit<<G1 as Group>::Scalar>,
+      CubicCircuit<<G2 as Group>::Scalar>,
     >::setup(&circuit_primary, &circuit_secondary);
 
     let num_steps = 3;
@@ -1030,14 +1031,14 @@ mod tests {
     let mut recursive_snark = RecursiveSNARK::<
       G1,
       G2,
-      TrivialCircuit<<G1 as GroupExt>::Scalar>,
-      CubicCircuit<<G2 as GroupExt>::Scalar>,
+      TrivialCircuit<<G1 as Group>::Scalar>,
+      CubicCircuit<<G2 as Group>::Scalar>,
     >::new(
       &pp,
       &circuit_primary,
       &circuit_secondary,
-      &[<G1 as GroupExt>::Scalar::ONE],
-      &[<G2 as GroupExt>::Scalar::ZERO],
+      &[<G1 as Group>::Scalar::ONE],
+      &[<G2 as Group>::Scalar::ZERO],
     )
     .unwrap();
 
@@ -1049,8 +1050,8 @@ mod tests {
       let res = recursive_snark.verify(
         &pp,
         i + 1,
-        &[<G1 as GroupExt>::Scalar::ONE],
-        &[<G2 as GroupExt>::Scalar::ZERO],
+        &[<G1 as Group>::Scalar::ONE],
+        &[<G2 as Group>::Scalar::ZERO],
       );
       assert!(res.is_ok());
     }
@@ -1059,24 +1060,21 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      &[<G1 as GroupExt>::Scalar::ONE],
-      &[<G2 as GroupExt>::Scalar::ZERO],
+      &[<G1 as Group>::Scalar::ONE],
+      &[<G2 as Group>::Scalar::ZERO],
     );
     assert!(res.is_ok());
 
     let (zn_primary, zn_secondary) = res.unwrap();
 
     // sanity: check the claimed output with a direct computation of the same
-    assert_eq!(zn_primary, vec![<G1 as GroupExt>::Scalar::ONE]);
-    let mut zn_secondary_direct = vec![<G2 as GroupExt>::Scalar::ZERO];
+    assert_eq!(zn_primary, vec![<G1 as Group>::Scalar::ONE]);
+    let mut zn_secondary_direct = vec![<G2 as Group>::Scalar::ZERO];
     for _i in 0..num_steps {
       zn_secondary_direct = circuit_secondary.clone().output(&zn_secondary_direct);
     }
     assert_eq!(zn_secondary, zn_secondary_direct);
-    assert_eq!(
-      zn_secondary,
-      vec![<G2 as GroupExt>::Scalar::from(2460515u64)]
-    );
+    assert_eq!(zn_secondary, vec![<G2 as Group>::Scalar::from(2460515u64)]);
   }
 
   #[test]
@@ -1091,8 +1089,8 @@ mod tests {
 
   fn test_ivc_nontrivial_with_compression_with<G1, G2, E1, E2>()
   where
-    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+    G1: GroupExt<Base = <G2 as Group>::Scalar>,
+    G2: GroupExt<Base = <G1 as Group>::Scalar>,
     E1: EvaluationEngineTrait<G1>,
     E2: EvaluationEngineTrait<G2>,
   {
@@ -1103,8 +1101,8 @@ mod tests {
     let pp = PublicParams::<
       G1,
       G2,
-      TrivialCircuit<<G1 as GroupExt>::Scalar>,
-      CubicCircuit<<G2 as GroupExt>::Scalar>,
+      TrivialCircuit<<G1 as Group>::Scalar>,
+      CubicCircuit<<G2 as Group>::Scalar>,
     >::setup(&circuit_primary, &circuit_secondary);
 
     let num_steps = 3;
@@ -1113,14 +1111,14 @@ mod tests {
     let mut recursive_snark = RecursiveSNARK::<
       G1,
       G2,
-      TrivialCircuit<<G1 as GroupExt>::Scalar>,
-      CubicCircuit<<G2 as GroupExt>::Scalar>,
+      TrivialCircuit<<G1 as Group>::Scalar>,
+      CubicCircuit<<G2 as Group>::Scalar>,
     >::new(
       &pp,
       &circuit_primary,
       &circuit_secondary,
-      &[<G1 as GroupExt>::Scalar::ONE],
-      &[<G2 as GroupExt>::Scalar::ZERO],
+      &[<G1 as Group>::Scalar::ONE],
+      &[<G2 as Group>::Scalar::ZERO],
     )
     .unwrap();
 
@@ -1133,24 +1131,21 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      &[<G1 as GroupExt>::Scalar::ONE],
-      &[<G2 as GroupExt>::Scalar::ZERO],
+      &[<G1 as Group>::Scalar::ONE],
+      &[<G2 as Group>::Scalar::ZERO],
     );
     assert!(res.is_ok());
 
     let (zn_primary, zn_secondary) = res.unwrap();
 
     // sanity: check the claimed output with a direct computation of the same
-    assert_eq!(zn_primary, vec![<G1 as GroupExt>::Scalar::ONE]);
-    let mut zn_secondary_direct = vec![<G2 as GroupExt>::Scalar::ZERO];
+    assert_eq!(zn_primary, vec![<G1 as Group>::Scalar::ONE]);
+    let mut zn_secondary_direct = vec![<G2 as Group>::Scalar::ZERO];
     for _i in 0..num_steps {
       zn_secondary_direct = circuit_secondary.clone().output(&zn_secondary_direct);
     }
     assert_eq!(zn_secondary, zn_secondary_direct);
-    assert_eq!(
-      zn_secondary,
-      vec![<G2 as GroupExt>::Scalar::from(2460515u64)]
-    );
+    assert_eq!(zn_secondary, vec![<G2 as Group>::Scalar::from(2460515u64)]);
 
     // produce the prover and verifier keys for compressed snark
     let (pk, vk) = CompressedSNARK::<_, _, _, _, S<G1, E1>, S<G2, E2>>::setup(&pp).unwrap();
@@ -1165,8 +1160,8 @@ mod tests {
     let res = compressed_snark.verify(
       &vk,
       num_steps,
-      &[<G1 as GroupExt>::Scalar::ONE],
-      &[<G2 as GroupExt>::Scalar::ZERO],
+      &[<G1 as Group>::Scalar::ONE],
+      &[<G2 as Group>::Scalar::ZERO],
     );
     assert!(res.is_ok());
   }
@@ -1183,8 +1178,8 @@ mod tests {
 
   fn test_ivc_nontrivial_with_spark_compression_with<G1, G2, E1, E2>()
   where
-    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+    G1: GroupExt<Base = <G2 as Group>::Scalar>,
+    G2: GroupExt<Base = <G1 as Group>::Scalar>,
     E1: EvaluationEngineTrait<G1>,
     E2: EvaluationEngineTrait<G2>,
   {
@@ -1195,8 +1190,8 @@ mod tests {
     let pp = PublicParams::<
       G1,
       G2,
-      TrivialCircuit<<G1 as GroupExt>::Scalar>,
-      CubicCircuit<<G2 as GroupExt>::Scalar>,
+      TrivialCircuit<<G1 as Group>::Scalar>,
+      CubicCircuit<<G2 as Group>::Scalar>,
     >::setup(&circuit_primary, &circuit_secondary);
 
     let num_steps = 3;
@@ -1205,14 +1200,14 @@ mod tests {
     let mut recursive_snark = RecursiveSNARK::<
       G1,
       G2,
-      TrivialCircuit<<G1 as GroupExt>::Scalar>,
-      CubicCircuit<<G2 as GroupExt>::Scalar>,
+      TrivialCircuit<<G1 as Group>::Scalar>,
+      CubicCircuit<<G2 as Group>::Scalar>,
     >::new(
       &pp,
       &circuit_primary,
       &circuit_secondary,
-      &[<G1 as GroupExt>::Scalar::ONE],
-      &[<G2 as GroupExt>::Scalar::ZERO],
+      &[<G1 as Group>::Scalar::ONE],
+      &[<G2 as Group>::Scalar::ZERO],
     )
     .unwrap();
 
@@ -1225,24 +1220,21 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      &[<G1 as GroupExt>::Scalar::ONE],
-      &[<G2 as GroupExt>::Scalar::ZERO],
+      &[<G1 as Group>::Scalar::ONE],
+      &[<G2 as Group>::Scalar::ZERO],
     );
     assert!(res.is_ok());
 
     let (zn_primary, zn_secondary) = res.unwrap();
 
     // sanity: check the claimed output with a direct computation of the same
-    assert_eq!(zn_primary, vec![<G1 as GroupExt>::Scalar::ONE]);
-    let mut zn_secondary_direct = vec![<G2 as GroupExt>::Scalar::ZERO];
+    assert_eq!(zn_primary, vec![<G1 as Group>::Scalar::ONE]);
+    let mut zn_secondary_direct = vec![<G2 as Group>::Scalar::ZERO];
     for _i in 0..num_steps {
       zn_secondary_direct = CubicCircuit::default().output(&zn_secondary_direct);
     }
     assert_eq!(zn_secondary, zn_secondary_direct);
-    assert_eq!(
-      zn_secondary,
-      vec![<G2 as GroupExt>::Scalar::from(2460515u64)]
-    );
+    assert_eq!(zn_secondary, vec![<G2 as Group>::Scalar::from(2460515u64)]);
 
     // run the compressed snark with Spark compiler
 
@@ -1263,8 +1255,8 @@ mod tests {
     let res = compressed_snark.verify(
       &vk,
       num_steps,
-      &[<G1 as GroupExt>::Scalar::ONE],
-      &[<G2 as GroupExt>::Scalar::ZERO],
+      &[<G1 as Group>::Scalar::ONE],
+      &[<G2 as Group>::Scalar::ZERO],
     );
     assert!(res.is_ok());
   }
@@ -1287,8 +1279,8 @@ mod tests {
 
   fn test_ivc_nondet_with_compression_with<G1, G2, E1, E2>()
   where
-    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+    G1: GroupExt<Base = <G2 as Group>::Scalar>,
+    G2: GroupExt<Base = <G1 as Group>::Scalar>,
     E1: EvaluationEngineTrait<G1>,
     E2: EvaluationEngineTrait<G2>,
   {
@@ -1353,7 +1345,7 @@ mod tests {
     }
 
     let circuit_primary = FifthRootCheckingCircuit {
-      y: <G1 as GroupExt>::Scalar::ZERO,
+      y: <G1 as Group>::Scalar::ZERO,
     };
 
     let circuit_secondary = TrivialCircuit::default();
@@ -1362,27 +1354,27 @@ mod tests {
     let pp = PublicParams::<
       G1,
       G2,
-      FifthRootCheckingCircuit<<G1 as GroupExt>::Scalar>,
-      TrivialCircuit<<G2 as GroupExt>::Scalar>,
+      FifthRootCheckingCircuit<<G1 as Group>::Scalar>,
+      TrivialCircuit<<G2 as Group>::Scalar>,
     >::setup(&circuit_primary, &circuit_secondary);
 
     let num_steps = 3;
 
     // produce non-deterministic advice
     let (z0_primary, roots) = FifthRootCheckingCircuit::new(num_steps);
-    let z0_secondary = vec![<G2 as GroupExt>::Scalar::ZERO];
+    let z0_secondary = vec![<G2 as Group>::Scalar::ZERO];
 
     // produce a recursive SNARK
     let mut recursive_snark: RecursiveSNARK<
       G1,
       G2,
-      FifthRootCheckingCircuit<<G1 as GroupExt>::Scalar>,
-      TrivialCircuit<<G2 as GroupExt>::Scalar>,
+      FifthRootCheckingCircuit<<G1 as Group>::Scalar>,
+      TrivialCircuit<<G2 as Group>::Scalar>,
     > = RecursiveSNARK::<
       G1,
       G2,
-      FifthRootCheckingCircuit<<G1 as GroupExt>::Scalar>,
-      TrivialCircuit<<G2 as GroupExt>::Scalar>,
+      FifthRootCheckingCircuit<<G1 as Group>::Scalar>,
+      TrivialCircuit<<G2 as Group>::Scalar>,
     >::new(
       &pp,
       &roots[0],
@@ -1427,18 +1419,18 @@ mod tests {
 
   fn test_ivc_base_with<G1, G2>()
   where
-    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
-    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
+    G1: GroupExt<Base = <G2 as Group>::Scalar>,
+    G2: GroupExt<Base = <G1 as Group>::Scalar>,
   {
-    let test_circuit1 = TrivialCircuit::<<G1 as GroupExt>::Scalar>::default();
-    let test_circuit2 = CubicCircuit::<<G2 as GroupExt>::Scalar>::default();
+    let test_circuit1 = TrivialCircuit::<<G1 as Group>::Scalar>::default();
+    let test_circuit2 = CubicCircuit::<<G2 as Group>::Scalar>::default();
 
     // produce public parameters
     let pp = PublicParams::<
       G1,
       G2,
-      TrivialCircuit<<G1 as GroupExt>::Scalar>,
-      CubicCircuit<<G2 as GroupExt>::Scalar>,
+      TrivialCircuit<<G1 as Group>::Scalar>,
+      CubicCircuit<<G2 as Group>::Scalar>,
     >::setup(&test_circuit1, &test_circuit2);
 
     let num_steps = 1;
@@ -1447,14 +1439,14 @@ mod tests {
     let mut recursive_snark = RecursiveSNARK::<
       G1,
       G2,
-      TrivialCircuit<<G1 as GroupExt>::Scalar>,
-      CubicCircuit<<G2 as GroupExt>::Scalar>,
+      TrivialCircuit<<G1 as Group>::Scalar>,
+      CubicCircuit<<G2 as Group>::Scalar>,
     >::new(
       &pp,
       &test_circuit1,
       &test_circuit2,
-      &[<G1 as GroupExt>::Scalar::ONE],
-      &[<G2 as GroupExt>::Scalar::ZERO],
+      &[<G1 as Group>::Scalar::ONE],
+      &[<G2 as Group>::Scalar::ZERO],
     )
     .unwrap();
 
@@ -1467,15 +1459,15 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      &[<G1 as GroupExt>::Scalar::ONE],
-      &[<G2 as GroupExt>::Scalar::ZERO],
+      &[<G1 as Group>::Scalar::ONE],
+      &[<G2 as Group>::Scalar::ZERO],
     );
     assert!(res.is_ok());
 
     let (zn_primary, zn_secondary) = res.unwrap();
 
-    assert_eq!(zn_primary, vec![<G1 as GroupExt>::Scalar::ONE]);
-    assert_eq!(zn_secondary, vec![<G2 as GroupExt>::Scalar::from(5u64)]);
+    assert_eq!(zn_primary, vec![<G1 as Group>::Scalar::ONE]);
+    assert_eq!(zn_secondary, vec![<G2 as Group>::Scalar::from(5u64)]);
   }
 
   #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ use traits::{
   circuit::StepCircuit,
   commitment::{CommitmentEngineTrait, CommitmentTrait},
   snark::RelaxedR1CSSNARKTrait,
-  AbsorbInROTrait, Group, ROConstants, ROConstantsCircuit, ROTrait,
+  AbsorbInROTrait, GroupExt, ROConstants, ROConstantsCircuit, ROTrait,
 };
 
 /// A type that holds public parameters of Nova
@@ -55,8 +55,8 @@ use traits::{
 #[serde(bound = "")]
 pub struct PublicParams<G1, G2, C1, C2>
 where
-  G1: Group<Base = <G2 as Group>::Scalar>,
-  G2: Group<Base = <G1 as Group>::Scalar>,
+  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
@@ -79,8 +79,8 @@ where
 
 impl<G1, G2, C1, C2> SimpleDigestible for PublicParams<G1, G2, C1, C2>
 where
-  G1: Group<Base = <G2 as Group>::Scalar>,
-  G2: Group<Base = <G1 as Group>::Scalar>,
+  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
@@ -88,8 +88,8 @@ where
 
 impl<G1, G2, C1, C2> PublicParams<G1, G2, C1, C2>
 where
-  G1: Group<Base = <G2 as Group>::Scalar>,
-  G2: Group<Base = <G1 as Group>::Scalar>,
+  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
@@ -181,8 +181,8 @@ where
 #[serde(bound = "")]
 pub struct RecursiveSNARK<G1, G2, C1, C2>
 where
-  G1: Group<Base = <G2 as Group>::Scalar>,
-  G2: Group<Base = <G1 as Group>::Scalar>,
+  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
@@ -203,8 +203,8 @@ where
 
 impl<G1, G2, C1, C2> RecursiveSNARK<G1, G2, C1, C2>
 where
-  G1: Group<Base = <G2 as Group>::Scalar>,
-  G2: Group<Base = <G1 as Group>::Scalar>,
+  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
 {
@@ -295,13 +295,13 @@ where
     let zi_primary = zi_primary
       .iter()
       .map(|v| v.get_value().ok_or(NovaError::SynthesisError))
-      .collect::<Result<Vec<<G1 as Group>::Scalar>, NovaError>>()
+      .collect::<Result<Vec<<G1 as GroupExt>::Scalar>, NovaError>>()
       .expect("Nova error synthesis");
 
     let zi_secondary = zi_secondary
       .iter()
       .map(|v| v.get_value().ok_or(NovaError::SynthesisError))
-      .collect::<Result<Vec<<G2 as Group>::Scalar>, NovaError>>()
+      .collect::<Result<Vec<<G2 as GroupExt>::Scalar>, NovaError>>()
       .expect("Nova error synthesis");
 
     Ok(Self {
@@ -416,11 +416,11 @@ where
     self.zi_primary = zi_primary
       .iter()
       .map(|v| v.get_value().ok_or(NovaError::SynthesisError))
-      .collect::<Result<Vec<<G1 as Group>::Scalar>, NovaError>>()?;
+      .collect::<Result<Vec<<G1 as GroupExt>::Scalar>, NovaError>>()?;
     self.zi_secondary = zi_secondary
       .iter()
       .map(|v| v.get_value().ok_or(NovaError::SynthesisError))
-      .collect::<Result<Vec<<G2 as Group>::Scalar>, NovaError>>()?;
+      .collect::<Result<Vec<<G2 as GroupExt>::Scalar>, NovaError>>()?;
 
     self.l_u_secondary = l_u_secondary;
     self.l_w_secondary = l_w_secondary;
@@ -469,7 +469,7 @@ where
 
     // check if the output hashes in R1CS instances point to the right running instances
     let (hash_primary, hash_secondary) = {
-      let mut hasher = <G2 as Group>::RO::new(
+      let mut hasher = <G2 as GroupExt>::RO::new(
         pp.ro_consts_secondary.clone(),
         NUM_FE_WITHOUT_IO_FOR_CRHF + 2 * pp.F_arity_primary,
       );
@@ -483,7 +483,7 @@ where
       }
       self.r_U_secondary.absorb_in_ro(&mut hasher);
 
-      let mut hasher2 = <G1 as Group>::RO::new(
+      let mut hasher2 = <G1 as GroupExt>::RO::new(
         pp.ro_consts_primary.clone(),
         NUM_FE_WITHOUT_IO_FOR_CRHF + 2 * pp.F_arity_secondary,
       );
@@ -549,8 +549,8 @@ where
 #[serde(bound = "")]
 pub struct ProverKey<G1, G2, C1, C2, S1, S2>
 where
-  G1: Group<Base = <G2 as Group>::Scalar>,
-  G2: Group<Base = <G1 as Group>::Scalar>,
+  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
   S1: RelaxedR1CSSNARKTrait<G1>,
@@ -567,8 +567,8 @@ where
 #[serde(bound = "")]
 pub struct VerifierKey<G1, G2, C1, C2, S1, S2>
 where
-  G1: Group<Base = <G2 as Group>::Scalar>,
-  G2: Group<Base = <G1 as Group>::Scalar>,
+  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
   S1: RelaxedR1CSSNARKTrait<G1>,
@@ -590,8 +590,8 @@ where
 #[serde(bound = "")]
 pub struct CompressedSNARK<G1, G2, C1, C2, S1, S2>
 where
-  G1: Group<Base = <G2 as Group>::Scalar>,
-  G2: Group<Base = <G1 as Group>::Scalar>,
+  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
   S1: RelaxedR1CSSNARKTrait<G1>,
@@ -614,8 +614,8 @@ where
 
 impl<G1, G2, C1, C2, S1, S2> CompressedSNARK<G1, G2, C1, C2, S1, S2>
 where
-  G1: Group<Base = <G2 as Group>::Scalar>,
-  G2: Group<Base = <G1 as Group>::Scalar>,
+  G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+  G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
   C1: StepCircuit<G1::Scalar>,
   C2: StepCircuit<G2::Scalar>,
   S1: RelaxedR1CSSNARKTrait<G1>,
@@ -738,7 +738,7 @@ where
 
     // check if the output hashes in R1CS instances point to the right running instances
     let (hash_primary, hash_secondary) = {
-      let mut hasher = <G2 as Group>::RO::new(
+      let mut hasher = <G2 as GroupExt>::RO::new(
         vk.ro_consts_secondary.clone(),
         NUM_FE_WITHOUT_IO_FOR_CRHF + 2 * vk.F_arity_primary,
       );
@@ -752,7 +752,7 @@ where
       }
       self.r_U_secondary.absorb_in_ro(&mut hasher);
 
-      let mut hasher2 = <G1 as Group>::RO::new(
+      let mut hasher2 = <G1 as GroupExt>::RO::new(
         vk.ro_consts_primary.clone(),
         NUM_FE_WITHOUT_IO_FOR_CRHF + 2 * vk.F_arity_secondary,
       );
@@ -807,10 +807,10 @@ where
   }
 }
 
-type CommitmentKey<G> = <<G as Group>::CE as CommitmentEngineTrait<G>>::CommitmentKey;
-type Commitment<G> = <<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment;
-type CompressedCommitment<G> = <<<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment as CommitmentTrait<G>>::CompressedCommitment;
-type CE<G> = <G as Group>::CE;
+type CommitmentKey<G> = <<G as GroupExt>::CE as CommitmentEngineTrait<G>>::CommitmentKey;
+type Commitment<G> = <<G as GroupExt>::CE as CommitmentEngineTrait<G>>::Commitment;
+type CompressedCommitment<G> = <<<G as GroupExt>::CE as CommitmentEngineTrait<G>>::Commitment as CommitmentTrait<G>>::CompressedCommitment;
+type CE<G> = <G as GroupExt>::CE;
 
 #[cfg(test)]
 mod tests {
@@ -885,8 +885,8 @@ mod tests {
 
   fn test_pp_digest_with<G1, G2, T1, T2>(circuit1: &T1, circuit2: &T2, expected: &str)
   where
-    G1: Group<Base = <G2 as Group>::Scalar>,
-    G2: Group<Base = <G1 as Group>::Scalar>,
+    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
     T1: StepCircuit<G1::Scalar>,
     T2: StepCircuit<G2::Scalar>,
   {
@@ -908,9 +908,9 @@ mod tests {
   fn test_pp_digest() {
     type G1 = pasta_curves::pallas::Point;
     type G2 = pasta_curves::vesta::Point;
-    let trivial_circuit1 = TrivialCircuit::<<G1 as Group>::Scalar>::default();
-    let trivial_circuit2 = TrivialCircuit::<<G2 as Group>::Scalar>::default();
-    let cubic_circuit1 = CubicCircuit::<<G1 as Group>::Scalar>::default();
+    let trivial_circuit1 = TrivialCircuit::<<G1 as GroupExt>::Scalar>::default();
+    let trivial_circuit2 = TrivialCircuit::<<G2 as GroupExt>::Scalar>::default();
+    let cubic_circuit1 = CubicCircuit::<<G1 as GroupExt>::Scalar>::default();
 
     test_pp_digest_with::<G1, G2, _, _>(
       &trivial_circuit1,
@@ -924,9 +924,10 @@ mod tests {
       "583c9964e180332e63a59450870a72b4cbf663ce0d274ac5bd0d052d4cd92903",
     );
 
-    let trivial_circuit1_grumpkin = TrivialCircuit::<<bn256::Point as Group>::Scalar>::default();
-    let trivial_circuit2_grumpkin = TrivialCircuit::<<grumpkin::Point as Group>::Scalar>::default();
-    let cubic_circuit1_grumpkin = CubicCircuit::<<bn256::Point as Group>::Scalar>::default();
+    let trivial_circuit1_grumpkin = TrivialCircuit::<<bn256::Point as GroupExt>::Scalar>::default();
+    let trivial_circuit2_grumpkin =
+      TrivialCircuit::<<grumpkin::Point as GroupExt>::Scalar>::default();
+    let cubic_circuit1_grumpkin = CubicCircuit::<<bn256::Point as GroupExt>::Scalar>::default();
 
     test_pp_digest_with::<bn256::Point, grumpkin::Point, _, _>(
       &trivial_circuit1_grumpkin,
@@ -939,9 +940,9 @@ mod tests {
       "684b2f7151031a79310f6fb553ab1480e290d73731fa34e74c27e004d589f102",
     );
 
-    let trivial_circuit1_secp = TrivialCircuit::<<secp256k1::Point as Group>::Scalar>::default();
-    let trivial_circuit2_secp = TrivialCircuit::<<secq256k1::Point as Group>::Scalar>::default();
-    let cubic_circuit1_secp = CubicCircuit::<<secp256k1::Point as Group>::Scalar>::default();
+    let trivial_circuit1_secp = TrivialCircuit::<<secp256k1::Point as GroupExt>::Scalar>::default();
+    let trivial_circuit2_secp = TrivialCircuit::<<secq256k1::Point as GroupExt>::Scalar>::default();
+    let cubic_circuit1_secp = CubicCircuit::<<secp256k1::Point as GroupExt>::Scalar>::default();
 
     test_pp_digest_with::<secp256k1::Point, secq256k1::Point, _, _>(
       &trivial_circuit1_secp,
@@ -957,18 +958,18 @@ mod tests {
 
   fn test_ivc_trivial_with<G1, G2>()
   where
-    G1: Group<Base = <G2 as Group>::Scalar>,
-    G2: Group<Base = <G1 as Group>::Scalar>,
+    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
   {
-    let test_circuit1 = TrivialCircuit::<<G1 as Group>::Scalar>::default();
-    let test_circuit2 = TrivialCircuit::<<G2 as Group>::Scalar>::default();
+    let test_circuit1 = TrivialCircuit::<<G1 as GroupExt>::Scalar>::default();
+    let test_circuit2 = TrivialCircuit::<<G2 as GroupExt>::Scalar>::default();
 
     // produce public parameters
     let pp = PublicParams::<
       G1,
       G2,
-      TrivialCircuit<<G1 as Group>::Scalar>,
-      TrivialCircuit<<G2 as Group>::Scalar>,
+      TrivialCircuit<<G1 as GroupExt>::Scalar>,
+      TrivialCircuit<<G2 as GroupExt>::Scalar>,
     >::setup(&test_circuit1, &test_circuit2);
 
     let num_steps = 1;
@@ -978,8 +979,8 @@ mod tests {
       &pp,
       &test_circuit1,
       &test_circuit2,
-      &[<G1 as Group>::Scalar::ZERO],
-      &[<G2 as Group>::Scalar::ZERO],
+      &[<G1 as GroupExt>::Scalar::ZERO],
+      &[<G2 as GroupExt>::Scalar::ZERO],
     )
     .unwrap();
 
@@ -991,8 +992,8 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      &[<G1 as Group>::Scalar::ZERO],
-      &[<G2 as Group>::Scalar::ZERO],
+      &[<G1 as GroupExt>::Scalar::ZERO],
+      &[<G2 as GroupExt>::Scalar::ZERO],
     );
     assert!(res.is_ok());
   }
@@ -1009,8 +1010,8 @@ mod tests {
 
   fn test_ivc_nontrivial_with<G1, G2>()
   where
-    G1: Group<Base = <G2 as Group>::Scalar>,
-    G2: Group<Base = <G1 as Group>::Scalar>,
+    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
   {
     let circuit_primary = TrivialCircuit::default();
     let circuit_secondary = CubicCircuit::default();
@@ -1019,8 +1020,8 @@ mod tests {
     let pp = PublicParams::<
       G1,
       G2,
-      TrivialCircuit<<G1 as Group>::Scalar>,
-      CubicCircuit<<G2 as Group>::Scalar>,
+      TrivialCircuit<<G1 as GroupExt>::Scalar>,
+      CubicCircuit<<G2 as GroupExt>::Scalar>,
     >::setup(&circuit_primary, &circuit_secondary);
 
     let num_steps = 3;
@@ -1029,14 +1030,14 @@ mod tests {
     let mut recursive_snark = RecursiveSNARK::<
       G1,
       G2,
-      TrivialCircuit<<G1 as Group>::Scalar>,
-      CubicCircuit<<G2 as Group>::Scalar>,
+      TrivialCircuit<<G1 as GroupExt>::Scalar>,
+      CubicCircuit<<G2 as GroupExt>::Scalar>,
     >::new(
       &pp,
       &circuit_primary,
       &circuit_secondary,
-      &[<G1 as Group>::Scalar::ONE],
-      &[<G2 as Group>::Scalar::ZERO],
+      &[<G1 as GroupExt>::Scalar::ONE],
+      &[<G2 as GroupExt>::Scalar::ZERO],
     )
     .unwrap();
 
@@ -1048,8 +1049,8 @@ mod tests {
       let res = recursive_snark.verify(
         &pp,
         i + 1,
-        &[<G1 as Group>::Scalar::ONE],
-        &[<G2 as Group>::Scalar::ZERO],
+        &[<G1 as GroupExt>::Scalar::ONE],
+        &[<G2 as GroupExt>::Scalar::ZERO],
       );
       assert!(res.is_ok());
     }
@@ -1058,21 +1059,24 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      &[<G1 as Group>::Scalar::ONE],
-      &[<G2 as Group>::Scalar::ZERO],
+      &[<G1 as GroupExt>::Scalar::ONE],
+      &[<G2 as GroupExt>::Scalar::ZERO],
     );
     assert!(res.is_ok());
 
     let (zn_primary, zn_secondary) = res.unwrap();
 
     // sanity: check the claimed output with a direct computation of the same
-    assert_eq!(zn_primary, vec![<G1 as Group>::Scalar::ONE]);
-    let mut zn_secondary_direct = vec![<G2 as Group>::Scalar::ZERO];
+    assert_eq!(zn_primary, vec![<G1 as GroupExt>::Scalar::ONE]);
+    let mut zn_secondary_direct = vec![<G2 as GroupExt>::Scalar::ZERO];
     for _i in 0..num_steps {
       zn_secondary_direct = circuit_secondary.clone().output(&zn_secondary_direct);
     }
     assert_eq!(zn_secondary, zn_secondary_direct);
-    assert_eq!(zn_secondary, vec![<G2 as Group>::Scalar::from(2460515u64)]);
+    assert_eq!(
+      zn_secondary,
+      vec![<G2 as GroupExt>::Scalar::from(2460515u64)]
+    );
   }
 
   #[test]
@@ -1087,8 +1091,8 @@ mod tests {
 
   fn test_ivc_nontrivial_with_compression_with<G1, G2, E1, E2>()
   where
-    G1: Group<Base = <G2 as Group>::Scalar>,
-    G2: Group<Base = <G1 as Group>::Scalar>,
+    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
     E1: EvaluationEngineTrait<G1>,
     E2: EvaluationEngineTrait<G2>,
   {
@@ -1099,8 +1103,8 @@ mod tests {
     let pp = PublicParams::<
       G1,
       G2,
-      TrivialCircuit<<G1 as Group>::Scalar>,
-      CubicCircuit<<G2 as Group>::Scalar>,
+      TrivialCircuit<<G1 as GroupExt>::Scalar>,
+      CubicCircuit<<G2 as GroupExt>::Scalar>,
     >::setup(&circuit_primary, &circuit_secondary);
 
     let num_steps = 3;
@@ -1109,14 +1113,14 @@ mod tests {
     let mut recursive_snark = RecursiveSNARK::<
       G1,
       G2,
-      TrivialCircuit<<G1 as Group>::Scalar>,
-      CubicCircuit<<G2 as Group>::Scalar>,
+      TrivialCircuit<<G1 as GroupExt>::Scalar>,
+      CubicCircuit<<G2 as GroupExt>::Scalar>,
     >::new(
       &pp,
       &circuit_primary,
       &circuit_secondary,
-      &[<G1 as Group>::Scalar::ONE],
-      &[<G2 as Group>::Scalar::ZERO],
+      &[<G1 as GroupExt>::Scalar::ONE],
+      &[<G2 as GroupExt>::Scalar::ZERO],
     )
     .unwrap();
 
@@ -1129,21 +1133,24 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      &[<G1 as Group>::Scalar::ONE],
-      &[<G2 as Group>::Scalar::ZERO],
+      &[<G1 as GroupExt>::Scalar::ONE],
+      &[<G2 as GroupExt>::Scalar::ZERO],
     );
     assert!(res.is_ok());
 
     let (zn_primary, zn_secondary) = res.unwrap();
 
     // sanity: check the claimed output with a direct computation of the same
-    assert_eq!(zn_primary, vec![<G1 as Group>::Scalar::ONE]);
-    let mut zn_secondary_direct = vec![<G2 as Group>::Scalar::ZERO];
+    assert_eq!(zn_primary, vec![<G1 as GroupExt>::Scalar::ONE]);
+    let mut zn_secondary_direct = vec![<G2 as GroupExt>::Scalar::ZERO];
     for _i in 0..num_steps {
       zn_secondary_direct = circuit_secondary.clone().output(&zn_secondary_direct);
     }
     assert_eq!(zn_secondary, zn_secondary_direct);
-    assert_eq!(zn_secondary, vec![<G2 as Group>::Scalar::from(2460515u64)]);
+    assert_eq!(
+      zn_secondary,
+      vec![<G2 as GroupExt>::Scalar::from(2460515u64)]
+    );
 
     // produce the prover and verifier keys for compressed snark
     let (pk, vk) = CompressedSNARK::<_, _, _, _, S<G1, E1>, S<G2, E2>>::setup(&pp).unwrap();
@@ -1158,8 +1165,8 @@ mod tests {
     let res = compressed_snark.verify(
       &vk,
       num_steps,
-      &[<G1 as Group>::Scalar::ONE],
-      &[<G2 as Group>::Scalar::ZERO],
+      &[<G1 as GroupExt>::Scalar::ONE],
+      &[<G2 as GroupExt>::Scalar::ZERO],
     );
     assert!(res.is_ok());
   }
@@ -1176,8 +1183,8 @@ mod tests {
 
   fn test_ivc_nontrivial_with_spark_compression_with<G1, G2, E1, E2>()
   where
-    G1: Group<Base = <G2 as Group>::Scalar>,
-    G2: Group<Base = <G1 as Group>::Scalar>,
+    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
     E1: EvaluationEngineTrait<G1>,
     E2: EvaluationEngineTrait<G2>,
   {
@@ -1188,8 +1195,8 @@ mod tests {
     let pp = PublicParams::<
       G1,
       G2,
-      TrivialCircuit<<G1 as Group>::Scalar>,
-      CubicCircuit<<G2 as Group>::Scalar>,
+      TrivialCircuit<<G1 as GroupExt>::Scalar>,
+      CubicCircuit<<G2 as GroupExt>::Scalar>,
     >::setup(&circuit_primary, &circuit_secondary);
 
     let num_steps = 3;
@@ -1198,14 +1205,14 @@ mod tests {
     let mut recursive_snark = RecursiveSNARK::<
       G1,
       G2,
-      TrivialCircuit<<G1 as Group>::Scalar>,
-      CubicCircuit<<G2 as Group>::Scalar>,
+      TrivialCircuit<<G1 as GroupExt>::Scalar>,
+      CubicCircuit<<G2 as GroupExt>::Scalar>,
     >::new(
       &pp,
       &circuit_primary,
       &circuit_secondary,
-      &[<G1 as Group>::Scalar::ONE],
-      &[<G2 as Group>::Scalar::ZERO],
+      &[<G1 as GroupExt>::Scalar::ONE],
+      &[<G2 as GroupExt>::Scalar::ZERO],
     )
     .unwrap();
 
@@ -1218,21 +1225,24 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      &[<G1 as Group>::Scalar::ONE],
-      &[<G2 as Group>::Scalar::ZERO],
+      &[<G1 as GroupExt>::Scalar::ONE],
+      &[<G2 as GroupExt>::Scalar::ZERO],
     );
     assert!(res.is_ok());
 
     let (zn_primary, zn_secondary) = res.unwrap();
 
     // sanity: check the claimed output with a direct computation of the same
-    assert_eq!(zn_primary, vec![<G1 as Group>::Scalar::ONE]);
-    let mut zn_secondary_direct = vec![<G2 as Group>::Scalar::ZERO];
+    assert_eq!(zn_primary, vec![<G1 as GroupExt>::Scalar::ONE]);
+    let mut zn_secondary_direct = vec![<G2 as GroupExt>::Scalar::ZERO];
     for _i in 0..num_steps {
       zn_secondary_direct = CubicCircuit::default().output(&zn_secondary_direct);
     }
     assert_eq!(zn_secondary, zn_secondary_direct);
-    assert_eq!(zn_secondary, vec![<G2 as Group>::Scalar::from(2460515u64)]);
+    assert_eq!(
+      zn_secondary,
+      vec![<G2 as GroupExt>::Scalar::from(2460515u64)]
+    );
 
     // run the compressed snark with Spark compiler
 
@@ -1253,8 +1263,8 @@ mod tests {
     let res = compressed_snark.verify(
       &vk,
       num_steps,
-      &[<G1 as Group>::Scalar::ONE],
-      &[<G2 as Group>::Scalar::ZERO],
+      &[<G1 as GroupExt>::Scalar::ONE],
+      &[<G2 as GroupExt>::Scalar::ZERO],
     );
     assert!(res.is_ok());
   }
@@ -1277,8 +1287,8 @@ mod tests {
 
   fn test_ivc_nondet_with_compression_with<G1, G2, E1, E2>()
   where
-    G1: Group<Base = <G2 as Group>::Scalar>,
-    G2: Group<Base = <G1 as Group>::Scalar>,
+    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
     E1: EvaluationEngineTrait<G1>,
     E2: EvaluationEngineTrait<G2>,
   {
@@ -1343,7 +1353,7 @@ mod tests {
     }
 
     let circuit_primary = FifthRootCheckingCircuit {
-      y: <G1 as Group>::Scalar::ZERO,
+      y: <G1 as GroupExt>::Scalar::ZERO,
     };
 
     let circuit_secondary = TrivialCircuit::default();
@@ -1352,27 +1362,27 @@ mod tests {
     let pp = PublicParams::<
       G1,
       G2,
-      FifthRootCheckingCircuit<<G1 as Group>::Scalar>,
-      TrivialCircuit<<G2 as Group>::Scalar>,
+      FifthRootCheckingCircuit<<G1 as GroupExt>::Scalar>,
+      TrivialCircuit<<G2 as GroupExt>::Scalar>,
     >::setup(&circuit_primary, &circuit_secondary);
 
     let num_steps = 3;
 
     // produce non-deterministic advice
     let (z0_primary, roots) = FifthRootCheckingCircuit::new(num_steps);
-    let z0_secondary = vec![<G2 as Group>::Scalar::ZERO];
+    let z0_secondary = vec![<G2 as GroupExt>::Scalar::ZERO];
 
     // produce a recursive SNARK
     let mut recursive_snark: RecursiveSNARK<
       G1,
       G2,
-      FifthRootCheckingCircuit<<G1 as Group>::Scalar>,
-      TrivialCircuit<<G2 as Group>::Scalar>,
+      FifthRootCheckingCircuit<<G1 as GroupExt>::Scalar>,
+      TrivialCircuit<<G2 as GroupExt>::Scalar>,
     > = RecursiveSNARK::<
       G1,
       G2,
-      FifthRootCheckingCircuit<<G1 as Group>::Scalar>,
-      TrivialCircuit<<G2 as Group>::Scalar>,
+      FifthRootCheckingCircuit<<G1 as GroupExt>::Scalar>,
+      TrivialCircuit<<G2 as GroupExt>::Scalar>,
     >::new(
       &pp,
       &roots[0],
@@ -1417,18 +1427,18 @@ mod tests {
 
   fn test_ivc_base_with<G1, G2>()
   where
-    G1: Group<Base = <G2 as Group>::Scalar>,
-    G2: Group<Base = <G1 as Group>::Scalar>,
+    G1: GroupExt<Base = <G2 as GroupExt>::Scalar>,
+    G2: GroupExt<Base = <G1 as GroupExt>::Scalar>,
   {
-    let test_circuit1 = TrivialCircuit::<<G1 as Group>::Scalar>::default();
-    let test_circuit2 = CubicCircuit::<<G2 as Group>::Scalar>::default();
+    let test_circuit1 = TrivialCircuit::<<G1 as GroupExt>::Scalar>::default();
+    let test_circuit2 = CubicCircuit::<<G2 as GroupExt>::Scalar>::default();
 
     // produce public parameters
     let pp = PublicParams::<
       G1,
       G2,
-      TrivialCircuit<<G1 as Group>::Scalar>,
-      CubicCircuit<<G2 as Group>::Scalar>,
+      TrivialCircuit<<G1 as GroupExt>::Scalar>,
+      CubicCircuit<<G2 as GroupExt>::Scalar>,
     >::setup(&test_circuit1, &test_circuit2);
 
     let num_steps = 1;
@@ -1437,14 +1447,14 @@ mod tests {
     let mut recursive_snark = RecursiveSNARK::<
       G1,
       G2,
-      TrivialCircuit<<G1 as Group>::Scalar>,
-      CubicCircuit<<G2 as Group>::Scalar>,
+      TrivialCircuit<<G1 as GroupExt>::Scalar>,
+      CubicCircuit<<G2 as GroupExt>::Scalar>,
     >::new(
       &pp,
       &test_circuit1,
       &test_circuit2,
-      &[<G1 as Group>::Scalar::ONE],
-      &[<G2 as Group>::Scalar::ZERO],
+      &[<G1 as GroupExt>::Scalar::ONE],
+      &[<G2 as GroupExt>::Scalar::ZERO],
     )
     .unwrap();
 
@@ -1457,15 +1467,15 @@ mod tests {
     let res = recursive_snark.verify(
       &pp,
       num_steps,
-      &[<G1 as Group>::Scalar::ONE],
-      &[<G2 as Group>::Scalar::ZERO],
+      &[<G1 as GroupExt>::Scalar::ONE],
+      &[<G2 as GroupExt>::Scalar::ZERO],
     );
     assert!(res.is_ok());
 
     let (zn_primary, zn_secondary) = res.unwrap();
 
-    assert_eq!(zn_primary, vec![<G1 as Group>::Scalar::ONE]);
-    assert_eq!(zn_secondary, vec![<G2 as Group>::Scalar::from(5u64)]);
+    assert_eq!(zn_primary, vec![<G1 as GroupExt>::Scalar::ONE]);
+    assert_eq!(zn_secondary, vec![<G2 as GroupExt>::Scalar::from(5u64)]);
   }
 
   #[test]

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -6,9 +6,10 @@ use crate::{
   errors::NovaError,
   r1cs::{R1CSInstance, R1CSShape, R1CSWitness, RelaxedR1CSInstance, RelaxedR1CSWitness},
   scalar_as_base,
-  traits::{commitment::CommitmentTrait, AbsorbInROTrait, GroupExt, ROTrait},
-  Commitment, CommitmentKey, CompressedCommitment,
+  traits::{AbsorbInROTrait, GroupExt, ROTrait},
+  Commitment, CommitmentKey, CommitmentTrait, CompressedCommitment,
 };
+use group::Group;
 use serde::{Deserialize, Serialize};
 
 /// A SNARK that holds the proof of a step of an incremental computation
@@ -20,7 +21,7 @@ pub struct NIFS<G: GroupExt> {
 }
 
 type ROConstants<G> =
-  <<G as GroupExt>::RO as ROTrait<<G as GroupExt>::Base, <G as GroupExt>::Scalar>>::Constants;
+  <<G as GroupExt>::RO as ROTrait<<G as GroupExt>::Base, <G as Group>::Scalar>>::Constants;
 
 impl<G: GroupExt> NIFS<G> {
   /// Takes as input a Relaxed R1CS instance-witness tuple `(U1, W1)` and
@@ -169,7 +170,7 @@ mod tests {
     let (shape, ck) = cs.r1cs_shape();
     let ro_consts = <<G as GroupExt>::RO as ROTrait<
       <G as GroupExt>::Base,
-      <G as GroupExt>::Scalar,
+      <G as Group>::Scalar,
     >>::Constants::default();
 
     // Now get the instance and assignment for one instance
@@ -192,7 +193,7 @@ mod tests {
     execute_sequence(
       &ck,
       &ro_consts,
-      &<G as GroupExt>::Scalar::ZERO,
+      &<G as Group>::Scalar::ZERO,
       &shape,
       &U1,
       &W1,
@@ -210,8 +211,8 @@ mod tests {
 
   fn execute_sequence<G>(
     ck: &CommitmentKey<G>,
-    ro_consts: &<<G as GroupExt>::RO as ROTrait<<G as GroupExt>::Base, <G as GroupExt>::Scalar>>::Constants,
-    pp_digest: &<G as GroupExt>::Scalar,
+    ro_consts: &<<G as GroupExt>::RO as ROTrait<<G as GroupExt>::Base, <G as Group>::Scalar>>::Constants,
+    pp_digest: &<G as Group>::Scalar,
     shape: &R1CSShape<G>,
     U1: &R1CSInstance<G>,
     W1: &R1CSWitness<G>,
@@ -332,7 +333,7 @@ mod tests {
     let ck = R1CS::<G>::commitment_key(&S);
     let ro_consts = <<G as GroupExt>::RO as ROTrait<
       <G as GroupExt>::Base,
-      <G as GroupExt>::Scalar,
+      <G as Group>::Scalar,
     >>::Constants::default();
 
     let rand_inst_witness_generator =
@@ -379,7 +380,7 @@ mod tests {
     execute_sequence(
       &ck,
       &ro_consts,
-      &<G as GroupExt>::Scalar::ZERO,
+      &<G as Group>::Scalar::ZERO,
       &S,
       &U1,
       &W1,

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -7,7 +7,7 @@ use crate::{
     pedersen::CommitmentEngine,
     poseidon::{PoseidonRO, PoseidonROCircuit},
   },
-  traits::{CompressedGroup, Group, PrimeFieldExt, TranscriptReprTrait},
+  traits::{CompressedGroup, GroupExt, PrimeFieldExt, TranscriptReprTrait},
 };
 use digest::{ExtendableOutput, Update};
 use ff::{FromUniformBytes, PrimeField};
@@ -41,13 +41,13 @@ pub mod grumpkin {
   };
 }
 
-impl<G: Group> TranscriptReprTrait<G> for grumpkin::Base {
+impl<G: GroupExt> TranscriptReprTrait<G> for grumpkin::Base {
   fn to_transcript_bytes(&self) -> Vec<u8> {
     self.to_repr().to_vec()
   }
 }
 
-impl<G: Group> TranscriptReprTrait<G> for grumpkin::Scalar {
+impl<G: GroupExt> TranscriptReprTrait<G> for grumpkin::Scalar {
   fn to_transcript_bytes(&self) -> Vec<u8> {
     self.to_repr().to_vec()
   }
@@ -94,7 +94,7 @@ mod tests {
     for n in [
       1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 1021,
     ] {
-      let ck_par = <G as Group>::from_label(label, n);
+      let ck_par = <G as GroupExt>::from_label(label, n);
       let ck_ser = from_label_serial(label, n);
       assert_eq!(ck_par.len(), n);
       assert_eq!(ck_ser.len(), n);

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use digest::{ExtendableOutput, Update};
 use ff::{FromUniformBytes, PrimeField};
-use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup, GroupEncoding};
+use group::{cofactor::CofactorCurveAffine, Curve, Group, GroupEncoding};
 use num_bigint::BigInt;
 use num_traits::Num;
 // Remove this when https://github.com/zcash/pasta_curves/issues/41 resolves

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use digest::{ExtendableOutput, Update};
 use ff::{FromUniformBytes, PrimeField};
-use group::{cofactor::CofactorCurveAffine, Curve, Group, GroupEncoding};
+use group::{cofactor::CofactorCurveAffine, Curve, GroupEncoding};
 use num_bigint::BigInt;
 use num_traits::Num;
 // Remove this when https://github.com/zcash/pasta_curves/issues/41 resolves

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -4,11 +4,10 @@ use crate::{
   provider::pedersen::CommitmentKeyExtTrait,
   spartan::polys::eq::EqPolynomial,
   traits::{
-    commitment::{CommitmentEngineTrait, CommitmentTrait},
-    evaluation::EvaluationEngineTrait,
-    GroupExt, TranscriptEngineTrait, TranscriptReprTrait,
+    commitment::CommitmentEngineTrait, evaluation::EvaluationEngineTrait, GroupExt,
+    TranscriptEngineTrait, TranscriptReprTrait,
   },
-  Commitment, CommitmentKey, CompressedCommitment, CE,
+  Commitment, CommitmentKey, CommitmentTrait, CompressedCommitment, CE,
 };
 use core::iter;
 use ff::Field;

--- a/src/provider/keccak.rs
+++ b/src/provider/keccak.rs
@@ -2,7 +2,7 @@
 use crate::traits::PrimeFieldExt;
 use crate::{
   errors::NovaError,
-  traits::{Group, TranscriptEngineTrait, TranscriptReprTrait},
+  traits::{GroupExt, TranscriptEngineTrait, TranscriptReprTrait},
 };
 use core::marker::PhantomData;
 use sha3::{Digest, Keccak256};
@@ -15,7 +15,7 @@ const KECCAK256_PREFIX_CHALLENGE_HI: u8 = 1;
 
 /// Provides an implementation of `TranscriptEngine`
 #[derive(Debug, Clone)]
-pub struct Keccak256Transcript<G: Group> {
+pub struct Keccak256Transcript<G: GroupExt> {
   round: u16,
   state: [u8; KECCAK256_STATE_SIZE],
   transcript: Keccak256,
@@ -45,7 +45,7 @@ fn compute_updated_state(keccak_instance: Keccak256, input: &[u8]) -> [u8; KECCA
     .unwrap()
 }
 
-impl<G: Group> TranscriptEngineTrait<G> for Keccak256Transcript<G> {
+impl<G: GroupExt> TranscriptEngineTrait<G> for Keccak256Transcript<G> {
   fn new(label: &'static [u8]) -> Self {
     let keccak_instance = Keccak256::new();
     let input = [PERSONA_TAG, label].concat();
@@ -101,35 +101,38 @@ mod tests {
   use crate::{
     provider::bn256_grumpkin::bn256,
     provider::{self, keccak::Keccak256Transcript, secp_secq},
-    traits::{Group, PrimeFieldExt, TranscriptEngineTrait, TranscriptReprTrait},
+    traits::{GroupExt, PrimeFieldExt, TranscriptEngineTrait, TranscriptReprTrait},
   };
   use ff::PrimeField;
   use rand::Rng;
   use sha3::{Digest, Keccak256};
 
-  fn test_keccak_transcript_with<G: Group>(expected_h1: &'static str, expected_h2: &'static str) {
+  fn test_keccak_transcript_with<G: GroupExt>(
+    expected_h1: &'static str,
+    expected_h2: &'static str,
+  ) {
     let mut transcript: Keccak256Transcript<G> = Keccak256Transcript::new(b"test");
 
     // two scalars
-    let s1 = <G as Group>::Scalar::from(2u64);
-    let s2 = <G as Group>::Scalar::from(5u64);
+    let s1 = G::Scalar::from(2u64);
+    let s2 = G::Scalar::from(5u64);
 
     // add the scalars to the transcript
     transcript.absorb(b"s1", &s1);
     transcript.absorb(b"s2", &s2);
 
     // make a challenge
-    let c1: <G as Group>::Scalar = transcript.squeeze(b"c1").unwrap();
+    let c1: G::Scalar = transcript.squeeze(b"c1").unwrap();
     assert_eq!(hex::encode(c1.to_repr().as_ref()), expected_h1);
 
     // a scalar
-    let s3 = <G as Group>::Scalar::from(128u64);
+    let s3 = G::Scalar::from(128u64);
 
     // add the scalar to the transcript
     transcript.absorb(b"s3", &s3);
 
     // make a challenge
-    let c2: <G as Group>::Scalar = transcript.squeeze(b"c2").unwrap();
+    let c2: G::Scalar = transcript.squeeze(b"c2").unwrap();
     assert_eq!(hex::encode(c2.to_repr().as_ref()), expected_h2);
   }
 
@@ -206,13 +209,13 @@ mod tests {
 
   // This test is meant to ensure compatibility between the incremental way of computing the transcript above, and
   // the former, which materialized the entirety of the input vector before calling Keccak256 on it.
-  fn test_keccak_transcript_incremental_vs_explicit_with<G: Group>() {
+  fn test_keccak_transcript_incremental_vs_explicit_with<G: GroupExt>() {
     let test_label = b"test";
     let mut transcript: Keccak256Transcript<G> = Keccak256Transcript::new(test_label);
     let mut rng = rand::thread_rng();
 
     // ten scalars
-    let scalars = std::iter::from_fn(|| Some(<G as Group>::Scalar::from(rng.gen::<u64>())))
+    let scalars = std::iter::from_fn(|| Some(<G as GroupExt>::Scalar::from(rng.gen::<u64>())))
       .take(10)
       .collect::<Vec<_>>();
 
@@ -233,7 +236,7 @@ mod tests {
     let initial_state = compute_updated_state_for_testing(&input);
 
     // make a challenge
-    let c1: <G as Group>::Scalar = transcript.squeeze(b"c1").unwrap();
+    let c1: G::Scalar = transcript.squeeze(b"c1").unwrap();
 
     let c1_bytes = squeeze_for_testing(&manual_transcript[..], 0u16, initial_state, b"c1");
     let to_hex = |g: G::Scalar| hex::encode(g.to_repr().as_ref());

--- a/src/provider/keccak.rs
+++ b/src/provider/keccak.rs
@@ -104,6 +104,7 @@ mod tests {
     traits::{GroupExt, PrimeFieldExt, TranscriptEngineTrait, TranscriptReprTrait},
   };
   use ff::PrimeField;
+  use group::Group;
   use rand::Rng;
   use sha3::{Digest, Keccak256};
 
@@ -215,7 +216,7 @@ mod tests {
     let mut rng = rand::thread_rng();
 
     // ten scalars
-    let scalars = std::iter::from_fn(|| Some(<G as GroupExt>::Scalar::from(rng.gen::<u64>())))
+    let scalars = std::iter::from_fn(|| Some(<G as Group>::Scalar::from(rng.gen::<u64>())))
       .take(10)
       .collect::<Vec<_>>();
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -146,7 +146,7 @@ macro_rules! impl_traits {
     $name_curve_affine:ident,
     $order_str:literal
   ) => {
-    impl Group for $name::Point {
+    impl GroupExt for $name::Point {
       type Base = $name::Base;
       type Scalar = $name::Scalar;
       type CompressedGroupElement = $name_compressed;
@@ -253,7 +253,7 @@ macro_rules! impl_traits {
       }
     }
 
-    impl<G: Group> TranscriptReprTrait<G> for $name_compressed {
+    impl<G: GroupExt> TranscriptReprTrait<G> for $name_compressed {
       fn to_transcript_bytes(&self) -> Vec<u8> {
         self.as_ref().to_vec()
       }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -148,7 +148,7 @@ macro_rules! impl_traits {
   ) => {
     impl GroupExt for $name::Point {
       type Base = $name::Base;
-      type Scalar = $name::Scalar;
+      type ScalarExt = $name::Scalar;
       type CompressedGroupElement = $name_compressed;
       type PreprocessedGroupElement = $name::Affine;
       type RO = PoseidonRO<Self::Base, Self::Scalar>;

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -13,7 +13,7 @@ pub mod poseidon;
 pub mod secp_secq;
 
 use ff::PrimeField;
-use pasta_curves::{self, arithmetic::CurveAffine, group::Group as AnotherGroup};
+use pasta_curves::{self, arithmetic::CurveAffine, group::Group};
 use rayon::{current_num_threads, prelude::*};
 
 /// Native implementation of fast multiexp

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -236,14 +236,6 @@ macro_rules! impl_traits {
 
         (A, B, order)
       }
-
-      fn zero() -> Self {
-        $name::Point::identity()
-      }
-
-      fn get_generator() -> Self {
-        $name::Point::generator()
-      }
     }
 
     impl PrimeFieldExt for $name::Scalar {

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -59,7 +59,7 @@ macro_rules! impl_traits {
   ) => {
     impl GroupExt for $name::Point {
       type Base = $name::Base;
-      type Scalar = $name::Scalar;
+      type ScalarExt = $name::Scalar;
       type CompressedGroupElement = $name_compressed;
       type PreprocessedGroupElement = $name::Affine;
       type RO = PoseidonRO<Self::Base, Self::Scalar>;

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -15,7 +15,7 @@ use num_traits::Num;
 use pasta_curves::{
   self,
   arithmetic::{CurveAffine, CurveExt},
-  group::{cofactor::CofactorCurveAffine, Curve, Group, GroupEncoding},
+  group::{cofactor::CofactorCurveAffine, Curve, GroupEncoding},
   pallas, vesta, Ep, EpAffine, Eq, EqAffine,
 };
 use rayon::prelude::*;
@@ -156,14 +156,6 @@ macro_rules! impl_traits {
         let order = BigInt::from_str_radix($order_str, 16).unwrap();
 
         (A, B, order)
-      }
-
-      fn zero() -> Self {
-        $name::Point::identity()
-      }
-
-      fn get_generator() -> Self {
-        $name::Point::generator()
       }
     }
 

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -6,7 +6,7 @@ use crate::{
     pedersen::CommitmentEngine,
     poseidon::{PoseidonRO, PoseidonROCircuit},
   },
-  traits::{CompressedGroup, Group, PrimeFieldExt, TranscriptReprTrait},
+  traits::{CompressedGroup, GroupExt, PrimeFieldExt, TranscriptReprTrait},
 };
 use digest::{ExtendableOutput, Update};
 use ff::{FromUniformBytes, PrimeField};
@@ -57,7 +57,7 @@ macro_rules! impl_traits {
     $name_curve_affine:ident,
     $order_str:literal
   ) => {
-    impl Group for $name::Point {
+    impl GroupExt for $name::Point {
       type Base = $name::Base;
       type Scalar = $name::Scalar;
       type CompressedGroupElement = $name_compressed;
@@ -174,7 +174,7 @@ macro_rules! impl_traits {
       }
     }
 
-    impl<G: Group> TranscriptReprTrait<G> for $name_compressed {
+    impl<G: GroupExt> TranscriptReprTrait<G> for $name_compressed {
       fn to_transcript_bytes(&self) -> Vec<u8> {
         self.repr.to_vec()
       }
@@ -190,13 +190,13 @@ macro_rules! impl_traits {
   };
 }
 
-impl<G: Group> TranscriptReprTrait<G> for pallas::Base {
+impl<G: GroupExt> TranscriptReprTrait<G> for pallas::Base {
   fn to_transcript_bytes(&self) -> Vec<u8> {
     self.to_repr().to_vec()
   }
 }
 
-impl<G: Group> TranscriptReprTrait<G> for pallas::Scalar {
+impl<G: GroupExt> TranscriptReprTrait<G> for pallas::Scalar {
   fn to_transcript_bytes(&self) -> Vec<u8> {
     self.to_repr().to_vec()
   }
@@ -243,7 +243,7 @@ mod tests {
     for n in [
       1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 1021,
     ] {
-      let ck_par = <G as Group>::from_label(label, n);
+      let ck_par = <G as GroupExt>::from_label(label, n);
       let ck_ser = from_label_serial(label, n);
       assert_eq!(ck_par.len(), n);
       assert_eq!(ck_ser.len(), n);

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -15,7 +15,7 @@ use num_traits::Num;
 use pasta_curves::{
   self,
   arithmetic::{CurveAffine, CurveExt},
-  group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup, GroupEncoding},
+  group::{cofactor::CofactorCurveAffine, Curve, Group, GroupEncoding},
   pallas, vesta, Ep, EpAffine, Eq, EqAffine,
 };
 use rayon::prelude::*;

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -61,7 +61,9 @@ impl<G: GroupExt> CommitmentTrait<G> for Commitment<G> {
 
 impl<G: GroupExt> Default for Commitment<G> {
   fn default() -> Self {
-    Commitment { comm: G::zero() }
+    Commitment {
+      comm: G::identity(),
+    }
   }
 }
 

--- a/src/provider/poseidon.rs
+++ b/src/provider/poseidon.rs
@@ -200,18 +200,18 @@ mod tests {
   use crate::provider::{bn256_grumpkin::bn256, secp_secq};
   use crate::{
     bellpepper::solver::SatisfyingAssignment, constants::NUM_CHALLENGE_BITS,
-    gadgets::utils::le_bits_to_num, traits::Group,
+    gadgets::utils::le_bits_to_num, traits::GroupExt,
   };
   use ff::Field;
   use rand::rngs::OsRng;
 
-  fn test_poseidon_ro_with<G: Group>()
+  fn test_poseidon_ro_with<G: GroupExt>()
   where
     // we can print the field elements we get from G's Base & Scalar fields,
     // and compare their byte representations
-    <<G as Group>::Base as PrimeField>::Repr: std::fmt::Debug,
-    <<G as Group>::Scalar as PrimeField>::Repr: std::fmt::Debug,
-    <<G as Group>::Base as PrimeField>::Repr: PartialEq<<<G as Group>::Scalar as PrimeField>::Repr>,
+    <G::Base as PrimeField>::Repr: std::fmt::Debug,
+    <G::Scalar as PrimeField>::Repr: std::fmt::Debug,
+    <G::Base as PrimeField>::Repr: PartialEq<<G::Scalar as PrimeField>::Repr>,
   {
     // Check that the number computed inside the circuit is equal to the number computed outside the circuit
     let mut csprng: OsRng = OsRng;

--- a/src/provider/secp_secq.rs
+++ b/src/provider/secp_secq.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use digest::{ExtendableOutput, Update};
 use ff::{FromUniformBytes, PrimeField};
-use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup, GroupEncoding};
+use group::{cofactor::CofactorCurveAffine, Curve, Group, GroupEncoding};
 use num_bigint::BigInt;
 use num_traits::Num;
 use pasta_curves::arithmetic::{CurveAffine, CurveExt};

--- a/src/provider/secp_secq.rs
+++ b/src/provider/secp_secq.rs
@@ -7,7 +7,7 @@ use crate::{
     pedersen::CommitmentEngine,
     poseidon::{PoseidonRO, PoseidonROCircuit},
   },
-  traits::{CompressedGroup, Group, PrimeFieldExt, TranscriptReprTrait},
+  traits::{CompressedGroup, GroupExt, PrimeFieldExt, TranscriptReprTrait},
 };
 use digest::{ExtendableOutput, Update};
 use ff::{FromUniformBytes, PrimeField};
@@ -38,13 +38,13 @@ pub mod secq256k1 {
   };
 }
 
-impl<G: Group> TranscriptReprTrait<G> for secp256k1::Base {
+impl<G: GroupExt> TranscriptReprTrait<G> for secp256k1::Base {
   fn to_transcript_bytes(&self) -> Vec<u8> {
     self.to_repr().to_vec()
   }
 }
 
-impl<G: Group> TranscriptReprTrait<G> for secp256k1::Scalar {
+impl<G: GroupExt> TranscriptReprTrait<G> for secp256k1::Scalar {
   fn to_transcript_bytes(&self) -> Vec<u8> {
     self.to_repr().to_vec()
   }
@@ -91,7 +91,7 @@ mod tests {
     for n in [
       1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 1021,
     ] {
-      let ck_par = <G as Group>::from_label(label, n);
+      let ck_par = <G as GroupExt>::from_label(label, n);
       let ck_ser = from_label_serial(label, n);
       assert_eq!(ck_par.len(), n);
       assert_eq!(ck_ser.len(), n);

--- a/src/provider/secp_secq.rs
+++ b/src/provider/secp_secq.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use digest::{ExtendableOutput, Update};
 use ff::{FromUniformBytes, PrimeField};
-use group::{cofactor::CofactorCurveAffine, Curve, Group, GroupEncoding};
+use group::{cofactor::CofactorCurveAffine, Curve, GroupEncoding};
 use num_bigint::BigInt;
 use num_traits::Num;
 use pasta_curves::arithmetic::{CurveAffine, CurveExt};

--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -162,16 +162,17 @@ impl<'a, F: PrimeField> Iterator for Iter<'a, F> {
 
 #[cfg(test)]
 mod tests {
-  use crate::{r1cs::util::FWrap, traits::GroupExt};
+  use crate::r1cs::util::FWrap;
 
   use super::SparseMatrix;
+  use group::Group;
   use pasta_curves::pallas::Point as G;
   use proptest::{
     prelude::*,
     strategy::{BoxedStrategy, Just, Strategy},
   };
 
-  type Fr = <G as GroupExt>::Scalar;
+  type Fr = <G as Group>::Scalar;
 
   #[test]
   fn test_matrix_creation() {

--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -162,7 +162,7 @@ impl<'a, F: PrimeField> Iterator for Iter<'a, F> {
 
 #[cfg(test)]
 mod tests {
-  use crate::{r1cs::util::FWrap, traits::Group};
+  use crate::{r1cs::util::FWrap, traits::GroupExt};
 
   use super::SparseMatrix;
   use pasta_curves::pallas::Point as G;
@@ -171,7 +171,7 @@ mod tests {
     strategy::{BoxedStrategy, Just, Strategy},
   };
 
-  type Fr = <G as Group>::Scalar;
+  type Fr = <G as GroupExt>::Scalar;
 
   #[test]
   fn test_matrix_creation() {

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -12,11 +12,11 @@ pub mod ppsnark;
 pub mod snark;
 mod sumcheck;
 
-use crate::{traits::Group, Commitment};
+use crate::{traits::GroupExt, Commitment};
 use ff::Field;
 use polys::multilinear::SparsePolynomial;
 
-fn powers<G: Group>(s: &G::Scalar, n: usize) -> Vec<G::Scalar> {
+fn powers<G: GroupExt>(s: &G::Scalar, n: usize) -> Vec<G::Scalar> {
   assert!(n >= 1);
   let mut powers = Vec::new();
   powers.push(G::Scalar::ONE);
@@ -27,11 +27,11 @@ fn powers<G: Group>(s: &G::Scalar, n: usize) -> Vec<G::Scalar> {
 }
 
 /// A type that holds a witness to a polynomial evaluation instance
-pub struct PolyEvalWitness<G: Group> {
+pub struct PolyEvalWitness<G: GroupExt> {
   p: Vec<G::Scalar>, // polynomial
 }
 
-impl<G: Group> PolyEvalWitness<G> {
+impl<G: GroupExt> PolyEvalWitness<G> {
   fn pad(W: &[PolyEvalWitness<G>]) -> Vec<PolyEvalWitness<G>> {
     // determine the maximum size
     if let Some(n) = W.iter().map(|w| w.p.len()).max() {
@@ -71,13 +71,13 @@ impl<G: Group> PolyEvalWitness<G> {
 }
 
 /// A type that holds a polynomial evaluation instance
-pub struct PolyEvalInstance<G: Group> {
+pub struct PolyEvalInstance<G: GroupExt> {
   c: Commitment<G>,  // commitment to the polynomial
   x: Vec<G::Scalar>, // evaluation point
   e: G::Scalar,      // claimed evaluation
 }
 
-impl<G: Group> PolyEvalInstance<G> {
+impl<G: GroupExt> PolyEvalInstance<G> {
   fn pad(U: &[PolyEvalInstance<G>]) -> Vec<PolyEvalInstance<G>> {
     // determine the maximum size
     if let Some(ell) = U.iter().map(|u| u.x.len()).max() {

--- a/src/spartan/polys/univariate.rs
+++ b/src/spartan/polys/univariate.rs
@@ -5,7 +5,7 @@ use ff::PrimeField;
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 
-use crate::traits::{Group, TranscriptReprTrait};
+use crate::traits::{GroupExt, TranscriptReprTrait};
 
 // ax^2 + bx + c stored as vec![c, b, a]
 // ax^3 + bx^2 + cx + d stored as vec![d, c, b, a]
@@ -106,7 +106,7 @@ impl<Scalar: PrimeField> CompressedUniPoly<Scalar> {
   }
 }
 
-impl<G: Group> TranscriptReprTrait<G> for UniPoly<G::Scalar> {
+impl<G: GroupExt> TranscriptReprTrait<G> for UniPoly<G::Scalar> {
   fn to_transcript_bytes(&self) -> Vec<u8> {
     let coeffs = self.compress().coeffs_except_linear_term;
     coeffs.as_slice().to_transcript_bytes()

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -17,7 +17,7 @@ use crate::{
   traits::{
     evaluation::EvaluationEngineTrait,
     snark::{DigestHelperTrait, RelaxedR1CSSNARKTrait},
-    Group, TranscriptEngineTrait,
+    GroupExt, TranscriptEngineTrait,
   },
   Commitment, CommitmentKey,
 };
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 /// A type that represents the prover's key
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G>> {
+pub struct ProverKey<G: GroupExt, EE: EvaluationEngineTrait<G>> {
   pk_ee: EE::ProverKey,
   vk_digest: G::Scalar, // digest of the verifier's key
 }
@@ -38,16 +38,16 @@ pub struct ProverKey<G: Group, EE: EvaluationEngineTrait<G>> {
 /// A type that represents the verifier's key
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct VerifierKey<G: Group, EE: EvaluationEngineTrait<G>> {
+pub struct VerifierKey<G: GroupExt, EE: EvaluationEngineTrait<G>> {
   vk_ee: EE::VerifierKey,
   S: R1CSShape<G>,
   #[serde(skip, default = "OnceCell::new")]
   digest: OnceCell<G::Scalar>,
 }
 
-impl<G: Group, EE: EvaluationEngineTrait<G>> SimpleDigestible for VerifierKey<G, EE> {}
+impl<G: GroupExt, EE: EvaluationEngineTrait<G>> SimpleDigestible for VerifierKey<G, EE> {}
 
-impl<G: Group, EE: EvaluationEngineTrait<G>> VerifierKey<G, EE> {
+impl<G: GroupExt, EE: EvaluationEngineTrait<G>> VerifierKey<G, EE> {
   fn new(shape: R1CSShape<G>, vk_ee: EE::VerifierKey) -> Self {
     VerifierKey {
       vk_ee,
@@ -57,7 +57,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> VerifierKey<G, EE> {
   }
 }
 
-impl<G: Group, EE: EvaluationEngineTrait<G>> DigestHelperTrait<G> for VerifierKey<G, EE> {
+impl<G: GroupExt, EE: EvaluationEngineTrait<G>> DigestHelperTrait<G> for VerifierKey<G, EE> {
   /// Returns the digest of the verifier's key.
   fn digest(&self) -> G::Scalar {
     self
@@ -76,7 +76,7 @@ impl<G: Group, EE: EvaluationEngineTrait<G>> DigestHelperTrait<G> for VerifierKe
 /// the commitment to a vector viewed as a polynomial commitment
 #[derive(Serialize, Deserialize)]
 #[serde(bound = "")]
-pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G>> {
+pub struct RelaxedR1CSSNARK<G: GroupExt, EE: EvaluationEngineTrait<G>> {
   sc_proof_outer: SumcheckProof<G>,
   claims_outer: (G::Scalar, G::Scalar, G::Scalar),
   eval_E: G::Scalar,
@@ -87,7 +87,9 @@ pub struct RelaxedR1CSSNARK<G: Group, EE: EvaluationEngineTrait<G>> {
   eval_arg: EE::EvaluationArgument,
 }
 
-impl<G: Group, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G> for RelaxedR1CSSNARK<G, EE> {
+impl<G: GroupExt, EE: EvaluationEngineTrait<G>> RelaxedR1CSSNARKTrait<G>
+  for RelaxedR1CSSNARK<G, EE>
+{
   type ProverKey = ProverKey<G, EE>;
   type VerifierKey = VerifierKey<G, EE>;
 

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -3,18 +3,18 @@ use crate::spartan::polys::{
   multilinear::MultilinearPolynomial,
   univariate::{CompressedUniPoly, UniPoly},
 };
-use crate::traits::{Group, TranscriptEngineTrait};
+use crate::traits::{GroupExt, TranscriptEngineTrait};
 use ff::Field;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
-pub(crate) struct SumcheckProof<G: Group> {
+pub(crate) struct SumcheckProof<G: GroupExt> {
   compressed_polys: Vec<CompressedUniPoly<G::Scalar>>,
 }
 
-impl<G: Group> SumcheckProof<G> {
+impl<G: GroupExt> SumcheckProof<G> {
   pub fn new(compressed_polys: Vec<CompressedUniPoly<G::Scalar>>) -> Self {
     Self { compressed_polys }
   }

--- a/src/traits/commitment.rs
+++ b/src/traits/commitment.rs
@@ -2,7 +2,7 @@
 //! We require the commitment engine to provide a commitment to vectors with a single group element
 use crate::{
   errors::NovaError,
-  traits::{AbsorbInROTrait, Group, TranscriptReprTrait},
+  traits::{AbsorbInROTrait, GroupExt, TranscriptReprTrait},
 };
 use core::{
   fmt::Debug,
@@ -34,7 +34,7 @@ impl<T, Rhs, Output> CommitmentOpsOwned<Rhs, Output> for T where
 }
 
 /// This trait defines the behavior of the commitment
-pub trait CommitmentTrait<G: Group>:
+pub trait CommitmentTrait<G: GroupExt>:
   Clone
   + Copy
   + Debug
@@ -73,7 +73,7 @@ pub trait CommitmentTrait<G: Group>:
 }
 
 /// A trait that ties different pieces of the commitment generation together
-pub trait CommitmentEngineTrait<G: Group>: Clone + Send + Sync {
+pub trait CommitmentEngineTrait<G: GroupExt>: Clone + Send + Sync {
   /// Holds the type of the commitment key
   type CommitmentKey: Clone + Debug + Send + Sync + Serialize + for<'de> Deserialize<'de>;
 

--- a/src/traits/commitment.rs
+++ b/src/traits/commitment.rs
@@ -8,9 +8,8 @@ use core::{
   fmt::Debug,
   ops::{Add, AddAssign},
 };
+use group::ScalarMul;
 use serde::{Deserialize, Serialize};
-
-use super::ScalarMul;
 
 /// Defines basic operations on commitments
 pub trait CommitmentOps<Rhs = Self, Output = Self>:

--- a/src/traits/evaluation.rs
+++ b/src/traits/evaluation.rs
@@ -3,12 +3,12 @@
 //! and a commitment provided by the commitment engine is treated as a multilinear polynomial commitment
 use crate::{
   errors::NovaError,
-  traits::{commitment::CommitmentEngineTrait, Group},
+  traits::{commitment::CommitmentEngineTrait, GroupExt},
 };
 use serde::{Deserialize, Serialize};
 
 /// A trait that ties different pieces of the commitment evaluation together
-pub trait EvaluationEngineTrait<G: Group>: Clone + Send + Sync {
+pub trait EvaluationEngineTrait<G: GroupExt>: Clone + Send + Sync {
   /// A type that holds the prover key
   type ProverKey: Clone + Send + Sync + Serialize + for<'de> Deserialize<'de>;
 
@@ -20,15 +20,15 @@ pub trait EvaluationEngineTrait<G: Group>: Clone + Send + Sync {
 
   /// A method to perform any additional setup needed to produce proofs of evaluations
   fn setup(
-    ck: &<<G as Group>::CE as CommitmentEngineTrait<G>>::CommitmentKey,
+    ck: &<<G as GroupExt>::CE as CommitmentEngineTrait<G>>::CommitmentKey,
   ) -> (Self::ProverKey, Self::VerifierKey);
 
   /// A method to prove the evaluation of a multilinear polynomial
   fn prove(
-    ck: &<<G as Group>::CE as CommitmentEngineTrait<G>>::CommitmentKey,
+    ck: &<<G as GroupExt>::CE as CommitmentEngineTrait<G>>::CommitmentKey,
     pk: &Self::ProverKey,
     transcript: &mut G::TE,
-    comm: &<<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment,
+    comm: &<<G as GroupExt>::CE as CommitmentEngineTrait<G>>::Commitment,
     poly: &[G::Scalar],
     point: &[G::Scalar],
     eval: &G::Scalar,
@@ -38,7 +38,7 @@ pub trait EvaluationEngineTrait<G: Group>: Clone + Send + Sync {
   fn verify(
     vk: &Self::VerifierKey,
     transcript: &mut G::TE,
-    comm: &<<G as Group>::CE as CommitmentEngineTrait<G>>::Commitment,
+    comm: &<<G as GroupExt>::CE as CommitmentEngineTrait<G>>::Commitment,
     point: &[G::Scalar],
     eval: &G::Scalar,
     arg: &Self::EvaluationArgument,

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -7,7 +7,10 @@ use group::Group;
 use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
 
+pub mod circuit;
 pub mod commitment;
+pub mod evaluation;
+pub mod snark;
 
 use commitment::CommitmentEngineTrait;
 
@@ -62,12 +65,6 @@ pub trait GroupExt:
 
   /// Returns the affine coordinates (x, y, infinty) for the point
   fn to_coordinates(&self) -> (Self::Base, Self::Base, bool);
-
-  /// Returns an element that is the additive identity of the group
-  fn zero() -> Self;
-
-  /// Returns the generator of the group
-  fn get_generator() -> Self;
 
   /// Returns A, B, and the order of the group as a big integer
   fn get_curve_params() -> (Self::Base, Self::Base, BigInt);
@@ -180,7 +177,3 @@ impl<G: GroupExt, T: TranscriptReprTrait<G>> TranscriptReprTrait<G> for &[T] {
       .collect::<Vec<u8>>()
   }
 }
-
-pub mod circuit;
-pub mod evaluation;
-pub mod snark;

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,11 +1,9 @@
 //! This module defines various traits required by the users of the library to implement.
 use crate::errors::NovaError;
 use bellpepper_core::{boolean::AllocatedBit, num::AllocatedNum, ConstraintSystem, SynthesisError};
-use core::{
-  fmt::Debug,
-  ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign},
-};
+use core::fmt::Debug;
 use ff::{PrimeField, PrimeFieldBits};
+use group::Group;
 use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
 
@@ -16,27 +14,14 @@ use commitment::CommitmentEngineTrait;
 /// Represents an element of a group
 /// This is currently tailored for an elliptic curve group
 pub trait GroupExt:
-  Clone
-  + Copy
-  + Debug
-  + Eq
-  + GroupOps
-  + GroupOpsOwned
-  + ScalarMul<Self::Scalar>
-  + ScalarMulOwned<Self::Scalar>
-  + Send
-  + Sync
-  + Serialize
-  + for<'de> Deserialize<'de>
+  Group<Scalar = Self::ScalarExt> + Serialize + for<'de> Deserialize<'de>
 {
   /// A type representing an element of the base field of the group
   type Base: PrimeFieldBits + TranscriptReprTrait<Self> + Serialize + for<'de> Deserialize<'de>;
 
   /// A type representing an element of the scalar field of the group
-  type Scalar: PrimeFieldBits
+  type ScalarExt: PrimeFieldBits
     + PrimeFieldExt
-    + Send
-    + Sync
     + TranscriptReprTrait<Self>
     + Serialize
     + for<'de> Deserialize<'de>;
@@ -154,36 +139,11 @@ pub trait ROCircuitTrait<Base: PrimeField> {
 
 /// An alias for constants associated with G::RO
 pub type ROConstants<G> =
-  <<G as GroupExt>::RO as ROTrait<<G as GroupExt>::Base, <G as GroupExt>::Scalar>>::Constants;
+  <<G as GroupExt>::RO as ROTrait<<G as GroupExt>::Base, <G as Group>::Scalar>>::Constants;
 
 /// An alias for constants associated with `G::ROCircuit`
 pub type ROConstantsCircuit<G> =
   <<G as GroupExt>::ROCircuit as ROCircuitTrait<<G as GroupExt>::Base>>::Constants;
-
-/// A helper trait for types with a group operation.
-pub trait GroupOps<Rhs = Self, Output = Self>:
-  Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + AddAssign<Rhs> + SubAssign<Rhs>
-{
-}
-
-impl<T, Rhs, Output> GroupOps<Rhs, Output> for T where
-  T: Add<Rhs, Output = Output> + Sub<Rhs, Output = Output> + AddAssign<Rhs> + SubAssign<Rhs>
-{
-}
-
-/// A helper trait for references with a group operation.
-pub trait GroupOpsOwned<Rhs = Self, Output = Self>: for<'r> GroupOps<&'r Rhs, Output> {}
-impl<T, Rhs, Output> GroupOpsOwned<Rhs, Output> for T where T: for<'r> GroupOps<&'r Rhs, Output> {}
-
-/// A helper trait for types implementing group scalar multiplication.
-pub trait ScalarMul<Rhs, Output = Self>: Mul<Rhs, Output = Output> + MulAssign<Rhs> {}
-
-impl<T, Rhs, Output> ScalarMul<Rhs, Output> for T where T: Mul<Rhs, Output = Output> + MulAssign<Rhs>
-{}
-
-/// A helper trait for references implementing group scalar multiplication.
-pub trait ScalarMulOwned<Rhs, Output = Self>: for<'r> ScalarMul<&'r Rhs, Output> {}
-impl<T, Rhs, Output> ScalarMulOwned<Rhs, Output> for T where T: for<'r> ScalarMul<&'r Rhs, Output> {}
 
 /// This trait allows types to implement how they want to be added to `TranscriptEngine`
 pub trait TranscriptReprTrait<G: GroupExt>: Send + Sync {

--- a/src/traits/snark.rs
+++ b/src/traits/snark.rs
@@ -2,14 +2,14 @@
 use crate::{
   errors::NovaError,
   r1cs::{R1CSShape, RelaxedR1CSInstance, RelaxedR1CSWitness},
-  traits::Group,
+  traits::GroupExt,
   CommitmentKey,
 };
 
 use serde::{Deserialize, Serialize};
 
 /// A trait that defines the behavior of a `zkSNARK`
-pub trait RelaxedR1CSSNARKTrait<G: Group>:
+pub trait RelaxedR1CSSNARKTrait<G: GroupExt>:
   Send + Sync + Serialize + for<'de> Deserialize<'de>
 {
   /// A type that represents the prover's key
@@ -38,7 +38,7 @@ pub trait RelaxedR1CSSNARKTrait<G: Group>:
 }
 
 /// A helper trait that defines the behavior of a verifier key of `zkSNARK`
-pub trait DigestHelperTrait<G: Group> {
+pub trait DigestHelperTrait<G: GroupExt> {
   /// Returns the digest of the verifier's key
   fn digest(&self) -> G::Scalar;
 }


### PR DESCRIPTION
close https://github.com/microsoft/Nova/issues/198

I moved to Zcash `Group` to reduce duplication of code and reduce the complexity of the lib.

1st: Rename Group -> GroupExt
2nd: Rename AnotherGroup -> Group
3rd: Move to Group trait
4th: Apply changes to benches and examples
5th: Remove GroupExt code duplication

I would appreciate it if you could confirm.
Thank you.