### PR TITLE
Expose the last outputs and number of steps from RecursiveSNARK

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -588,6 +588,16 @@ where
 
     Ok((self.zi_primary.clone(), self.zi_secondary.clone()))
   }
+
+  /// Get the outputs after the last step of computation.
+  pub fn outputs(&self) -> (&[E1::Scalar], &[E2::Scalar]) {
+    (&self.zi_primary, &self.zi_secondary)
+  }
+
+  /// The number of steps which have been executed thus far.
+  pub fn num_steps(&self) -> usize {
+    self.i
+  }
 }
 
 /// A type that holds the prover key for `CompressedSNARK`


### PR DESCRIPTION
Both of these data are easily accessible, and could be very useful to clients:
* Exposing the last outputs allows us to get the current state of the computation on the prover side without wasting energy recomputing it
* Exposing the number of steps makes it easier to eventually pass `num_steps` into `CompressedSNARK::verify`