### PR TITLE
Remove unused random scalar draw in NIFSRelaxed::prove

### DIFF
--- a/src/nova/nifs.rs
+++ b/src/nova/nifs.rs
@@ -148,7 +148,6 @@ impl<E: Engine> NIFSRelaxed<E> {
 
     // compute a commitment to the cross-term
     let r_T = E::Scalar::random(&mut OsRng);
-    E::Scalar::random(&mut OsRng);
     let (T, comm_T) = S.commit_T_relaxed(ck, U1, W1, U2, W2, &r_T)?;
 
     // append `comm_T` to the transcript and obtain a challenge


### PR DESCRIPTION
- Delete redundant E::Scalar::random(&mut OsRng) call not used.
- Aligns with commit_T_relaxed API which requires only r_T.