### PR TITLE
avoid explicit compression/decompression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-snark"
-version = "0.36.0"
+version = "0.37.0"
 authors = ["Srinath Setty <srinath@microsoft.com>"]
 edition = "2021"
 description = "High-speed recursive arguments from folding schemes"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,9 +22,6 @@ pub enum NovaError {
   /// returned if the supplied witness is not a satisfying witness to a given shape and instance
   #[error("UnSat")]
   UnSat,
-  /// returned when the supplied compressed commitment cannot be decompressed
-  #[error("DecompressionError")]
-  DecompressionError,
   /// returned if proof verification fails
   #[error("ProofVerifyError")]
   ProofVerifyError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,9 +46,7 @@ use r1cs::{
 };
 use serde::{Deserialize, Serialize};
 use traits::{
-  circuit::StepCircuit,
-  commitment::{CommitmentEngineTrait, CommitmentTrait},
-  snark::RelaxedR1CSSNARKTrait,
+  circuit::StepCircuit, commitment::CommitmentEngineTrait, snark::RelaxedR1CSSNARKTrait,
   AbsorbInROTrait, Engine, ROConstants, ROConstantsCircuit, ROTrait,
 };
 
@@ -399,7 +397,7 @@ where
       Some(self.zi_primary.clone()),
       Some(self.r_U_secondary.clone()),
       Some(self.l_u_secondary.clone()),
-      Some(Commitment::<E2>::decompress(&nifs_secondary.comm_T)?),
+      Some(nifs_secondary.comm_T),
     );
 
     let circuit_primary: NovaAugmentedCircuit<'_, E2, C1> = NovaAugmentedCircuit::new(
@@ -433,7 +431,7 @@ where
       Some(self.zi_secondary.clone()),
       Some(self.r_U_primary.clone()),
       Some(l_u_primary),
-      Some(Commitment::<E1>::decompress(&nifs_primary.comm_T)?),
+      Some(nifs_primary.comm_T),
     );
 
     let circuit_secondary: NovaAugmentedCircuit<'_, E1, C2> = NovaAugmentedCircuit::new(
@@ -847,7 +845,6 @@ where
 
 type CommitmentKey<E> = <<E as Engine>::CE as CommitmentEngineTrait<E>>::CommitmentKey;
 type Commitment<E> = <<E as Engine>::CE as CommitmentEngineTrait<E>>::Commitment;
-type CompressedCommitment<E> = <<<E as Engine>::CE as CommitmentEngineTrait<E>>::Commitment as CommitmentTrait<E>>::CompressedCommitment;
 type CE<E> = <E as Engine>::CE;
 
 #[cfg(test)]

--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -8,7 +8,7 @@
 #![allow(non_snake_case)]
 use crate::{
   errors::NovaError,
-  provider::traits::{CompressedGroup, DlogGroup, PairingGroup},
+  provider::traits::{DlogGroup, PairingGroup},
   traits::{
     commitment::{CommitmentEngineTrait, CommitmentTrait, Len},
     evaluation::EvaluationEngineTrait,
@@ -62,36 +62,13 @@ where
   comm: <E as Engine>::GE,
 }
 
-/// A compressed commitment (suitable for serialization)
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CompressedCommitment<E>
-where
-  E: Engine,
-  E::GE: PairingGroup,
-{
-  comm: <E::GE as DlogGroup>::CompressedGroupElement,
-}
-
 impl<E> CommitmentTrait<E> for Commitment<E>
 where
   E: Engine,
   E::GE: PairingGroup,
 {
-  type CompressedCommitment = CompressedCommitment<E>;
-
-  fn compress(&self) -> Self::CompressedCommitment {
-    CompressedCommitment {
-      comm: self.comm.compress(),
-    }
-  }
-
   fn to_coordinates(&self) -> (E::Base, E::Base, bool) {
     self.comm.to_coordinates()
-  }
-
-  fn decompress(c: &Self::CompressedCommitment) -> Result<Self, NovaError> {
-    let comm = <<E as Engine>::GE as DlogGroup>::CompressedGroupElement::decompress(&c.comm)?;
-    Ok(Commitment { comm })
   }
 }
 
@@ -138,15 +115,6 @@ where
     } else {
       E::Base::ZERO
     });
-  }
-}
-
-impl<E: Engine> TranscriptReprTrait<E::GE> for CompressedCommitment<E>
-where
-  E::GE: PairingGroup,
-{
-  fn to_transcript_bytes(&self) -> Vec<u8> {
-    self.comm.to_transcript_bytes()
   }
 }
 

--- a/src/provider/ipa_pc.rs
+++ b/src/provider/ipa_pc.rs
@@ -4,11 +4,10 @@ use crate::{
   provider::{pedersen::CommitmentKeyExtTrait, traits::DlogGroup},
   spartan::polys::eq::EqPolynomial,
   traits::{
-    commitment::{CommitmentEngineTrait, CommitmentTrait},
-    evaluation::EvaluationEngineTrait,
-    Engine, TranscriptEngineTrait, TranscriptReprTrait,
+    commitment::CommitmentEngineTrait, evaluation::EvaluationEngineTrait, Engine,
+    TranscriptEngineTrait, TranscriptReprTrait,
   },
-  Commitment, CommitmentKey, CompressedCommitment, CE,
+  Commitment, CommitmentKey, CE,
 };
 use core::iter;
 use ff::Field;
