### PR TITLE
fix(r1cs): make SparseMatrix::iter() safe for empty matrices and leading-zero rows

### DIFF
--- a/src/r1cs/sparse.rs
+++ b/src/r1cs/sparse.rs
@@ -108,15 +108,25 @@ impl<F: PrimeField> SparseMatrix<F> {
 
   /// returns a custom iterator
   pub fn iter(&self) -> Iter<'_, F> {
+    let nnz = *self.indptr.last().unwrap();
+    if nnz == 0 {
+      return Iter {
+        matrix: self,
+        row: 0,
+        i: 0,
+        nnz,
+      };
+    }
+
     let mut row = 0;
-    while self.indptr[row + 1] == 0 {
+    while row + 1 < self.indptr.len() && self.indptr[row + 1] == 0 {
       row += 1;
     }
     Iter {
       matrix: self,
       row,
       i: 0,
-      nnz: *self.indptr.last().unwrap(),
+      nnz,
     }
   }
 }


### PR DESCRIPTION
 Ensure SparseMatrix::iter() handles empty matrices and matrices with leading empty rows without panicking. The iterator now short-circuits when nnz == 0 and advances row with a boundary check on indptr, preventing out-of-bounds access and aligning behavior with existing callers that expect an empty iterator for empty matrices.