### PR TITLE
docs: fix minor comment typos

### DIFF
--- a/benches/ppsnark.rs
+++ b/benches/ppsnark.rs
@@ -49,7 +49,7 @@ fn bench_ppsnark(c: &mut Criterion) {
     let (pk, vk) =
       DirectSNARK::<E, S, NonTrivialCircuit<<E as Engine>::Scalar>>::setup(c.clone()).unwrap();
 
-    // Bench time to produce a  ppSNARK;
+    // Bench time to produce a ppSNARK;
     group.bench_function("Prove", |b| {
       b.iter(|| {
         let res = DirectSNARK::prove(

--- a/src/frontend/gadgets/poseidon/circuit2.rs
+++ b/src/frontend/gadgets/poseidon/circuit2.rs
@@ -65,7 +65,7 @@ impl<Scalar: PrimeField> Elt<Scalar> {
     }
   }
 
-  /// Get the [`LinearCombination`]  of the Elt.
+  /// Get the [`LinearCombination`] of the Elt.
   pub fn lc(&self) -> LinearCombination<Scalar> {
     match self {
       Self::Num(num) => num.lc(Scalar::ONE),

--- a/src/frontend/gadgets/poseidon/preprocessing.rs
+++ b/src/frontend/gadgets/poseidon/preprocessing.rs
@@ -74,7 +74,7 @@ pub(crate) fn compress_round_constants<F: PrimeField>(
   // Everything in here is dev-driven testing.
   // Dev test case only checks one deep.
   if partial_preprocessed == 1 {
-    // Check assumptions about how the fold calculating round_acc  manifested.
+    // Check assumptions about how the fold calculating round_acc manifested.
 
     // The last round containing unpreprocessed constants which should be compressed.
     let terminal_constants_round = half_full_rounds + partial_rounds;

--- a/src/frontend/gadgets/poseidon/sponge/api.rs
+++ b/src/frontend/gadgets/poseidon/sponge/api.rs
@@ -1,4 +1,4 @@
-/// This module implements a variant of the 'Secure Sponge API for Field Elements':  https://hackmd.io/bHgsH6mMStCVibM_wYvb2w
+/// This module implements a variant of the 'Secure Sponge API for Field Elements': https://hackmd.io/bHgsH6mMStCVibM_wYvb2w
 ///
 /// The API is defined by the `SpongeAPI` trait, which is implemented in terms of the `InnerSpongeAPI` trait.
 /// `Neptune` provides implementations of `InnerSpongeAPI` for both `sponge::Sponge` and `sponge_circuit::SpongeCircuit`.

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -234,12 +234,12 @@ where
     // lambda = (other.y - self.y) * (other.x - self.x).invert().unwrap();
     //************************************************************************/
     // First compute (other.x - self.x).inverse()
-    // If either self or other are the infinity point or self.x = other.x  then compute bogus values
+    // If either self or other are the infinity point or self.x = other.x then compute bogus values
     // Specifically,
     // x_diff = self != inf && other != inf && self.x == other.x ? (other.x - self.x) : 1
 
     // Compute self.is_infinity OR other.is_infinity =
-    // NOT(NOT(self.is_ifninity) AND NOT(other.is_infinity))
+    // NOT(NOT(self.is_infinity) AND NOT(other.is_infinity))
     let at_least_one_inf = AllocatedNum::alloc(cs.namespace(|| "at least one inf"), || {
       Ok(
         E::Base::ONE

--- a/src/nova/circuit/r1cs.rs
+++ b/src/nova/circuit/r1cs.rs
@@ -82,7 +82,7 @@ impl<E: Engine> AllocatedRelaxedR1CSInstance<E> {
     )?;
 
     // u << |E::Base| despite the fact that u is a scalar.
-    // So we parse all of its bytes as a E::Base element
+    // So we parse all of its bytes as an E::Base element
     let u = alloc_scalar_as_base::<E, _>(cs.namespace(|| "allocate u"), inst.map(|inst| inst.u))?;
 
     // Allocate X0 and X1. If the input instance is None, then allocate default values 0.


### PR DESCRIPTION
Fix a few minor typos and spacing issues in comments.

This only updates documentation comments and inline comments. No code behavior is changed.
