### PR TITLE
refactor: avoid creating intermediate vectors during commit

### DIFF
--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -272,13 +272,9 @@ where
   fn commit(ck: &Self::CommitmentKey, v: &[E::Scalar], r: &E::Scalar) -> Self::Commitment {
     assert!(ck.ck.len() >= v.len());
 
-    let mut scalars: Vec<E::Scalar> = v.to_vec();
-    scalars.push(*r);
-    let mut bases = ck.ck[..v.len()].to_vec();
-    bases.push(ck.h.clone());
-
     Commitment {
-      comm: E::GE::vartime_multiscalar_mul(&scalars, &bases),
+      comm: E::GE::vartime_multiscalar_mul(v, &ck.ck[..v.len()])
+        + <E::GE as DlogGroup>::group(&ck.h) * r,
     }
   }
 

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -190,7 +190,7 @@ where
     if ck.h.is_some() {
       Commitment {
         comm: E::GE::vartime_multiscalar_mul(v, &ck.ck[..v.len()])
-          + <E::GE as DlogGroup>::group(&ck.h.as_ref().unwrap().clone()) * r,
+          + <E::GE as DlogGroup>::group(ck.h.as_ref().unwrap()) * r,
       }
     } else {
       assert_eq!(*r, E::Scalar::ZERO);

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -188,13 +188,9 @@ where
     assert!(ck.ck.len() >= v.len());
 
     if ck.h.is_some() {
-      let mut scalars: Vec<E::Scalar> = v.to_vec();
-      scalars.push(*r);
-      let mut bases = ck.ck[..v.len()].to_vec();
-      bases.push(ck.h.as_ref().unwrap().clone());
-
       Commitment {
-        comm: E::GE::vartime_multiscalar_mul(&scalars, &bases),
+        comm: E::GE::vartime_multiscalar_mul(v, &ck.ck[..v.len()])
+          + <E::GE as DlogGroup>::group(&ck.h.as_ref().unwrap().clone()) * r,
       }
     } else {
       assert_eq!(*r, E::Scalar::ZERO);


### PR DESCRIPTION
# Rationale for this change
This PR refactors the `commit` function in the `hyperkzg` and `pedersen` modules to improve space performance by eliminating the creation of intermediate `scalars` and `bases` vectors. Instead, it directly constructs the required slices for the `vartime_multiscalar_mul` function call and adds the binding factor in a separate step, reducing memory allocations. 

# Criterion benchmark results
Benchmarks were completed on an Azure VM: `Standard NC24ads A100 v4 (24 vcpus, AMD EPYC 7V13 (Milan) [x86-64], and 220 GiB memory)`

The `compressed-snark` criterion benchmarks show that no change in performance was detected or, in one case, within the noise threshold. Gray relates to the `main` branch, blue relates to the updates in this PR..

- CompressedSNARK-StepCircuitSize-0/Prove 
![image](https://github.com/user-attachments/assets/99e04ff6-1d01-48d8-8ab4-2590abed9d31)

- CompressedSNARK-StepCircuitSize-6399/Prove 
![image](https://github.com/user-attachments/assets/adc98825-29c4-4bc0-9fe6-c9bc7efad756)

- CompressedSNARK-StepCircuitSize-22783/Prove 
![image](https://github.com/user-attachments/assets/84bed3a6-3400-402e-b317-7b2c4aa51949)

- CompressedSNARK-StepCircuitSize-55551/Prove 
![image](https://github.com/user-attachments/assets/6f6f6b08-942b-44e8-8737-62a0cfb4e17f)

- CompressedSNARK-StepCircuitSize-121087/Prove 
![image](https://github.com/user-attachments/assets/9fb93bbb-b199-4698-82b5-0ccb38e049d2)

- CompressedSNARK-StepCircuitSize-252159/Prove 
![image](https://github.com/user-attachments/assets/a246a734-0b09-42ab-b62f-12a3d70cf4f3)

- CompressedSNARK-StepCircuitSize-514303/Prove 
![image](https://github.com/user-attachments/assets/e810c865-0edb-4022-8b6c-92e69931cc89)

- CompressedSNARK-StepCircuitSize-1038591/Prove 
![image](https://github.com/user-attachments/assets/fa27e962-f3de-4b2d-bf5b-9b3235251f46)

- CompressedSNARK-Commitments-StepCircuitSize-0/Prove 
![image](https://github.com/user-attachments/assets/8739d2f7-e6e0-44df-99a5-5d3d596b31b6)

- CompressedSNARK-Commitments-StepCircuitSize-6399/Prove 
![image](https://github.com/user-attachments/assets/425d1818-223a-492f-9032-a62fbce3a73b)

- CompressedSNARK-Commitments-StepCircuitSize-22783/Prove 
![image](https://github.com/user-attachments/assets/820c32cf-e331-4356-9f68-80f64ae95360)

- CompressedSNARK-Commitments-StepCircuitSize-55551/Prove 
![image](https://github.com/user-attachments/assets/aa1fe59b-f06b-4f7b-ba02-069d84ea70ee)

- CompressedSNARK-Commitments-StepCircuitSize-121087/Prove 
![image](https://github.com/user-attachments/assets/5ade9523-e4a3-4fbd-879d-15e26f1386d1)

- CompressedSNARK-Commitments-StepCircuitSize-252159/Prove
![image](https://github.com/user-attachments/assets/e2c783f1-c756-4a4c-9440-909973749da7)
