### PR TITLE
Update SECURITY.md with correct Microsoft vulnerability definition link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://www.microsoft.com/en-us/msrc/definition-of-a-security-vulnerability), please report it to us as described below.
 
 ## Reporting Security Issues
 


### PR DESCRIPTION
Replaced the outdated and non-working link to Microsoft’s definition of a security vulnerability with the official and current URL: https://www.microsoft.com/en-us/msrc/definition-of-a-security-vulnerability. This ensures users are directed to the authoritative source for security vulnerability criteria. No other content was changed.