### PR TITLE
docs: improve HASHER_BASE constant readability and documentation

### DIFF
--- a/src/frontend/gadgets/poseidon/sponge/api.rs
+++ b/src/frontend/gadgets/poseidon/sponge/api.rs
@@ -40,8 +40,10 @@ impl IOPattern {
   }
 }
 
-// A large 128-bit prime, per https://primes.utm.edu/lists/2small/100bit.html.
-const HASHER_BASE: u128 = (0 - 159) as u128;
+// Large 128-bit constant for sponge construction hashing.
+// Using 2^128 - 159, which provides good distribution properties
+// for the hasher state computation in sponge operations.
+const HASHER_BASE: u128 = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFu128 - 158;
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct Hasher {


### PR DESCRIPTION
Replace cryptic (0 - 159) as u128 expression with explicit hex constant and add detailed documentation explaining the constant's role in sponge construction hashing. Maintains exact same value for compatibility with existing tests.