### PR TITLE
Updates actions/checkout to the latest stable version v4

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build
         uses: actions-rs/toolchain@v1
         with:
@@ -27,7 +27,7 @@ jobs:
   build-wasm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Wasm build
         uses: actions-rs/toolchain@v1
         with:
@@ -41,7 +41,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Run tests
         uses: actions-rs/toolchain@v1
         with:
@@ -54,7 +54,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Check Rustfmt Code Style
         uses: actions-rs/toolchain@v1
         with:
@@ -68,7 +68,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Check clippy warnings
         uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
Updates actions/checkout to the latest stable version v4.

Changes:

Updates all instances of actions/checkout@v2 to actions/checkout@v4

Reference:
Latest version confirmation: https://github.com/actions/checkout/releases/tag/v4.2.2

This update ensures we're using the most recent stable version of the GitHub checkout action across our CI/CD pipelines.