### PR TITLE
feat!: improve hyperkzg api

### DIFF
--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -284,6 +284,24 @@ where
   v: Vec<Vec<E::Scalar>>,
 }
 
+impl<E: Engine> EvaluationArgument<E>
+where
+  E::GE: PairingGroup,
+{
+  /// The KZG commitments to intermediate polynomials
+  pub fn com(&self) -> &[G1Affine<E>] {
+    &self.com
+  }
+  /// The KZG witnesses for batch openings
+  pub fn w(&self) -> &[G1Affine<E>] {
+    &self.w
+  }
+  /// The evaluations of the polynomials at challenge points
+  pub fn v(&self) -> &[Vec<E::Scalar>] {
+    &self.v
+  }
+}
+
 /// Provides an implementation of a polynomial evaluation engine using KZG
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EvaluationEngine<E: Engine> {

--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -71,6 +71,20 @@ where
   comm: <E as Engine>::GE,
 }
 
+impl<E: Engine> Commitment<E>
+where
+  E::GE: PairingGroup,
+{
+  /// Creates a new commitment from the underlying group element
+  pub fn new(comm: <E as Engine>::GE) -> Self {
+    Commitment { comm }
+  }
+  /// Returns the commitment as a group element
+  pub fn into_inner(self) -> <E as Engine>::GE {
+    self.comm
+  }
+}
+
 impl<E: Engine> CommitmentTrait<E> for Commitment<E>
 where
   E::GE: PairingGroup,

--- a/src/provider/keccak.rs
+++ b/src/provider/keccak.rs
@@ -137,18 +137,18 @@ mod tests {
   #[test]
   fn test_keccak_transcript() {
     test_keccak_transcript_with::<PallasEngine>(
-      "5ddffa8dc091862132788b8976af88b9a2c70594727e611c7217ba4c30c8c70a",
-      "4d4bf42c065870395749fa1c4fb641df1e0d53f05309b03d5b1db7f0be3aa13d",
+      "b67339da79ce5f6dc72ad23c8c3b4179f49655cadf92d47e79c3e7788f00f125",
+      "b7f033d47b3519dd6efe320b995eaad1dc11712cb9b655d2e7006ed5f86bd321",
     );
 
     test_keccak_transcript_with::<Bn256EngineKZG>(
-      "9fb71e3b74bfd0b60d97349849b895595779a240b92a6fae86bd2812692b6b0e",
-      "bfd4c50b7d6317e9267d5d65c985eb455a3561129c0b3beef79bfc8461a84f18",
+      "b387ba3a8b9a22b3b7544a3dbbd26a048a1d354d8dc582c64d1513335e66a205",
+      "73ad65097d947fe45de5241bb340bbd97b198b52cc559a9657f73c361bf8700b",
     );
 
     test_keccak_transcript_with::<Secp256k1Engine>(
-      "9723aafb69ec8f0e9c7de756df0993247d98cf2b2f72fa353e3de654a177e310",
-      "a6a90fcb6e1b1a2a2f84c950ef1510d369aea8e42085f5c629bfa66d00255f25",
+      "f15ddd8fa1675a9e273e0ef441711005d77a5fd485f4e6cdee59760ca01493fa",
+      "3c019f0e557abaecc99790382974cb27132bfe038af9c4d43a33ec9c426e19f5",
     );
   }
 

--- a/src/provider/traits.rs
+++ b/src/provider/traits.rs
@@ -197,15 +197,16 @@ macro_rules! impl_traits {
 
     impl<G: Group> TranscriptReprTrait<G> for $name::Scalar {
       fn to_transcript_bytes(&self) -> Vec<u8> {
-        self.to_bytes().to_vec()
+        self.to_bytes().into_iter().rev().collect()
       }
     }
 
     impl<G: DlogGroup> TranscriptReprTrait<G> for $name::Affine {
       fn to_transcript_bytes(&self) -> Vec<u8> {
         let coords = self.coordinates().unwrap();
-
-        [coords.x().to_bytes(), coords.y().to_bytes()].concat()
+        let x_bytes = coords.x().to_bytes().into_iter();
+        let y_bytes = coords.y().to_bytes().into_iter();
+        x_bytes.rev().chain(y_bytes.rev()).collect()
       }
     }
   };


### PR DESCRIPTION
# Rationale

There are a few things in hyperkzg that make upstream usage impossible or difficult. In particular, the actual proof is inaccessible in a transparent fashion.

# Changes

Take a look at the individual commits.

* [feat!: make field elements serialize into transcript in big-endian form](https://github.com/microsoft/Nova/pull/353/commits/8221d2243bece69dc36affc1b43689055b52d054)
    - This makes the transcript more compatible with the EVM, which is big-endian
* [feat: expose hyperkzg underlying group](https://github.com/microsoft/Nova/pull/353/commits/f043aabbf12e481c30b1592b76e99f46341f145e)
    - This is accomplished via `new` and `into_inner` methods
* [feat: expose hyperkzg argument underlying elements](https://github.com/microsoft/Nova/pull/353/commits/ef432cd171a0162ce7ed2a4c1907725915eaede1)
    - This is accomplished via `com`, `w`, and `v` accessors.
* [feat: add `setup_from_rng` for hyperkzg::CommitmentKey](https://github.com/microsoft/Nova/pull/353/commits/74b783e0a37e53bbf9530db94958baff7a62e583)
    - This can be used instead of `CommitmentEngineTrait::setup` to generate a reproducible commitment key