### PR TITLE
fix: clippy warning

### DIFF
--- a/examples/and.rs
+++ b/examples/and.rs
@@ -72,7 +72,7 @@ pub fn u64_into_bit_vec_le<Scalar: PrimeField, CS: ConstraintSystem<Scalar>>(
       let mut tmp = Vec::with_capacity(64);
 
       for i in 0..64 {
-        tmp.push(Some(*value >> i & 1 == 1));
+        tmp.push(Some((*value >> i) & 1 == 1));
       }
 
       tmp

--- a/src/gadgets/nonnative/mod.rs
+++ b/src/gadgets/nonnative/mod.rs
@@ -26,7 +26,7 @@ impl<Scalar: PrimeField> BitAccess for Scalar {
 
     let (byte_pos, bit_pos) = (i / 8, i % 8);
     let byte = self.to_repr().as_ref()[byte_pos];
-    let bit = byte >> bit_pos & 1;
+    let bit = (byte >> bit_pos) & 1;
     Some(bit == 1)
   }
 }


### PR DESCRIPTION
There is a clippy warning that is blocking a few PRs - see CI message [here](https://github.com/microsoft/Nova/actions/runs/13392690038/job/37747269290?pr=364) and [here](https://github.com/microsoft/Nova/actions/runs/13595552859/job/38013255593?pr=366). 

This PR fixes the warning. All tests run successfully on local machine.