### PR TITLE
Improve error handling

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -58,12 +58,23 @@ pub enum NovaError {
   #[error("IncorrectWitness")]
   IncorrectWitness,
   /// return when error during synthesis
-  #[error("SynthesisError")]
-  SynthesisError,
+  #[error("SynthesisError: {reason}")]
+  SynthesisError {
+    /// The reason for circuit synthesis failure
+    reason: String,
+  },
   /// returned when there is an error creating a digest
   #[error("DigestError")]
   DigestError,
   /// returned when the prover cannot prove the provided statement due to completeness error
   #[error("InternalError")]
   InternalError,
+}
+
+impl From<bellpepper_core::SynthesisError> for NovaError {
+  fn from(err: bellpepper_core::SynthesisError) -> Self {
+    Self::SynthesisError {
+      reason: err.to_string(),
+    }
+  }
 }


### PR DESCRIPTION
* When a function already returns a `Result`, propagate errors instead of panicking with `expect`
* For `NovaError::SynthesisError`, retain information about the original bellpepper error. Since `NovaError` implements `Clone` but bellpepper's `SynthesisError` does not, we keep the error information as a `String`.

This commit only fixes low-hanging fruit in lib.rs, for functions that already return a `Result` and can easily propagate errors just by replacing `expect(...)` with `?`. There are still many `unwrap()` calls in functions returning `Result` in other modules, particularly gadgets. But I don't understand the code well in those parts, and I suspect some of those `unwrap()`s actually can't fail based on invariants of the code, so it makes perfect sense to leave them as is.