### PR TITLE
refactor: define auxiliary functions for the batching of sumcheck claims (Arecibo backport)

### DIFF
--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -33,16 +33,13 @@ pub struct PolyEvalWitness<E: Engine> {
 }
 
 impl<E: Engine> PolyEvalWitness<E> {
-  fn pad(W: &[PolyEvalWitness<E>]) -> Vec<PolyEvalWitness<E>> {
+  fn pad(mut W: Vec<PolyEvalWitness<E>>) -> Vec<PolyEvalWitness<E>> {
     // determine the maximum size
     if let Some(n) = W.iter().map(|w| w.p.len()).max() {
-      W.iter()
-        .map(|w| {
-          let mut p = vec![E::Scalar::ZERO; n];
-          p[..w.p.len()].copy_from_slice(&w.p);
-          PolyEvalWitness { p }
-        })
-        .collect()
+      W.iter_mut().for_each(|w| {
+        w.p.resize(n, E::Scalar::ZERO);
+      });
+      W
     } else {
       Vec::new()
     }
@@ -94,14 +91,14 @@ pub struct PolyEvalInstance<E: Engine> {
 }
 
 impl<E: Engine> PolyEvalInstance<E> {
-  fn pad(U: &[PolyEvalInstance<E>]) -> Vec<PolyEvalInstance<E>> {
+  fn pad(U: Vec<PolyEvalInstance<E>>) -> Vec<PolyEvalInstance<E>> {
     // determine the maximum size
     if let Some(ell) = U.iter().map(|u| u.x.len()).max() {
-      U.iter()
-        .map(|u| {
+      U.into_iter()
+        .map(|mut u| {
           let mut x = vec![E::Scalar::ZERO; ell - u.x.len()];
-          x.extend(u.x.clone());
-          PolyEvalInstance { c: u.c, x, e: u.e }
+          x.append(&mut u.x);
+          PolyEvalInstance { x, ..u }
         })
         .collect()
     } else {

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -281,11 +281,11 @@ impl<E: Engine> MemorySumcheckInstance<E> {
   pub fn new(
     ck: &CommitmentKey<E>,
     r: &E::Scalar,
-    T_row: Vec<E::Scalar>,
-    W_row: Vec<E::Scalar>,
+    T_row: &[E::Scalar],
+    W_row: &[E::Scalar],
     ts_row: Vec<E::Scalar>,
-    T_col: Vec<E::Scalar>,
-    W_col: Vec<E::Scalar>,
+    T_col: &[E::Scalar],
+    W_col: &[E::Scalar],
     ts_col: Vec<E::Scalar>,
     transcript: &mut E::TE,
   ) -> Result<(Self, [Commitment<E>; 4], [Vec<E::Scalar>; 4]), NovaError> {
@@ -362,8 +362,8 @@ impl<E: Engine> MemorySumcheckInstance<E> {
       ((t_plus_r_inv_row, w_plus_r_inv_row), (t_plus_r_row, w_plus_r_row)),
       ((t_plus_r_inv_col, w_plus_r_inv_col), (t_plus_r_col, w_plus_r_col)),
     ) = rayon::join(
-      || helper(&T_row, &W_row, &ts_row, r),
-      || helper(&T_col, &W_col, &ts_col, r),
+      || helper(T_row, W_row, &ts_row, r),
+      || helper(T_col, W_col, &ts_col, r),
     );
 
     let t_plus_r_inv_row = t_plus_r_inv_row?;
@@ -1139,11 +1139,11 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
         MemorySumcheckInstance::new(
           ck,
           &r,
-          T_row,
-          W_row,
+          &T_row,
+          &W_row,
           pk.S_repr.ts_row.clone(),
-          T_col,
-          W_col,
+          &T_col,
+          &W_col,
           pk.S_repr.ts_col.clone(),
           &mut transcript,
         )

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -1068,7 +1068,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
     let u: PolyEvalInstance<E> = PolyEvalInstance::batch(&comm_vec, &tau_coords, &eval_vec, &c);
 
     // we now need to prove three claims
-    // (1) 0 = \sum_x poly_tau(x) * (poly_Az(x) * poly_Bz(x) - poly_uCz_E(x)), and eval_Az_at_tau + r * eval_Az_at_tau + r^2 * eval_Cz_at_tau = (Az+r*Bz+r^2*Cz)(tau)
+    // (1) 0 = \sum_x poly_tau(x) * (poly_Az(x) * poly_Bz(x) - poly_uCz_E(x)), and eval_Az_at_tau + r * eval_Bz_at_tau + r^2 * eval_Cz_at_tau = (Az+r*Bz+r^2*Cz)(tau)
     // (2) eval_Az_at_tau + c * eval_Bz_at_tau + c^2 * eval_Cz_at_tau = \sum_y L_row(y) * (val_A(y) + c * val_B(y) + c^2 * val_C(y)) * L_col(y)
     // (3) L_row(i) = eq(tau, row(i)) and L_col(i) = z(col(i))
     let gamma = transcript.squeeze(b"g")?;

--- a/src/spartan/snark.rs
+++ b/src/spartan/snark.rs
@@ -471,8 +471,8 @@ fn batch_eval_prove<E: Engine>(
 > {
   assert_eq!(u_vec.len(), w_vec.len());
 
-  let w_vec_padded = PolyEvalWitness::pad(&w_vec); // pad the polynomials to be of the same size
-  let u_vec_padded = PolyEvalInstance::pad(&u_vec); // pad the evaluation points
+  let w_vec_padded = PolyEvalWitness::pad(w_vec); // pad the polynomials to be of the same size
+  let u_vec_padded = PolyEvalInstance::pad(u_vec); // pad the evaluation points
 
   // generate a challenge
   let rho = transcript.squeeze(b"r")?;
@@ -547,13 +547,13 @@ fn batch_eval_verify<E: Engine>(
 ) -> Result<PolyEvalInstance<E>, NovaError> {
   assert_eq!(evals_batch.len(), evals_batch.len());
 
-  let u_vec_padded = PolyEvalInstance::pad(&u_vec); // pad the evaluation points
+  let u_vec_padded = PolyEvalInstance::pad(u_vec); // pad the evaluation points
 
   // generate a challenge
   let rho = transcript.squeeze(b"r")?;
-  let num_claims = u_vec.len();
+  let num_claims: usize = u_vec_padded.len();
   let powers_of_rho = powers::<E>(&rho, num_claims);
-  let claim_batch_joint = u_vec
+  let claim_batch_joint = u_vec_padded
     .iter()
     .zip(powers_of_rho.iter())
     .map(|(u, p)| u.e * p)


### PR DESCRIPTION
This backports the following Arecibo PRs:
- https://github.com/lurk-lab/arecibo/pull/106
- https://github.com/lurk-lab/arecibo/pull/122

This factors out the single-point aggregation of Sumcheck instances implemented at the end of the (non-preprocessing) Spartan SNARk to a couple of auxiliary functions `batch_eval_prove`/`batch_eval_verify`. 
- They will be reused in our upcoming instance of Supernova, so we could include the change here or there, 
- but It's expected this simple change will also ease review and testing of that part of the protocol in the future.

This also performs minor changes the API of a few internal functions which took their argument by value without needing to (as indicated by [tooling](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_pass_by_value)).