### PR TITLE
Improve HyperKZG commitment performance with rayon parallelization

### DIFF
--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -486,8 +486,8 @@ where
     let h = <E::GE as DlogGroup>::group(&ck.h);
 
     E::GE::batch_vartime_multiscalar_mul(v, &ck.ck[..max])
-      .iter()
-      .zip(r.iter())
+      .par_iter()
+      .zip(r.par_iter())
       .map(|(commit, r_i)| Commitment {
         comm: *commit + (h * r_i),
       })
@@ -823,7 +823,7 @@ where
     // Compute commitments in parallel
     let r = vec![E::Scalar::ZERO; ell - 1];
     let com: Vec<G1Affine<E>> = E::CE::batch_commit(ck, &polys[1..], r.as_slice())
-      .iter()
+      .par_iter()
       .map(|i| i.comm.affine())
       .collect();
 


### PR DESCRIPTION
## Overview
There are a number of opportunities to run HyperKZG computations in parallel when executing code on the GPU, `--features="blitzar"`. The work in this PR identifies adds the parallel execution paths using the `rayon` crate. Criterion benchmarks show an overall improvement, though not in every single case.

## Criterion benchmarks
Results from `cargo criterion --bench commit --features="blitzar"` run on an Azure VM, `Standard NC96ads A100 v4`.
- time 1: current NOVA main
- time 2: this PR

halo2curves_commit_u1_1048576                                                                          
- time:   [217.55 ms 219.67 ms 221.51 ms]
- time:   [218.09 ms 219.86 ms 221.40 ms]
- change: [-1.0816% +0.0827% +1.2476%] (p = 0.87 > 0.05)
- No change in performance detected.

