### PR TITLE
feat: allow for more general transcripts

### DIFF
--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -283,7 +283,7 @@ where
   // This impl block defines helper functions that are not a part of
   // EvaluationEngineTrait, but that we will use to implement the trait methods.
   fn compute_challenge(com: &[G1Affine<E>], transcript: &mut <E as Engine>::TE) -> E::Scalar {
-    transcript.absorb(b"c", &com.to_vec().as_slice());
+    transcript.absorb_affine_group_elements(b"c", &com.to_vec().as_slice());
 
     transcript.squeeze(b"c").unwrap()
   }
@@ -291,7 +291,7 @@ where
   // Compute challenge q = Hash(vk, C0, ..., C_{k-1}, u0, ...., u_{t-1},
   // (f_i(u_j))_{i=0..k-1,j=0..t-1})
   fn get_batch_challenge(v: &[Vec<E::Scalar>], transcript: &mut <E as Engine>::TE) -> E::Scalar {
-    transcript.absorb(
+    transcript.absorb_scalars(
       b"v",
       &v.iter()
         .flatten()
@@ -313,7 +313,7 @@ where
   }
 
   fn verifier_second_challenge(W: &[G1Affine<E>], transcript: &mut <E as Engine>::TE) -> E::Scalar {
-    transcript.absorb(b"W", &W.to_vec().as_slice());
+    transcript.absorb_affine_group_elements(b"W", &W.to_vec().as_slice());
 
     transcript.squeeze(b"d").unwrap()
   }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -4,12 +4,12 @@
 pub mod bn256_grumpkin;
 pub mod hyperkzg;
 pub mod ipa_pc;
+pub mod keccak;
 pub mod pasta;
 pub mod poseidon;
 pub mod secp_secq;
 
 // crate-private modules
-pub(crate) mod keccak;
 pub(crate) mod pedersen;
 pub(crate) mod traits;
 

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -2,6 +2,7 @@
 use crate::{
   errors::NovaError,
   frontend::{num::AllocatedNum, AllocatedBit, ConstraintSystem, SynthesisError},
+  provider::traits::DlogGroup,
 };
 use core::fmt::Debug;
 use ff::{PrimeField, PrimeFieldBits};
@@ -129,6 +130,24 @@ pub trait TranscriptEngineTrait<E: Engine>: Send + Sync {
 
   /// adds a domain separator
   fn dom_sep(&mut self, bytes: &'static [u8]);
+
+  /// absorbs a slice of scalar elements. This defaults to absorbing the bytes of the scalar using `TranscriptReprTrait`
+  /// but can be overridden for other reasons
+  fn absorb_scalars(&mut self, label: &'static [u8], o: &[E::Scalar]) {
+    TranscriptEngineTrait::absorb(self, label, &o);
+  }
+
+  /// absorbs a slice of group elements. This defaults to absorbing the bytes of the group element using `TranscriptReprTrait`
+  /// but can be overridden for other reasons
+  fn absorb_affine_group_elements(
+    &mut self,
+    label: &'static [u8],
+    o: &[<E::GE as DlogGroup>::AffineGroupElement],
+  ) where
+    E::GE: DlogGroup,
+  {
+    TranscriptEngineTrait::absorb(self, label, &o);
+  }
 }
 
 /// Defines additional methods on `PrimeField` objects


### PR DESCRIPTION
# Rationale

HyperKZG requires using `TranscriptReprTrait` for serialization before putting a value on the transcript. This serialization is dependent on the scalar, rather than the transcript.

This become challenging when trying to duplicate the transcript in the EVM, which is big-endian. Allowing for a custom serialization allows for more flexible usage upstream.