### PR TITLE
Reduce duplicate code across different curve cycle providers

### DIFF
--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -69,37 +69,3 @@ impl_traits!(
   "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",
   "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001"
 );
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-  type G = bn256::Point;
-
-  fn from_label_serial(label: &'static [u8], n: usize) -> Vec<Bn256Affine> {
-    let mut shake = Shake256::default();
-    shake.update(label);
-    let mut reader = shake.finalize_xof();
-    let mut ck = Vec::new();
-    for _ in 0..n {
-      let mut uniform_bytes = [0u8; 32];
-      reader.read_exact(&mut uniform_bytes).unwrap();
-      let hash = bn256::Point::hash_to_curve("from_uniform_bytes");
-      ck.push(hash(&uniform_bytes).to_affine());
-    }
-    ck
-  }
-
-  #[test]
-  fn test_from_label() {
-    let label = b"test_from_label";
-    for n in [
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 1021,
-    ] {
-      let ck_par = <G as DlogGroup>::from_label(label, n);
-      let ck_ser = from_label_serial(label, n);
-      assert_eq!(ck_par.len(), n);
-      assert_eq!(ck_ser.len(), n);
-      assert_eq!(ck_par, ck_ser);
-    }
-  }
-}

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -1,6 +1,6 @@
 //! This module implements the Nova traits for `bn256::Point`, `bn256::Scalar`, `grumpkin::Point`, `grumpkin::Scalar`.
 use crate::{
-  impl_folding, impl_traits,
+  impl_engine, impl_traits,
   provider::{
     cpu_best_multiexp,
     keccak::Keccak256Transcript,

--- a/src/provider/bn256_grumpkin.rs
+++ b/src/provider/bn256_grumpkin.rs
@@ -1,6 +1,6 @@
 //! This module implements the Nova traits for `bn256::Point`, `bn256::Scalar`, `grumpkin::Point`, `grumpkin::Scalar`.
 use crate::{
-  impl_traits,
+  impl_folding, impl_traits,
   provider::{
     cpu_best_multiexp,
     keccak::Keccak256Transcript,

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -393,11 +393,44 @@ mod tests {
   use crate::provider::{
     bn256_grumpkin::{bn256, grumpkin},
     secp_secq::{secp256k1, secq256k1},
+    DlogGroup,
   };
-  use group::{ff::Field, Group};
-  use halo2curves::CurveAffine;
+  use digest::{ExtendableOutput, Update};
+  use group::{ff::Field, Curve, Group};
+  use halo2curves::{CurveAffine, CurveExt};
   use pasta_curves::{pallas, vesta};
   use rand_core::OsRng;
+  use sha3::Shake256;
+  use std::io::Read;
+
+  macro_rules! impl_cycle_pair_test {
+    ($curve:ident) => {
+      fn from_label_serial(label: &'static [u8], n: usize) -> Vec<$curve::Affine> {
+        let mut shake = Shake256::default();
+        shake.update(label);
+        let mut reader = shake.finalize_xof();
+        (0..n)
+          .map(|_| {
+            let mut uniform_bytes = [0u8; 32];
+            reader.read_exact(&mut uniform_bytes).unwrap();
+            let hash = $curve::Point::hash_to_curve("from_uniform_bytes");
+            hash(&uniform_bytes).to_affine()
+          })
+          .collect()
+      }
+
+      let label = b"test_from_label";
+      for n in [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 1021,
+      ] {
+        let ck_par = <$curve::Point as DlogGroup>::from_label(label, n);
+        let ck_ser = from_label_serial(label, n);
+        assert_eq!(ck_par.len(), n);
+        assert_eq!(ck_ser.len(), n);
+        assert_eq!(ck_par, ck_ser);
+      }
+    };
+  }
 
   fn test_msm_with<F: Field, A: CurveAffine<ScalarExt = F>>() {
     let n = 8;
@@ -424,5 +457,20 @@ mod tests {
     test_msm_with::<grumpkin::Scalar, grumpkin::Affine>();
     test_msm_with::<secp256k1::Scalar, secp256k1::Affine>();
     test_msm_with::<secq256k1::Scalar, secq256k1::Affine>();
+  }
+
+  #[test]
+  fn test_bn256_from_label() {
+    impl_cycle_pair_test!(bn256);
+  }
+
+  #[test]
+  fn test_pallas_from_label() {
+    impl_cycle_pair_test!(pallas);
+  }
+
+  #[test]
+  fn test_secp256k1_from_label() {
+    impl_cycle_pair_test!(secp256k1);
   }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -229,7 +229,7 @@ macro_rules! impl_traits {
     $order_str:literal,
     $base_str:literal
   ) => {
-    impl_folding!(
+    impl_engine!(
       $engine,
       $name,
       $name_compressed,
@@ -338,7 +338,7 @@ macro_rules! impl_traits {
 
 /// Nova folding circuit engine and curve group ops
 #[macro_export]
-macro_rules! impl_folding {
+macro_rules! impl_engine {
   (
     $engine:ident,
     $name:ident,

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -199,37 +199,3 @@ impl_traits!(
   "40000000000000000000000000000000224698fc094cf91b992d30ed00000001",
   "40000000000000000000000000000000224698fc0994a8dd8c46eb2100000001"
 );
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-  type G = <PallasEngine as Engine>::GE;
-
-  fn from_label_serial(label: &'static [u8], n: usize) -> Vec<EpAffine> {
-    let mut shake = Shake256::default();
-    shake.update(label);
-    let mut reader = shake.finalize_xof();
-    let mut ck = Vec::new();
-    for _ in 0..n {
-      let mut uniform_bytes = [0u8; 32];
-      reader.read_exact(&mut uniform_bytes).unwrap();
-      let hash = Ep::hash_to_curve("from_uniform_bytes");
-      ck.push(hash(&uniform_bytes).to_affine());
-    }
-    ck
-  }
-
-  #[test]
-  fn test_from_label() {
-    let label = b"test_from_label";
-    for n in [
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 1021,
-    ] {
-      let ck_par = <G as DlogGroup>::from_label(label, n);
-      let ck_ser = from_label_serial(label, n);
-      assert_eq!(ck_par.len(), n);
-      assert_eq!(ck_ser.len(), n);
-      assert_eq!(ck_par, ck_ser);
-    }
-  }
-}

--- a/src/provider/pasta.rs
+++ b/src/provider/pasta.rs
@@ -1,6 +1,6 @@
 //! This module implements the Nova traits for `pallas::Point`, `pallas::Scalar`, `vesta::Point`, `vesta::Scalar`.
 use crate::{
-  impl_folding,
+  impl_engine,
   provider::{
     cpu_best_multiexp,
     keccak::Keccak256Transcript,
@@ -69,7 +69,7 @@ macro_rules! impl_traits {
     $order_str:literal,
     $base_str:literal
   ) => {
-    impl_folding!(
+    impl_engine!(
       $engine,
       $name,
       $name_compressed,

--- a/src/provider/secp_secq.rs
+++ b/src/provider/secp_secq.rs
@@ -66,37 +66,3 @@ impl_traits!(
   "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
   "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141"
 );
-
-#[cfg(test)]
-mod tests {
-  use super::*;
-  type G = secp256k1::Point;
-
-  fn from_label_serial(label: &'static [u8], n: usize) -> Vec<Secp256k1Affine> {
-    let mut shake = Shake256::default();
-    shake.update(label);
-    let mut reader = shake.finalize_xof();
-    let mut ck = Vec::new();
-    for _ in 0..n {
-      let mut uniform_bytes = [0u8; 32];
-      reader.read_exact(&mut uniform_bytes).unwrap();
-      let hash = secp256k1::Point::hash_to_curve("from_uniform_bytes");
-      ck.push(hash(&uniform_bytes).to_affine());
-    }
-    ck
-  }
-
-  #[test]
-  fn test_from_label() {
-    let label = b"test_from_label";
-    for n in [
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 1021,
-    ] {
-      let ck_par = <G as DlogGroup>::from_label(label, n);
-      let ck_ser = from_label_serial(label, n);
-      assert_eq!(ck_par.len(), n);
-      assert_eq!(ck_ser.len(), n);
-      assert_eq!(ck_par, ck_ser);
-    }
-  }
-}

--- a/src/provider/secp_secq.rs
+++ b/src/provider/secp_secq.rs
@@ -1,6 +1,6 @@
 //! This module implements the Nova traits for `secp::Point`, `secp::Scalar`, `secq::Point`, `secq::Scalar`.
 use crate::{
-  impl_traits,
+  impl_folding, impl_traits,
   provider::{
     cpu_best_multiexp,
     keccak::Keccak256Transcript,

--- a/src/provider/secp_secq.rs
+++ b/src/provider/secp_secq.rs
@@ -1,6 +1,6 @@
 //! This module implements the Nova traits for `secp::Point`, `secp::Scalar`, `secq::Point`, `secq::Scalar`.
 use crate::{
-  impl_folding, impl_traits,
+  impl_engine, impl_traits,
   provider::{
     cpu_best_multiexp,
     keccak::Keccak256Transcript,


### PR DESCRIPTION
I reduced test and transcript trait code across curve cycle by macros.

**improvement**
curve cycle group methods difference is only vartime_multiscalar_mul.
https://github.com/microsoft/Nova/blob/main/src/provider/mod.rs#L159
If we call msm method through such that `Self::msm()`, we can use same trait between pasta and other cycle pair.

**question**
Is there any reason not to use complete addition for `ecc` gadget?
https://github.com/microsoft/Nova/blob/main/src/gadgets/ecc.rs#L135
We can skip condition branch constraint.

**typo**
`the` duplication
![the](https://github.com/microsoft/Nova/assets/39494661/149d02b1-e466-47f6-9bc3-89ff68bb9f12)
https://eprint.iacr.org/2023/1192.pdf#page=4&zoom=100,100,250

I would appreciate it if you could confirm.
Thank you.