### PR TITLE
Implement performance improvements to the HyperKZG evaluation engine prove's `kzg_open_batch` closure

### DIFF
--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -745,9 +745,9 @@ where
 
       let scalar_vector_muladd = |a: &mut Vec<E::Scalar>, v: &Vec<E::Scalar>, s: E::Scalar| {
         assert!(a.len() >= v.len());
-        for i in 0..v.len() {
-          a[i] += s * v[i];
-        }
+        a.par_iter_mut().zip(v.par_iter()).for_each(|(a_i, v_i)| {
+          *a_i += s * *v_i;
+        });
       };
 
       let kzg_compute_batch_polynomial = |f: &[Vec<E::Scalar>], q: E::Scalar| -> Vec<E::Scalar> {

--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -732,15 +732,13 @@ where
                           transcript: &mut <E as Engine>::TE|
      -> (Vec<G1Affine<E>>, Vec<[E::Scalar; 3]>) {
       let poly_eval = |f: &[E::Scalar], u: E::Scalar| -> E::Scalar {
-        let mut v = f[0];
-        let mut u_power = E::Scalar::ONE;
-
-        for fi in f.iter().skip(1) {
-          u_power *= u;
-          v += u_power * fi;
+        // Horner's method
+        let mut acc = E::Scalar::ZERO;
+        for &fi in f.iter().rev() {
+          acc = acc * u + fi;
         }
 
-        v
+        acc
       };
 
       let scalar_vector_muladd = |a: &mut Vec<E::Scalar>, v: &Vec<E::Scalar>, s: E::Scalar| {


### PR DESCRIPTION
There are some opportunities for performance improvements in the `kzg_open_batch` closure found in the HyperKZG `EvaluationEngine` `Prove` method. Specifically:

- `poly_eval` can use Horner's method for polynomial evaluation
- `scalar_vector_muladd` does not rely on previous calculations, so it can be done in parallel using `rayon`

Criterion benchmarks performed on a `Standard NC96ads A100 v4` machine, not using GPU acceleration, indicate that `ppsnark` showed the largest performance gains while `CompressedSNARK` and `RecursiveSNARK` showed no signification regression of improvements. Results of the benchmarks are in comments below.