### PR TITLE
Update the HyperKZG prover's  `compute_witness_polynomial` with a chunk-based Horner algorithm

### DIFF
--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -758,11 +758,11 @@ where
                 *e += prev_partial;
               }
             });
-          result
+          result[1..].to_vec()
         };
 
       let target_chunks = DEFAULT_TARGET_CHUNKS;
-      let h = &div_by_monomial(f, u, target_chunks)[1..];
+      let h = &div_by_monomial(f, u, target_chunks);
 
       E::CE::commit(ck, h, &E::Scalar::ZERO).comm.affine()
     };

--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -40,6 +40,9 @@ type G1Affine<E> = <<E as Engine>::GE as DlogGroup>::AffineGroupElement;
 /// Alias to points on G1 that are in preprocessed form
 type G2Affine<E> = <<<E as Engine>::GE as PairingGroup>::G2 as DlogGroup>::AffineGroupElement;
 
+/// Default number of target chunks used in splitting up polynomial division in the kzg_open closure
+const DEFAULT_TARGET_CHUNKS: usize = 1 << 10;
+
 /// KZG commitment key
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommitmentKey<E: Engine>
@@ -758,7 +761,7 @@ where
           result
         };
 
-      let target_chunks = 1 << 10;
+      let target_chunks = DEFAULT_TARGET_CHUNKS;
       let h = &div_by_monomial(f, u, target_chunks)[1..];
 
       E::CE::commit(ck, h, &E::Scalar::ZERO).comm.affine()

--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -728,7 +728,7 @@ where
           let log2_chunk_size = target_chunk_size.max(1).ilog2();
           let chunk_size = 1 << log2_chunk_size;
 
-          let u_to_the_chunk_size = (0..log2_chunk_size).fold(u, |u_pow, _| u_pow * u_pow);
+          let u_to_the_chunk_size = (0..log2_chunk_size).fold(u, |u_pow, _| u_pow.square());
           let mut result = f.to_vec();
           result
             .par_chunks_mut(chunk_size)

--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -725,10 +725,10 @@ where
         |f: &[E::Scalar], u: E::Scalar, target_chunks: usize| -> Vec<E::Scalar> {
           assert!(!f.is_empty());
           let target_chunk_size = f.len() / target_chunks;
-          let nu = target_chunk_size.max(1).ilog2();
-          let chunk_size = 1 << nu;
+          let log2_chunk_size = target_chunk_size.max(1).ilog2();
+          let chunk_size = 1 << log2_chunk_size;
 
-          let u_to_the_chunk_size = (0..nu).fold(u, |u_pow, _| u_pow * u_pow);
+          let u_to_the_chunk_size = (0..log2_chunk_size).fold(u, |u_pow, _| u_pow * u_pow);
           let mut result = f.to_vec();
           result
             .par_chunks_mut(chunk_size)


### PR DESCRIPTION
# Overview
HyperKZG prove's  `kzg_open` closure has `compute_witness_polynomial` which uses Horner's method to compute a witness polynomial. The prover already uses `kzg_open` in a parallel iterator, but the number of iterations is always 3. The `div_by_monomial` implementation uses this limit to its advantage by performing a chunked Horner's method, spreading the computation over more than 3 cores.

Note, `div_by_monomial` does add additional operations. The trade off is that more than 3 cores will be in use. 

# Benchmarks
Internal Jaeger benchmarks show a 1.24x speed up on a Standard NC96ads A100 v4 when using GPU accelerated code. 

Nova main, `kzg_open` took 178.05ms.
![image](https://github.com/user-attachments/assets/e1ddfa47-b505-410e-921c-469c2606c4a5)

This PR, `kzg_open` took 143.1ms - 1.24x speed up of `kzg_open`.
![image](https://github.com/user-attachments/assets/42400bb5-c574-435b-8493-26ffbe3d2c5d)

Criterion benchmarks show an improvement using the GPU on the Standard NC96ads A100 v4. The results are in comments in this PR.