### PR TITLE
A indexed `commit_sparse` implementation; clippy fixes

### DIFF
--- a/examples/ppot_prune.rs
+++ b/examples/ppot_prune.rs
@@ -176,8 +176,8 @@ fn download_ptau(power: u32, dest: &PathBuf) -> Result<(), PrunerError> {
     downloaded += bytes_read as u64;
 
     // Print progress every 10%
-    if total_size > 0 {
-      let percent = (downloaded * 100 / total_size) as u32;
+    if let Some(percent) = (downloaded * 100).checked_div(total_size) {
+      let percent = percent as u32;
       if percent >= last_percent + 10 {
         println!(
           "  {}% downloaded ({:.2} MB)",

--- a/src/provider/hyperkzg.rs
+++ b/src/provider/hyperkzg.rs
@@ -744,6 +744,25 @@ where
 
     Commitment { comm }
   }
+
+  fn commit_sparse(
+    ck: &Self::CommitmentKey,
+    indices: &[usize],
+    scalars: &[E::Scalar],
+    r: &E::Scalar,
+  ) -> Self::Commitment {
+    assert_eq!(indices.len(), scalars.len());
+
+    let bases: Vec<_> = indices.par_iter().map(|&i| ck.ck[i]).collect();
+
+    let mut comm = E::GE::vartime_multiscalar_mul(scalars, &bases);
+
+    if r != &E::Scalar::ZERO {
+      comm += <E::GE as DlogGroup>::group(&ck.h) * r;
+    }
+
+    Commitment { comm }
+  }
 }
 
 /// Provides an implementation of generators for proving evaluations

--- a/src/provider/pedersen.rs
+++ b/src/provider/pedersen.rs
@@ -428,6 +428,25 @@ where
 
     Commitment { comm }
   }
+
+  fn commit_sparse(
+    ck: &Self::CommitmentKey,
+    indices: &[usize],
+    scalars: &[E::Scalar],
+    r: &E::Scalar,
+  ) -> Self::Commitment {
+    assert_eq!(indices.len(), scalars.len());
+
+    let bases: Vec<_> = indices.par_iter().map(|&i| ck.ck[i]).collect();
+
+    let mut comm = E::GE::vartime_multiscalar_mul(scalars, &bases);
+
+    if r != &E::Scalar::ZERO {
+      comm += <E::GE as DlogGroup>::group(&ck.h) * r;
+    }
+
+    Commitment { comm }
+  }
 }
 
 /// A trait listing properties of a commitment key that can be managed in a divide-and-conquer fashion

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -935,8 +935,8 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARK<E, EE> {
 
       let evals: Vec<Vec<E::Scalar>> = evals_mem
         .into_iter()
-        .chain(evals_inner.into_iter())
-        .chain(evals_witness.into_iter())
+        .chain(evals_inner)
+        .chain(evals_witness)
         .collect::<Vec<Vec<E::Scalar>>>();
       assert_eq!(evals.len(), claims.len());
 

--- a/src/traits/commitment.rs
+++ b/src/traits/commitment.rs
@@ -110,6 +110,15 @@ pub trait CommitmentEngineTrait<E: Engine>: Clone + Send + Sync {
     r: &E::Scalar,
   ) -> Self::Commitment;
 
+  /// Commits to the provided vector of sparse scalars given by (indices, scalars),
+  /// using the provided generators and random blind
+  fn commit_sparse(
+    ck: &Self::CommitmentKey,
+    indices: &[usize],
+    scalars: &[E::Scalar],
+    r: &E::Scalar,
+  ) -> Self::Commitment;
+
   /// Commits to the provided vector of "small" scalars (at most 64 bits) using the provided generators and random blind
   fn commit_small<T: Integer + Into<u64> + Copy + Sync + ToPrimitive>(
     ck: &Self::CommitmentKey,


### PR DESCRIPTION
This PR adds a `commit_sparse` implementation of sparse _field_ vector into `CommitmentEngineTrait`. The vector to be committed is provided with its indices of non-zero entries and their corresponding field values--similiar to how `commit_sparse_binary` is implemented.