### PR TITLE
Remove absorbing of running instance

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -456,7 +456,7 @@ mod tests {
     let ro_consts2: ROConstantsCircuit<PallasEngine> = PoseidonConstantsCircuit::default();
 
     test_recursive_circuit_with::<PallasEngine, VestaEngine>(
-      &params1, &params2, ro_consts1, ro_consts2, 9825, 10357,
+      &params1, &params2, ro_consts1, ro_consts2, 9817, 10349,
     );
   }
 
@@ -468,7 +468,7 @@ mod tests {
     let ro_consts2: ROConstantsCircuit<Bn256Engine> = PoseidonConstantsCircuit::default();
 
     test_recursive_circuit_with::<Bn256Engine, GrumpkinEngine>(
-      &params1, &params2, ro_consts1, ro_consts2, 9993, 10546,
+      &params1, &params2, ro_consts1, ro_consts2, 9985, 10538,
     );
   }
 
@@ -480,7 +480,7 @@ mod tests {
     let ro_consts2: ROConstantsCircuit<Secp256k1Engine> = PoseidonConstantsCircuit::default();
 
     test_recursive_circuit_with::<Secp256k1Engine, Secq256k1Engine>(
-      &params1, &params2, ro_consts1, ro_consts2, 10272, 10969,
+      &params1, &params2, ro_consts1, ro_consts2, 10264, 10961,
     );
   }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,4 +3,4 @@ pub(crate) const NUM_HASH_BITS: usize = 250;
 pub(crate) const BN_LIMB_WIDTH: usize = 64;
 pub(crate) const BN_N_LIMBS: usize = 4;
 pub(crate) const NUM_FE_WITHOUT_IO_FOR_CRHF: usize = 17;
-pub(crate) const NUM_FE_FOR_RO: usize = 24;
+pub(crate) const NUM_FE_FOR_RO: usize = 9;

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -237,7 +237,6 @@ impl<E: Engine> AllocatedRelaxedR1CSInstance<E> {
     // Compute r:
     let mut ro = E::ROCircuit::new(ro_consts, NUM_FE_FOR_RO);
     ro.absorb(params);
-    self.absorb_in_ro(cs.namespace(|| "absorb running instance"), &mut ro)?;
     u.absorb_in_ro(&mut ro);
     ro.absorb(&T.x);
     ro.absorb(&T.y);

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -237,7 +237,10 @@ impl<E: Engine> AllocatedRelaxedR1CSInstance<E> {
     // Compute r:
     let mut ro = E::ROCircuit::new(ro_consts, NUM_FE_FOR_RO);
     ro.absorb(params);
+
+    // running instance `U` does not need to absorbed since u.X[0] = Hash(params, U, i, z0, zi)
     u.absorb_in_ro(&mut ro);
+    
     ro.absorb(&T.x);
     ro.absorb(&T.y);
     ro.absorb(&T.is_infinity);

--- a/src/gadgets/r1cs.rs
+++ b/src/gadgets/r1cs.rs
@@ -240,7 +240,7 @@ impl<E: Engine> AllocatedRelaxedR1CSInstance<E> {
 
     // running instance `U` does not need to absorbed since u.X[0] = Hash(params, U, i, z0, zi)
     u.absorb_in_ro(&mut ro);
-    
+
     ro.absorb(&T.x);
     ro.absorb(&T.y);
     ro.absorb(&T.is_infinity);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -946,13 +946,13 @@ mod tests {
     test_pp_digest_with::<PallasEngine, VestaEngine, _, _>(
       &trivial_circuit1,
       &trivial_circuit2,
-      "cb581e2d5c4b2ef2ddbe2d6849e0da810352f59bcdaca51476dcf9e16072f100",
+      "9bc7ad2ab3f2a12455fdd21527598e365a14619c7f1e09f5cc3c78caa2fdd602",
     );
 
     test_pp_digest_with::<PallasEngine, VestaEngine, _, _>(
       &cubic_circuit1,
       &trivial_circuit2,
-      "3cc29bb864910463e0501bac84cdefc1d4327e9c2ef5b0fd6d45ad1741f1a401",
+      "8dea023ed642fd2d1a7bedb536cd96d22c0d25ea40961a4fe4a865169bf6ee01",
     );
 
     let trivial_circuit1_grumpkin = TrivialCircuit::<<Bn256Engine as Engine>::Scalar>::default();
@@ -962,13 +962,13 @@ mod tests {
     test_pp_digest_with::<Bn256Engine, GrumpkinEngine, _, _>(
       &trivial_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
-      "1507bae161c78d6fbb231d5aa288a5cbc91f667c563e1fc4d47e7965a00a6b02",
+      "89e746ed5055445a4aceb2b6fb0413fe0bf4d2efec387dee85613922a972a701",
     );
 
     test_pp_digest_with::<Bn256Engine, GrumpkinEngine, _, _>(
       &cubic_circuit1_grumpkin,
       &trivial_circuit2_grumpkin,
-      "3ffcbf855534eea209f2c9735c71ed055e88eecc7342144d47d5de9597432001",
+      "941f55146ac21a3b4ff9863546bea95df48cb0069d2fa9e8249f8d0a00560401",
     );
 
     let trivial_circuit1_secp = TrivialCircuit::<<Secp256k1Engine as Engine>::Scalar>::default();
@@ -978,12 +978,12 @@ mod tests {
     test_pp_digest_with::<Secp256k1Engine, Secq256k1Engine, _, _>(
       &trivial_circuit1_secp,
       &trivial_circuit2_secp,
-      "ac3329f372c18a100b89fe6363844d2df42e6be539ce21bdfbe867e709be5403",
+      "4320b4f18ac17958f77db04e78c2d9d6064810f44441e0681f44e977d0fddf03",
     );
     test_pp_digest_with::<Secp256k1Engine, Secq256k1Engine, _, _>(
       &cubic_circuit1_secp,
       &trivial_circuit2_secp,
-      "2310754f2fd0e1c4e097d178f7d36e18c0362ee59c713f2a0157a9d9be066103",
+      "ac86337a156c328c400a6c38ce4f65dc29dcca7317b1f5da45599e4031d1a302",
     );
   }
 

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -45,8 +45,7 @@ impl<E: Engine> NIFS<E> {
     // append the digest of pp to the transcript
     ro.absorb(scalar_as_base::<E>(*pp_digest));
 
-    // append U1 and U2 to transcript
-    U1.absorb_in_ro(&mut ro);
+    // append U2 to transcript, U1 does not need to absorbed since U2.X[0] = Hash(params, U1, i, z0, zi)
     U2.absorb_in_ro(&mut ro);
 
     // compute a commitment to the cross-term
@@ -91,8 +90,7 @@ impl<E: Engine> NIFS<E> {
     // append the digest of pp to the transcript
     ro.absorb(scalar_as_base::<E>(*pp_digest));
 
-    // append U1 and U2 to transcript
-    U1.absorb_in_ro(&mut ro);
+    // append U2 to transcript, U1 does not need to absorbed since U2.X[0] = Hash(params, U1, i, z0, zi)
     U2.absorb_in_ro(&mut ro);
 
     // append `comm_T` to the transcript and obtain a challenge


### PR DESCRIPTION
This PR is corresponding to issue #56. It removes absorbing of running instance and updates the value of `NUM_FE_FOR_RO` and expected values in tests.