nova_generic_commit_u1_1048576                                                                           
- time:   [79.986 ms 80.040 ms 80.138 ms]
- time:   [68.186 ms 68.442 ms 68.750 ms]
- change: [-15.177% -14.691% -14.075%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u1_1048576                                                                            
- time:   [4.9361 ms 5.2216 ms 5.4592 ms]
- time:   [4.4039 ms 4.6158 ms 4.9023 ms]
- change: [-15.834% -10.714% -4.5806%] (p = 0.01 < 0.05)
- Performance has improved.

halo2curves_commit_u10_1048576                                                                          
- time:   [247.35 ms 248.55 ms 249.85 ms]
- time:   [244.56 ms 246.12 ms 247.65 ms]
- change: [-1.8153% -0.9762% -0.2014%] (p = 0.04 < 0.05)
- Change within noise threshold.

nova_generic_commit_u10_1048576                                                                           
- time:   [91.390 ms 91.513 ms 91.703 ms]
- time:   [80.435 ms 80.880 ms 81.115 ms]
- change: [-12.411% -11.927% -11.514%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u10_1048576                                                                           
- time:   [7.5514 ms 7.6916 ms 7.7944 ms]
- time:   [9.7838 ms 10.271 ms 10.598 ms]
- change: [+32.687% +37.711% +42.117%] (p = 0.00 < 0.05)
- Performance has regressed.

halo2curves_commit_u16_1048576                                                                          
- time:   [355.62 ms 357.88 ms 360.11 ms]
- time:   [354.51 ms 356.27 ms 358.03 ms]
- change: [-1.2348% -0.4510% +0.3703%] (p = 0.30 > 0.05)
- No change in performance detected.

nova_generic_commit_u16_1048576                                                                           
- time:   [91.261 ms 91.402 ms 91.570 ms]
- time:   [79.950 ms 80.409 ms 81.102 ms]
- change: [-12.074% -11.482% -10.812%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u16_1048576                                                                           
- time:   [14.131 ms 14.574 ms 15.386 ms]
- time:   [16.011 ms 17.313 ms 18.167 ms]
- change: [+2.0119% +10.992% +20.650%] (p = 0.04 < 0.05)
- Performance has regressed.

halo2curves_commit_u32_1048576                                                                          
- time:   [391.45 ms 394.88 ms 399.77 ms]
- time:   [394.25 ms 396.25 ms 398.22 ms]
- change: [-0.9834% +0.3481% +1.3902%] (p = 0.61 > 0.05)
- No change in performance detected.

nova_generic_commit_u32_1048576                                                                           
- time:   [92.550 ms 92.877 ms 93.183 ms]
- time:   [79.700 ms 80.023 ms 80.259 ms]
- change: [-14.129% -13.814% -13.530%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u32_1048576                                                                           
- time:   [26.525 ms 28.286 ms 31.434 ms]
- time:   [23.696 ms 24.650 ms 25.968 ms]
- change: [-22.862% -14.258% -2.9881%] (p = 0.02 < 0.05)
- Performance has improved.

halo2curves_commit_u64_1048576                                                                          
- time:   [279.31 ms 281.02 ms 283.01 ms]
- time:   [279.88 ms 282.04 ms 284.31 ms]
- change: [-0.7042% +0.3622% +1.4037%] (p = 0.52 > 0.05)
- No change in performance detected.

nova_generic_commit_u64_1048576                                                                           
- time:   [91.978 ms 92.238 ms 92.423 ms]
- time:   [80.407 ms 80.697 ms 81.101 ms]
- change: [-12.491% -12.138% -11.801%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u64_1048576                                                                           
- time:   [40.856 ms 41.707 ms 43.209 ms]
- time:   [42.934 ms 44.418 ms 46.971 ms]
- change: [+6.8255% +15.931% +25.163%] (p = 0.00 < 0.05)
- Performance has regressed.

halo2curves_commit_random_1048576                                                                          
- time:   [379.29 ms 381.10 ms 382.49 ms]
- time:   [377.50 ms 378.92 ms 380.06 ms]
- change: [-1.0666% -0.5723% +0.0040%] (p = 0.07 > 0.05)
- No change in performance detected.

nova_generic_commit_random_1048576                                                                           
- time:   [99.491 ms 99.717 ms 99.978 ms]
- time:   [86.905 ms 87.362 ms 87.785 ms]
- change: [-13.064% -12.490% -12.009%] (p = 0.00 < 0.05)
- Performance has improved.

halo2curves_commit_u1_4194304                                                                          
- time:   [839.44 ms 851.88 ms 864.52 ms]
- time:   [824.46 ms 833.84 ms 844.58 ms]
- change: [-4.0381% -2.1176% -0.2327%] (p = 0.06 > 0.05)
- No change in performance detected.

nova_generic_commit_u1_4194304                                                                          
- time:   [263.39 ms 263.67 ms 263.95 ms]
- time:   [202.85 ms 203.63 ms 204.46 ms]
- change: [-23.053% -22.771% -22.460%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u1_4194304                                                                           
- time:   [16.296 ms 17.616 ms 18.302 ms]
- time:   [15.586 ms 15.939 ms 16.532 ms]
- change: [-7.9231% -1.1349% +6.8835%] (p = 0.78 > 0.05)
- No change in performance detected.

halo2curves_commit_u10_4194304                                                                          
- time:   [971.46 ms 990.06 ms 1.0085 s]
- time:   [944.19 ms 953.59 ms 963.13 ms]
- change: [-5.6807% -3.6832% -1.6673%] (p = 0.00 < 0.05)
- Performance has improved.

nova_generic_commit_u10_4194304                                                                          
- time:   [315.22 ms 316.53 ms 317.85 ms]
- time:   [252.97 ms 254.31 ms 255.72 ms]
- change: [-20.215% -19.656% -19.088%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u10_4194304                                                                           
- time:   [26.423 ms 27.593 ms 29.692 ms]
- time:   [28.827 ms 30.817 ms 32.313 ms]
- change: [-5.5973% +2.8200% +11.453%] (p = 0.55 > 0.05)
- No change in performance detected.

halo2curves_commit_u16_4194304                                                                          
- time:   [987.85 ms 1.0048 s 1.0219 s]
- time:   [966.55 ms 977.90 ms 991.25 ms]
- change: [-4.6901% -2.6767% -0.5644%] (p = 0.03 < 0.05)
- Change within noise threshold.

nova_generic_commit_u16_4194304                                                                          
- time:   [315.41 ms 316.62 ms 318.02 ms]
- time:   [253.06 ms 253.51 ms 253.88 ms]
- change: [-20.306% -19.933% -19.606%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u16_4194304                                                                           
- time:   [52.833 ms 54.496 ms 56.219 ms]
- time:   [52.592 ms 58.205 ms 61.841 ms]
- change: [-8.8116% +2.2022% +12.492%] (p = 0.71 > 0.05)
- No change in performance detected.

halo2curves_commit_u32_4194304                                                                          
- time:   [971.10 ms 993.79 ms 1.0183 s]
- time:   [966.28 ms 977.71 ms 991.09 ms]
- change: [-4.2097% -1.6183% +0.9990%] (p = 0.28 > 0.05)
- No change in performance detected.

nova_generic_commit_u32_4194304                                                                          
- time:   [313.22 ms 313.63 ms 314.02 ms]
- time:   [255.97 ms 256.35 ms 256.74 ms]
- change: [-18.420% -18.264% -18.096%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u32_4194304                                                                          
- time:   [81.207 ms 89.251 ms 94.783 ms]
- time:   [78.862 ms 86.494 ms 98.498 ms]
- change: [-4.5721% +6.9455% +18.261%] (p = 0.26 > 0.05)
- No change in performance detected.

halo2curves_commit_u64_4194304                                                                          
- time:   [995.17 ms 1.0083 s 1.0213 s]
- time:   [977.58 ms 990.63 ms 1.0054 s]
- change: [-3.4949% -1.7528% +0.2749%] (p = 0.11 > 0.05)
- No change in performance detected.

nova_generic_commit_u64_4194304                                                                          
- time:   [314.86 ms 315.48 ms 316.29 ms]
- time:   [255.92 ms 256.78 ms 257.69 ms]
- change: [-18.964% -18.608% -18.273%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u64_4194304                                                                          
- time:   [143.72 ms 151.67 ms 161.52 ms]
- time:   [140.21 ms 146.90 ms 154.31 ms]
- change: [-19.245% -11.565% -2.6309%] (p = 0.03 < 0.05)
- Performance has improved.

halo2curves_commit_random_4194304                                                                          
- time:   [1.0677 s 1.0748 s 1.0807 s]
- time:   [1.0570 s 1.0649 s 1.0716 s]
- change: [-1.8293% -0.9245% -0.0371%] (p = 0.08 > 0.05)
- No change in performance detected.

nova_generic_commit_random_4194304                                                                          
- time:   [342.70 ms 342.96 ms 343.21 ms]
- time:   [285.14 ms 286.32 ms 287.85 ms]
- change: [-16.866% -16.516% -16.086%] (p = 0.00 < 0.05)
- Performance has improved.

halo2curves_commit_u1_16777216                                                                          
- time:   [3.2115 s 3.2376 s 3.2654 s]
- time:   [3.2008 s 3.2292 s 3.2651 s]
- change: [-1.4720% -0.2605% +1.1634%] (p = 0.72 > 0.05)
- No change in performance detected.

nova_generic_commit_u1_16777216                                                                          
- time:   [859.45 ms 862.68 ms 866.39 ms]
- time:   [594.91 ms 598.87 ms 602.76 ms]
- change: [-31.129% -30.580% -30.027%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u1_16777216                                                                           
- time:   [54.574 ms 57.648 ms 60.964 ms]
- time:   [54.316 ms 56.014 ms 59.230 ms]
- change: [-7.2425% -0.7549% +6.7158%] (p = 0.84 > 0.05)
- No change in performance detected.

halo2curves_commit_u10_16777216                                                                          
- time:   [3.6636 s 3.7001 s 3.7453 s]
- time:   [3.6529 s 3.6802 s 3.7091 s]
- change: [-1.9285% -0.5365% +0.7693%] (p = 0.47 > 0.05)
- No change in performance detected.

nova_generic_commit_u10_16777216                                                                          
- time:   [927.01 ms 928.76 ms 930.53 ms]
- time:   [650.29 ms 656.50 ms 663.88 ms]
- change: [-30.023% -29.314% -28.529%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u10_16777216                                                                          
- time:   [90.910 ms 94.373 ms 98.838 ms]
- time:   [100.12 ms 107.36 ms 116.34 ms]
- change: [+3.6482% +11.937% +20.336%] (p = 0.01 < 0.05)
- Performance has regressed.

halo2curves_commit_u16_16777216                                                                          
- time:   [3.5683 s 3.5980 s 3.6351 s]
- time:   [3.5984 s 3.6242 s 3.6497 s]
- change: [-0.5168% +0.7281% +1.8151%] (p = 0.26 > 0.05)
- No change in performance detected.

nova_generic_commit_u16_16777216                                                                          
- time:   [918.21 ms 925.54 ms 937.89 ms]
- time:   [652.97 ms 656.54 ms 661.10 ms]
- change: [-30.127% -29.065% -28.215%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u16_16777216                                                                          
- time:   [200.86 ms 214.33 ms 227.76 ms]
- time:   [184.75 ms 203.64 ms 223.15 ms]
- change: [-15.616% -4.9847% +6.4948%] (p = 0.40 > 0.05)
- No change in performance detected.

halo2curves_commit_u32_16777216                                                                          
- time:   [3.7417 s 3.8109 s 3.8847 s]
- time:   [3.6848 s 3.7268 s 3.7704 s]
- change: [-4.2916% -2.2069% -0.0651%] (p = 0.08 > 0.05)
- No change in performance detected.

nova_generic_commit_u32_16777216                                                                          
- time:   [914.14 ms 916.85 ms 920.32 ms]
- time:   [655.04 ms 660.72 ms 668.06 ms]
- change: [-28.591% -27.936% -27.088%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u32_16777216                                                                          
- time:   [276.89 ms 294.10 ms 316.80 ms]
- time:   [268.45 ms 272.90 ms 278.05 ms]
- change: [-13.921% -7.2089% -1.0795%] (p = 0.06 > 0.05)
- No change in performance detected.

halo2curves_commit_u64_16777216     
- time:   [3.7347 s 3.7703 s 3.8045 s]
- time:   [3.7866 s 3.8382 s 3.8890 s]
- change: [+0.1683% +1.8019% +3.4121%] (p = 0.05 > 0.05)
- No change in performance detected.

nova_generic_commit_u64_16777216                                                                          
- time:   [914.96 ms 916.42 ms 918.14 ms]                                                                     
- time:   [643.56 ms 645.04 ms 646.61 ms]
- change: [-29.827% -29.613% -29.416%] (p = 0.00 < 0.05)
- Performance has improved.

nova_specialized_commit_u64_16777216
- time:   [442.24 ms 463.21 ms 500.45 ms]                                                                          
- time:   [470.59 ms 515.22 ms 562.85 ms]
- change: [-1.2190% +11.227% +25.064%] (p = 0.11 > 0.05)
- No change in performance detected.

halo2curves_commit_random_16777216                                                                          
- time:   [4.0467 s 4.1006 s 4.1526 s]
- time:   [4.0484 s 4.0876 s 4.1341 s]
- change: [-1.9434% -0.3173% +1.3048%] (p = 0.73 > 0.05)
- No change in performance detected.

nova_generic_commit_random_16777216
- time:   [987.63 ms 988.88 ms 990.25 ms]
- time:   [720.52 ms 722.86 ms 724.89 ms]
- change: [-27.158% -26.901% -26.659%] (p = 0.00 < 0.05)
- Performance has improved.