### PR TITLE
refactor: simplify hyperkzg verify

### DIFF
--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -19,6 +19,7 @@ use core::{
   iter,
   marker::PhantomData,
   ops::{Add, Mul, MulAssign},
+  slice,
 };
 use ff::Field;
 use rand_core::OsRng;
@@ -532,9 +533,8 @@ where
     let Y = &pi.v[2];
 
     // Check consistency of (Y, ypos, yneg)
-    let two = E::Scalar::from(2u64);
     for i in 0..ell {
-      if two * r * Y.get(i + 1).unwrap_or(y)
+      if r.double() * Y.get(i + 1).unwrap_or(y)
         != r * (E::Scalar::ONE - x[ell - i - 1]) * (ypos[i] + yneg[i])
           + x[ell - i - 1] * (ypos[i] - yneg[i])
       {
@@ -551,7 +551,7 @@ where
     let q = Self::get_batch_challenge(&pi.v, transcript);
 
     let d_0 = Self::verifier_second_challenge(&pi.w, transcript);
-    let d_1 = d_0 * d_0;
+    let d_1 = d_0.square();
 
     // We write a special case for t=3, since this what is required for
     // hyperkzg. Following the paper directly, we must compute:
@@ -605,12 +605,8 @@ where
       &[
         &[C.comm.affine()][..],
         &pi.com,
-        &[
-          pi.w[0].clone(),
-          pi.w[1].clone(),
-          pi.w[2].clone(),
-          vk.G.clone(),
-        ],
+        &pi.w,
+        slice::from_ref(&vk.G),
       ]
       .concat(),
     );

--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -525,7 +525,11 @@ where
     let u = [r, -r, r * r];
 
     // Setup vectors (Y, ypos, yneg) from pi.v
-    if pi.v[0].len() != ell || pi.v[1].len() != ell || pi.v[2].len() != ell {
+    if pi.v[0].len() != ell
+      || pi.v[1].len() != ell
+      || pi.v[2].len() != ell
+      || pi.com.len() != ell - 1
+    {
       return Err(NovaError::ProofVerifyError);
     }
     let ypos = &pi.v[0];


### PR DESCRIPTION
# Rationale

One of the first steps that we did when writing a hyperkzg EVM verifier was simplifying the existing Rust verifier to make a port more direct. The code has been written. It doesn't impact anything other than readability. (With the possible exception of the final commit.)

# Changes

See the individual commits. This PR may be hard to review as a whole, but the individual commits are intended to be very simple.
* The first two commits involve inlining the `kzg_verify_batch` closure, which involves a large `git diff` but very little actual change.
* The remaining commits do various thing. In particular, the main focus is to eliminate "helper" vectors, superfluous variables, mutability, and copy/clone. These all simplify code in general, but in particular make an EVM port much easier.
* The last commit, in particular, is a potential security fix. I believe that the protocol is sound as is, but it is non-trivial to prove this.