### PR TITLE
feat: bump halo2curves to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ ff = { version = "0.13.0", features = ["derive"] }
 digest = "0.10"
 sha3 = "0.10"
 rayon = "1.10"
-rand_core = { version = "0.6", default-features = false }
+rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 rand_chacha = "0.3"
 subtle = "2.6.1"
-halo2curves = { version = "0.8.0", features = ["bits", "derive_serde"] }
+halo2curves = { version = "0.9.0", features = ["std", "bits", "derive_serde"] }
 generic-array = "1.2.0"
 num-bigint = { version = "0.4.6", features = ["serde", "rand"] }
 num-traits = "0.2.19"


### PR DESCRIPTION
halo2curves 0.9.0 can be easily used in WASM so it is a good idea to bump it.