@@ -156,8 +155,8 @@ impl<E: Engine> InnerProductWitness<E> {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct InnerProductArgument<E: Engine> {
-  L_vec: Vec<CompressedCommitment<E>>,
-  R_vec: Vec<CompressedCommitment<E>>,
+  L_vec: Vec<Commitment<E>>,
+  R_vec: Vec<Commitment<E>>,
   a_hat: E::Scalar,
 }
 
@@ -200,8 +199,8 @@ where
                        transcript: &mut E::TE|
      -> Result<
       (
-        CompressedCommitment<E>,
-        CompressedCommitment<E>,
+        Commitment<E>,
+        Commitment<E>,
         Vec<E::Scalar>,
         Vec<E::Scalar>,
         CommitmentKey<E>,
@@ -221,8 +220,7 @@ where
           .chain(iter::once(&c_L))
           .copied()
           .collect::<Vec<E::Scalar>>(),
-      )
-      .compress();
+      );
       let R = CE::<E>::commit(
         &ck_L.combine(&ck_c),
         &a_vec[n / 2..n]
@@ -230,8 +228,7 @@ where
           .chain(iter::once(&c_R))
           .copied()
           .collect::<Vec<E::Scalar>>(),
-      )
-      .compress();
+      );
 
       transcript.absorb(b"L", &L);
       transcript.absorb(b"R", &R);
@@ -258,8 +255,8 @@ where
     };
 
     // two vectors to hold the logarithmic number of group elements
-    let mut L_vec: Vec<CompressedCommitment<E>> = Vec::new();
-    let mut R_vec: Vec<CompressedCommitment<E>> = Vec::new();
+    let mut L_vec: Vec<Commitment<E>> = Vec::new();
+    let mut R_vec: Vec<Commitment<E>> = Vec::new();
 
     // we create mutable copies of vectors and generators
     let mut a_vec = W.a_vec.to_vec();
@@ -375,7 +372,7 @@ where
     };
 
     let ck_hat = {
-      let c = CE::<E>::commit(&ck, &s).compress();
+      let c = CE::<E>::commit(&ck, &s);
       CommitmentKey::<E>::reinterpret_commitments_as_ck(&[c])?
     };
 
@@ -385,7 +382,7 @@ where
       let ck_folded = {
         let ck_L = CommitmentKey::<E>::reinterpret_commitments_as_ck(&self.L_vec)?;
         let ck_R = CommitmentKey::<E>::reinterpret_commitments_as_ck(&self.R_vec)?;
-        let ck_P = CommitmentKey::<E>::reinterpret_commitments_as_ck(&[P.compress()])?;
+        let ck_P = CommitmentKey::<E>::reinterpret_commitments_as_ck(&[P])?;
         ck_L.combine(&ck_R).combine(&ck_P)
       };
 

--- a/src/provider/secp_secq.rs
+++ b/src/provider/secp_secq.rs
@@ -1,17 +1,16 @@
 //! This module implements the Nova traits for `secp::Point`, `secp::Scalar`, `secq::Point`, `secq::Scalar`.
 use crate::{
-  errors::NovaError,
   impl_traits,
-  provider::traits::{CompressedGroup, DlogGroup},
+  provider::traits::DlogGroup,
   traits::{Group, PrimeFieldExt, TranscriptReprTrait},
 };
 use digest::{ExtendableOutput, Update};
 use ff::{FromUniformBytes, PrimeField};
-use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup, GroupEncoding};
+use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup};
 use halo2curves::{
   msm::best_multiexp,
-  secp256k1::{Secp256k1, Secp256k1Affine, Secp256k1Compressed},
-  secq256k1::{Secq256k1, Secq256k1Affine, Secq256k1Compressed},
+  secp256k1::{Secp256k1, Secp256k1Affine},
+  secq256k1::{Secq256k1, Secq256k1Affine},
 };
 use num_bigint::BigInt;
 use num_traits::Num;
@@ -36,7 +35,6 @@ pub mod secq256k1 {
 
 impl_traits!(
   secp256k1,
-  Secp256k1Compressed,
   Secp256k1,
   Secp256k1Affine,
   "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
@@ -45,7 +43,6 @@ impl_traits!(
 
 impl_traits!(
   secq256k1,
-  Secq256k1Compressed,
   Secq256k1,
   Secq256k1Affine,
   "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",

--- a/src/traits/commitment.rs
+++ b/src/traits/commitment.rs
@@ -1,9 +1,6 @@
 //! This module defines a collection of traits that define the behavior of a commitment engine
 //! We require the commitment engine to provide a commitment to vectors with a single group element
-use crate::{
-  errors::NovaError,
-  traits::{AbsorbInROTrait, Engine, TranscriptReprTrait},
-};
+use crate::traits::{AbsorbInROTrait, Engine, TranscriptReprTrait};
 use core::{
   fmt::Debug,
   ops::{Add, Mul, MulAssign},
@@ -33,25 +30,8 @@ pub trait CommitmentTrait<E: Engine>:
   + Add<Self, Output = Self>
   + ScalarMul<E::Scalar>
 {
-  /// Holds the type of the compressed commitment
-  type CompressedCommitment: Clone
-    + Debug
-    + PartialEq
-    + Eq
-    + Send
-    + Sync
-    + TranscriptReprTrait<E::GE>
-    + Serialize
-    + for<'de> Deserialize<'de>;
-
-  /// Compresses self into a compressed commitment
-  fn compress(&self) -> Self::CompressedCommitment;
-
   /// Returns the coordinate representation of the commitment
   fn to_coordinates(&self) -> (E::Base, E::Base, bool);
-
-  /// Decompresses a compressed commitment into a commitment
-  fn decompress(c: &Self::CompressedCommitment) -> Result<Self, NovaError>;
 }
 
 /// A trait that helps determine the length of a structure.


### PR DESCRIPTION
The underlying curve libraries that we use (pasta_curves and halo2curves) already serialize group elements in compressed form, so higher-level code such as Nova does not have to manually manage compressed vs. uncompressed forms. This simplifies code.