### PR TITLE
feat: expose Commitment key fields in API

### DIFF
--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -43,6 +43,35 @@ where
   tau_H: <<E::GE as PairingGroup>::G2 as DlogGroup>::AffineGroupElement, // needed only for the verifier key
 }
 
+impl<E: Engine> CommitmentKey<E>
+where
+  E::GE: PairingGroup,
+{
+  /// Create a new commitment key
+  pub fn new(
+    ck: Vec<<E::GE as DlogGroup>::AffineGroupElement>,
+    h: <E::GE as DlogGroup>::AffineGroupElement,
+    tau_H: <<E::GE as PairingGroup>::G2 as DlogGroup>::AffineGroupElement,
+  ) -> Self {
+    Self { ck, h, tau_H }
+  }
+
+  /// Returns a reference to the ck field
+  pub fn ck(&self) -> &[<E::GE as DlogGroup>::AffineGroupElement] {
+    &self.ck
+  }
+
+  /// Returns a reference to the h field
+  pub fn h(&self) -> &<E::GE as DlogGroup>::AffineGroupElement {
+    &self.h
+  }
+
+  /// Returns a reference to the tau_H field
+  pub fn tau_H(&self) -> &<<E::GE as PairingGroup>::G2 as DlogGroup>::AffineGroupElement {
+    &self.tau_H
+  }
+}
+
 impl<E: Engine> Len for CommitmentKey<E>
 where
   E::GE: PairingGroup,


### PR DESCRIPTION
# Rationale
The `CommitmentKey` fields `ck`, `h`, and `tau_H` are currently private. This PR exposed the fields in the API. This enables users of the Nova project to do things like use different multi-scalar multiplication implementations.

# Changes
- Implemented a `new` method for the `CommitmentKey` struct to create a new instance.
- Implemented accessor methods for the `ck`, `h`, and `tau_H` fields. 