### PR TITLE
Streamline Nova allocations (Arecibo backport)

### DIFF
--- a/src/bellpepper/r1cs.rs
+++ b/src/bellpepper/r1cs.rs
@@ -16,7 +16,7 @@ use ff::PrimeField;
 pub trait NovaWitness<E: Engine> {
   /// Return an instance and witness, given a shape and ck.
   fn r1cs_instance_and_witness(
-    &self,
+    self,
     shape: &R1CSShape<E>,
     ck: &CommitmentKey<E>,
   ) -> Result<(R1CSInstance<E>, R1CSWitness<E>), NovaError>;
@@ -32,16 +32,17 @@ pub trait NovaShape<E: Engine> {
 
 impl<E: Engine> NovaWitness<E> for SatisfyingAssignment<E> {
   fn r1cs_instance_and_witness(
-    &self,
+    self,
     shape: &R1CSShape<E>,
     ck: &CommitmentKey<E>,
   ) -> Result<(R1CSInstance<E>, R1CSWitness<E>), NovaError> {
-    let W = R1CSWitness::<E>::new(shape, self.aux_assignment())?;
-    let X = &self.input_assignment()[1..];
+    let (input_assignment, aux_assignment) = self.to_assignments();
+    let W = R1CSWitness::<E>::new(shape, aux_assignment)?;
+    let X = input_assignment[1..].to_owned();
 
     let comm_W = W.commit(ck);
 
-    let instance = R1CSInstance::<E>::new(shape, &comm_W, X)?;
+    let instance = R1CSInstance::<E>::new(shape, comm_W, X)?;
 
     Ok((instance, W))
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,9 +318,9 @@ where
     // IVC proof for the primary circuit
     let l_w_primary = w_primary;
     let l_u_primary = u_primary;
-    let r_W_primary = RelaxedR1CSWitness::from_r1cs_witness(&pp.r1cs_shape_primary, &l_w_primary);
+    let r_W_primary = RelaxedR1CSWitness::from_r1cs_witness(&pp.r1cs_shape_primary, l_w_primary);
     let r_U_primary =
-      RelaxedR1CSInstance::from_r1cs_instance(&pp.ck_primary, &pp.r1cs_shape_primary, &l_u_primary);
+      RelaxedR1CSInstance::from_r1cs_instance(&pp.ck_primary, &pp.r1cs_shape_primary, l_u_primary);
 
     // IVC proof for the secondary circuit
     let l_w_secondary = w_secondary;
@@ -386,7 +386,10 @@ where
       &self.l_w_secondary,
     )?;
 
-    let mut cs_primary = SatisfyingAssignment::<E1>::new();
+    let mut cs_primary = SatisfyingAssignment::<E1>::with_capacity(
+      pp.r1cs_shape_primary.num_io + 1,
+      pp.r1cs_shape_primary.num_vars,
+    );
     let inputs_primary: NovaAugmentedCircuitInputs<E2> = NovaAugmentedCircuitInputs::new(
       scalar_as_base::<E1>(pp.digest()),
       E1::Scalar::from(self.i as u64),
@@ -420,7 +423,10 @@ where
       &l_w_primary,
     )?;
 
-    let mut cs_secondary = SatisfyingAssignment::<E2>::new();
+    let mut cs_secondary = SatisfyingAssignment::<E2>::with_capacity(
+      pp.r1cs_shape_secondary.num_io + 1,
+      pp.r1cs_shape_secondary.num_vars,
+    );
     let inputs_secondary: NovaAugmentedCircuitInputs<E1> = NovaAugmentedCircuitInputs::new(
       pp.digest(),
       E2::Scalar::from(self.i as u64),

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -105,8 +105,7 @@ impl<E: Engine> NIFS<E> {
     // append the digest of pp to the transcript
     ro.absorb(scalar_as_base::<E>(*pp_digest));
 
-    // append U1 and U2 to transcript
-    U1.absorb_in_ro(&mut ro);
+    // append U2 to transcript, U1 does not need to absorbed since U2.X[0] = Hash(params, U1, i, z0, zi)
     U2.absorb_in_ro(&mut ro);
 
     // compute a commitment to the cross-term

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -349,13 +349,13 @@ mod tests {
         };
 
         let W = {
-          let res = R1CSWitness::new(&S, &vars);
+          let res = R1CSWitness::new(&S, vars);
           assert!(res.is_ok());
           res.unwrap()
         };
         let U = {
           let comm_W = W.commit(ck);
-          let res = R1CSInstance::new(&S, &comm_W, &X);
+          let res = R1CSInstance::new(&S, comm_W, X);
           assert!(res.is_ok());
           res.unwrap()
         };

--- a/src/spartan/direct.rs
+++ b/src/spartan/direct.rs
@@ -137,7 +137,7 @@ impl<E: Engine, S: RelaxedR1CSSNARKTrait<E>, C: StepCircuit<E::Scalar>> DirectSN
     // convert the instance and witness to relaxed form
     let (u_relaxed, w_relaxed) = (
       RelaxedR1CSInstance::from_r1cs_instance_unchecked(&u.comm_W, &u.X),
-      RelaxedR1CSWitness::from_r1cs_witness(&pk.S, &w),
+      RelaxedR1CSWitness::from_r1cs_witness(&pk.S, w),
     );
 
     // prove the instance using Spartan


### PR DESCRIPTION
## What
This backports the following PRs in Arecibo:
- https://github.com/lurk-lab/arecibo/pull/139
- https://github.com/lurk-lab/arecibo/pull/143
- https://github.com/lurk-lab/arecibo/pull/144

## Why

These PRs streamline the memory allocations occuring in performance-sensitive parts of Nova by applying a few simple techniques:
- pre-allocating known-size vectors,
- when a known-size amount of data will be allocated on each iteration of a tight loop, reuse the allocation from the prior iteration,
- read arguments by reference in few-argument matrix operations rather than copying those arguments to a single contiguous allocation

## Outcome
Each PR (in Arecibo: each commit here) has been benchmarked on Lurk-size circuits showing its impact on large witnesses / instances, and each shows a 5-8% improvement on proving latency.

## Local benchmarks (small circuits, no memory pressure, high variance)
<details><summary> critcmp results (meant to demonstrate this does not make things worse from a CPU PoV)</summary>

```
group                                                        main                                    nova_allocations
-----                                                        ----                                    ----------------
CompressedSNARK-Commitments-StepCircuitSize-0/Prove          1.00       7.3±0.08s             1.00       7.3±0.12s
CompressedSNARK-Commitments-StepCircuitSize-0/Verify         1.00    188.3±5.29ms             1.02    191.5±4.17ms
CompressedSNARK-Commitments-StepCircuitSize-121253/Prove     1.01      23.3±0.58s             1.00      23.1±0.20s
CompressedSNARK-Commitments-StepCircuitSize-121253/Verify    1.05   728.1±60.72ms             1.00   694.4±20.50ms
CompressedSNARK-Commitments-StepCircuitSize-22949/Prove      1.00      11.6±0.16s             1.00      11.6±0.16s
CompressedSNARK-Commitments-StepCircuitSize-22949/Verify     1.07   333.4±31.70ms             1.00   312.0±10.16ms
CompressedSNARK-Commitments-StepCircuitSize-252325/Prove     1.00      43.4±0.87s             1.01      43.9±0.78s
CompressedSNARK-Commitments-StepCircuitSize-252325/Verify    1.03  1213.0±107.21ms            1.00  1173.6±48.71ms
CompressedSNARK-Commitments-StepCircuitSize-55717/Prove      1.00      19.7±0.35s             1.00      19.8±0.43s
CompressedSNARK-Commitments-StepCircuitSize-55717/Verify     1.00   599.4±29.04ms             1.00   599.9±28.39ms
CompressedSNARK-Commitments-StepCircuitSize-6565/Prove       1.00      10.8±0.13s             1.00      10.7±0.09s
CompressedSNARK-Commitments-StepCircuitSize-6565/Verify      1.04   302.6±10.64ms             1.00   291.6±10.66ms
CompressedSNARK-StepCircuitSize-0/Prove                      1.01   799.1±26.03ms             1.00   791.7±10.32ms
CompressedSNARK-StepCircuitSize-0/Verify                     1.02     31.3±1.15ms             1.00     30.7±0.61ms
CompressedSNARK-StepCircuitSize-1038757/Prove                1.00      48.6±0.76s             1.00      48.4±1.05s
CompressedSNARK-StepCircuitSize-1038757/Verify               1.00  1599.8±38.46ms             1.01  1622.6±36.11ms
CompressedSNARK-StepCircuitSize-121253/Prove                 1.00       6.5±0.27s             1.01       6.6±0.15s
CompressedSNARK-StepCircuitSize-121253/Verify                1.02   210.2±12.48ms             1.00   206.0±12.69ms
CompressedSNARK-StepCircuitSize-22949/Prove                  1.00  1865.4±41.89ms             1.01  1879.3±40.81ms
CompressedSNARK-StepCircuitSize-22949/Verify                 1.00     70.5±3.44ms             1.00     70.3±2.00ms
CompressedSNARK-StepCircuitSize-252325/Prove                 1.00      12.7±0.36s             1.01      12.8±0.37s
CompressedSNARK-StepCircuitSize-252325/Verify                1.00   438.9±21.82ms             1.04   455.3±23.93ms
CompressedSNARK-StepCircuitSize-514469/Prove                 1.00      24.7±0.63s             1.00      24.6±0.63s
CompressedSNARK-StepCircuitSize-514469/Verify                1.01   701.7±30.84ms             1.00   697.0±31.46ms
CompressedSNARK-StepCircuitSize-55717/Prove                  1.01       3.5±0.12s             1.00       3.5±0.11s
CompressedSNARK-StepCircuitSize-55717/Verify                 1.00    123.0±4.74ms             1.02    124.9±7.61ms
CompressedSNARK-StepCircuitSize-6565/Prove                   1.00  1147.2±13.65ms             1.03  1180.6±52.56ms
CompressedSNARK-StepCircuitSize-6565/Verify                  1.00     46.8±1.97ms             1.01     47.2±1.51ms
RecursiveSNARK-StepCircuitSize-0/Prove                       1.00     68.6±4.89ms             1.02    69.7±12.03ms
RecursiveSNARK-StepCircuitSize-0/Verify                      1.01     28.2±0.79ms             1.00     28.0±0.57ms
RecursiveSNARK-StepCircuitSize-1038757/Prove                 1.00  1504.2±82.11ms             1.00  1500.8±37.38ms
RecursiveSNARK-StepCircuitSize-1038757/Verify                1.00  1390.6±33.57ms             1.02  1423.2±81.45ms
RecursiveSNARK-StepCircuitSize-121253/Prove                  1.00    224.4±5.93ms             1.04   233.0±11.44ms
RecursiveSNARK-StepCircuitSize-121253/Verify                 1.01    177.0±7.56ms             1.00    176.0±9.24ms
RecursiveSNARK-StepCircuitSize-22949/Prove                   1.00    107.8±7.98ms             1.01   108.7±12.36ms
RecursiveSNARK-StepCircuitSize-22949/Verify                  1.00     59.1±2.03ms             1.00     59.4±0.88ms
RecursiveSNARK-StepCircuitSize-252325/Prove                  1.00   393.3±15.95ms             1.04   407.6±16.87ms
RecursiveSNARK-StepCircuitSize-252325/Verify                 1.00   343.9±25.63ms             1.01   347.8±15.34ms
RecursiveSNARK-StepCircuitSize-514469/Prove                  1.00   781.9±21.67ms             1.02   793.9±25.06ms
RecursiveSNARK-StepCircuitSize-514469/Verify                 1.02   718.6±28.72ms             1.00   706.0±30.34ms
RecursiveSNARK-StepCircuitSize-55717/Prove                   1.00    151.4±7.48ms             1.03   155.5±13.56ms
RecursiveSNARK-StepCircuitSize-55717/Verify                  1.00     92.6±2.94ms             1.08    100.3±7.13ms
RecursiveSNARK-StepCircuitSize-6565/Prove                    1.01     77.4±4.27ms             1.00     76.6±4.25ms
RecursiveSNARK-StepCircuitSize-6565/Verify                   1.00     36.3±0.65ms             1.02     37.0±1.56ms
```
</details>

h/t @winston-h-zhang 👏 