### PR TITLE
Make uint32 and multieq modules public

### DIFF
--- a/src/frontend/gadgets/mod.rs
+++ b/src/frontend/gadgets/mod.rs
@@ -2,8 +2,8 @@
 
 use super::SynthesisError;
 
-mod multieq;
-mod uint32;
+pub mod multieq;
+pub mod uint32;
 
 pub mod boolean;
 pub mod num;

--- a/src/frontend/gadgets/multieq.rs
+++ b/src/frontend/gadgets/multieq.rs
@@ -1,7 +1,10 @@
+//! Gadgets for enforcing multiple equalities in a single constraint.
+
 use ff::PrimeField;
 
 use crate::frontend::{ConstraintSystem, LinearCombination, SynthesisError, Variable};
 
+/// A gadget for efficiently enforcing multiple equalities in a single constraint system.
 #[derive(Debug)]
 pub struct MultiEq<Scalar: PrimeField, CS: ConstraintSystem<Scalar>> {
   cs: CS,
@@ -12,6 +15,7 @@ pub struct MultiEq<Scalar: PrimeField, CS: ConstraintSystem<Scalar>> {
 }
 
 impl<Scalar: PrimeField, CS: ConstraintSystem<Scalar>> MultiEq<Scalar, CS> {
+  /// Creates a new `MultiEq` gadget with the given constraint system.
   pub fn new(cs: CS) -> Self {
     MultiEq {
       cs,
@@ -38,6 +42,8 @@ impl<Scalar: PrimeField, CS: ConstraintSystem<Scalar>> MultiEq<Scalar, CS> {
     self.ops += 1;
   }
 
+  /// Enforces that the given left-hand side and right-hand side linear combinations
+  /// are equal for the specified number of bits.
   pub fn enforce_equal(
     &mut self,
     num_bits: usize,

--- a/src/frontend/gadgets/uint32.rs
+++ b/src/frontend/gadgets/uint32.rs
@@ -41,12 +41,14 @@ impl UInt32 {
     }
   }
 
+  /// Returns the bits of this `UInt32` in big-endian order
   pub fn into_bits_be(self) -> Vec<Boolean> {
     let mut ret = self.bits;
     ret.reverse();
     ret
   }
 
+  /// Constructs a `UInt32` from a slice of 32 `Boolean` bits in big-endian order.
   pub fn from_bits_be(bits: &[Boolean]) -> Self {
     assert_eq!(bits.len(), 32);
 
@@ -75,6 +77,7 @@ impl UInt32 {
     }
   }
 
+  /// Returns a new `UInt32` with its bits rotated right by `by` positions.
   pub fn rotr(&self, by: usize) -> Self {
     let by = by % 32;
 
@@ -93,6 +96,7 @@ impl UInt32 {
     }
   }
 
+  /// Returns a new `UInt32` with its bits shifted right by `by` positions, filling with zeros.
   pub fn shr(&self, by: usize) -> Self {
     let by = by % 32;
 


### PR DESCRIPTION
- Added documentation comments to fix missing_docs errors
- Tested with a [Nova-based SHA256 circuit](https://github.com/avras/nova-sha256)

Fixes #389 