### PR TITLE
 feat(ppsnark): improve ppsnark memory-check with Logup-GKR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,5 +94,8 @@ flamegraph = ["pprof2/flamegraph", "pprof2/criterion"]
 experimental = []
 evm = []
 io = []
+# Use the original inverse-logup memory-check in ppSNARK instead of Logup-GKR.
+# Default (feature off) uses the Logup-GKR memory-check.
+logup-no-gkr = []
 # Enables insecure setup methods that generate random tau. Only for testing!
 test-utils = []

--- a/benches/sumcheckeq.rs
+++ b/benches/sumcheckeq.rs
@@ -4,7 +4,7 @@
 use criterion::*;
 use nova_snark::{
   provider::Bn256EngineKZG,
-  spartan::{ppsnark::MemorySumcheckInstance, SumcheckEngine},
+  spartan::{mem_check_logup::MemorySumcheckInstance, SumcheckEngine},
   traits::Engine,
 };
 use rayon::iter::{IntoParallelIterator, ParallelIterator};

--- a/src/frontend/gadgets/num.rs
+++ b/src/frontend/gadgets/num.rs
@@ -228,7 +228,7 @@ impl<Scalar: PrimeField> AllocatedNum<Scalar> {
             cs.namespace(|| format!("run ending at {i}")),
             &current_run,
           )?);
-          current_run.truncate(0);
+          current_run.clear();
         }
 
         // If `last_run` is true, `a` must be false, or it would

--- a/src/frontend/test_shape_cs.rs
+++ b/src/frontend/test_shape_cs.rs
@@ -141,7 +141,7 @@ where
     let mut s = String::new();
 
     for input in &self.inputs {
-      writeln!(s, "INPUT {}", &input).unwrap()
+      writeln!(s, "INPUT {}", input).unwrap()
     }
 
     let negone = -<E::Scalar>::ONE;
@@ -174,10 +174,10 @@ where
 
         match var.0.get_unchecked() {
           Index::Input(i) => {
-            write!(s, "`I{}`", &self.inputs[i]).unwrap();
+            write!(s, "`I{}`", self.inputs[i]).unwrap();
           }
           Index::Aux(i) => {
-            write!(s, "`A{}`", &self.aux[i]).unwrap();
+            write!(s, "`A{}`", self.aux[i]).unwrap();
           }
         }
       }

--- a/src/spartan/logup_gkr/fraction.rs
+++ b/src/spartan/logup_gkr/fraction.rs
@@ -1,0 +1,95 @@
+//! Projective fraction arithmetic for the Logup-GKR fractional-sum tree.
+//!
+//! A fraction `num/den` is kept in projective form so the GKR circuit never
+//! performs a field inversion: the fraction-add gate combines two children
+//! `(n_l, d_l)` and `(n_r, d_r)` into `(n_l·d_r + n_r·d_l, d_l·d_r)`. This is the
+//! root of why Logup-GKR avoids the inverse-polynomial commitments that the
+//! current ppSNARK memory-check pays for.
+
+use crate::traits::evm_serde::{CustomSerdeTrait, EvmCompatSerde};
+use core::iter::Sum;
+use core::ops::Add;
+use ff::Field;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+/// A projective fraction `numerator / denominator` over the engine scalar field.
+///
+/// Equality of the represented rationals is cross-multiplicative
+/// (`a/b == c/d` iff `a·d == c·b`); this type does not normalize.
+#[serde_as]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "F: CustomSerdeTrait")]
+pub struct Fraction<F: Field> {
+  /// Numerator.
+  #[serde_as(as = "EvmCompatSerde")]
+  pub num: F,
+  /// Denominator.
+  #[serde_as(as = "EvmCompatSerde")]
+  pub den: F,
+}
+
+impl<F: Field> Fraction<F> {
+  /// Creates a new projective fraction `num/den`.
+  pub fn new(num: F, den: F) -> Self {
+    Self { num, den }
+  }
+
+  /// The additive identity `0/1` for projective fraction addition.
+  pub fn zero() -> Self {
+    Self {
+      num: F::ZERO,
+      den: F::ONE,
+    }
+  }
+}
+
+/// Projective fraction addition (the 2-to-1 gate): `a/b + c/d = (a·d + c·b)/(b·d)`.
+///
+/// `Fraction` is `Copy`, so `+` takes values with no cost.
+impl<F: Field> Add for Fraction<F> {
+  type Output = Self;
+
+  fn add(self, rhs: Self) -> Self {
+    Self {
+      num: self.num * rhs.den + rhs.num * self.den,
+      den: self.den * rhs.den,
+    }
+  }
+}
+
+/// Sum of a sequence of fractions, folding from the identity `0/1`. Lets a whole
+/// tree level be reduced with `.sum()`.
+impl<F: Field> Sum for Fraction<F> {
+  fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+    iter.fold(Self::zero(), |a, b| a + b)
+  }
+}
+
+#[cfg(all(test, feature = "evm"))]
+mod evm_serde_tests {
+  use super::Fraction;
+  use crate::traits::Engine;
+
+  type E = crate::provider::Bn256EngineKZG;
+  type Fr = <E as Engine>::Scalar;
+
+  #[test]
+  fn fraction_has_big_endian_scalar_golden_encoding() {
+    let fraction = Fraction::new(Fr::from(1), Fr::from(2));
+    let config = bincode::config::legacy()
+      .with_big_endian()
+      .with_fixed_int_encoding();
+    let bytes = bincode::serde::encode_to_vec(fraction, config).expect("serialize fraction");
+
+    let mut expected = [0u8; 64];
+    expected[31] = 1;
+    expected[63] = 2;
+    assert_eq!(bytes, expected);
+
+    let (decoded, consumed): (Fraction<Fr>, usize) =
+      bincode::serde::decode_from_slice(&bytes, config).expect("deserialize fraction");
+    assert_eq!(decoded, fraction);
+    assert_eq!(consumed, expected.len());
+  }
+}

--- a/src/spartan/logup_gkr/layer.rs
+++ b/src/spartan/logup_gkr/layer.rs
@@ -1,0 +1,215 @@
+//! Layer type for the Logup-GKR fractional-sum tree.
+//!
+//! One [`Layer`] is a single level of a tree: two multilinear polynomials
+//! (numerator, denominator). The same type serves the input layer, every
+//! internal layer, and the output layer — they differ only in height (the
+//! coefficient length halves each level, `N → N/2 → … → 1`). The same `Layer`
+//! type serves all levels, with no separate input/output variants.
+//!
+//! ppSNARK constructs separate table and access input layers for each of its row
+//! and column relations. Their leaves are `(num, den) = (ts, T+r)` on a table
+//! side and `(-1, W+r)` on an access side.
+//!
+//! # Endianness (critical): MSB-first, pairs are `i` and `i+n`
+//! Nova's MLEs are **MSB-first** (`bind_poly_var_top` folds the top variable by
+//! `split_at(len/2)`). So a level's two children are the halves `x[i]` (top bit
+//! 0) and `x[i+n]` (top bit 1), `n = len/2` — NOT `x[2i]` / `x[2i+1]`. Folding
+//! this way keeps the tree consistent with Nova's sumcheck round order
+//! (`eval_point` challenges bind MSB→LSB), so the GKR point matches the sumcheck
+//! point.
+
+use crate::spartan::logup_gkr::fraction::Fraction;
+use crate::spartan::polys::multilinear::MultilinearPolynomial;
+use crate::spartan::polys::multilinear::MultilinearPolynomial as MLE;
+use crate::traits::Engine;
+use rayon::prelude::*;
+
+/// Parallelize `fold_up` only above this many output cells. A fold cell is a
+/// few field multiplications, so rayon's scheduling overhead dominates on
+/// smaller layers. This threshold is intentionally higher than the crate's
+/// `PARALLEL_THRESHOLD`, which is tuned for more expensive per-element curve
+/// operations such as MSMs.
+const FOLD_PARALLEL_THRESHOLD: usize = 1 << 16;
+
+/// One level of a fractional-sum tree: parallel numerator and denominator
+/// multilinear polynomials over `{0,1}^{log len}`.
+///
+/// Storage is **two** MLEs. The "left/right" children the fraction gate consumes
+/// are the two halves of these MLEs (`x[i]` and `x[i+n]`, `n = len/2`; MSB-first,
+/// see module docs), read during the fold. So a layer holds 2 polynomials; a
+/// per-layer *claim* exposes 4 values (`nL, nR, dL, dR`; see
+/// `proof::LayerFinalClaim`). Do not confuse the two.
+///
+/// Invariant: `num.len() == den.len()` and both lengths are a power of two.
+///
+/// # Numerator/denominator convention (read before constructing)
+/// `num` is the **signed weight** side (`ts` on a table side, `-1` on an access
+/// side); `den` is the **fingerprint** side (`T+r` / `W+r`, never
+/// inverted). To make an accidental swap impossible, this type has **no
+/// positional constructor**: build it with field-init syntax so `num`/`den` are
+/// named explicitly, e.g. `Layer { num: ts, den: t_plus_r }`.
+pub struct Layer<E: Engine> {
+  /// Numerator = signed weight (`ts` on a table side, `-1` on an access side).
+  pub num: MultilinearPolynomial<E::Scalar>,
+  /// Denominator = fingerprint (`T+r` / `W+r`), never inverted.
+  pub den: MultilinearPolynomial<E::Scalar>,
+}
+
+impl<E: Engine> Layer<E> {
+  /// Number of hypercube variables of this layer (`log2(len)`).
+  pub fn num_vars(&self) -> usize {
+    self.num.get_num_vars()
+  }
+
+  /// True when the layer has collapsed to a single cell (the output/root).
+  pub fn is_output(&self) -> bool {
+    self.num.len() == 1
+  }
+
+  /// Folds this layer one level up via the fraction-add gate, MSB-first: the two
+  /// children of output cell `i` are the halves `i` (top bit 0) and `i+n` (top
+  /// bit 1), `n = len/2`. Returns the parent layer of half the height.
+  ///
+  /// `(num[i]/den[i]) + (num[i+n]/den[i+n]) =
+  ///   ((num[i]·den[i+n] + num[i+n]·den[i]) / (den[i]·den[i+n]))`
+  pub fn fold_up(&self) -> Self {
+    let len = self.num.len();
+    debug_assert_eq!(len, self.den.len());
+    debug_assert!(len >= 2 && len.is_power_of_two());
+    let n = len / 2;
+
+    // Each output cell i is the fraction-add of the two MSB-halves (child cells
+    // i and i+n) — independent across i, so parallelize above the threshold.
+    let fold = |i: usize| -> (E::Scalar, E::Scalar) {
+      let child = Fraction::new(self.num.Z[i], self.den.Z[i])
+        + Fraction::new(self.num.Z[i + n], self.den.Z[i + n]);
+      (child.num, child.den)
+    };
+
+    let (next_num, next_den): (Vec<_>, Vec<_>) = if n < FOLD_PARALLEL_THRESHOLD {
+      (0..n).map(fold).unzip()
+    } else {
+      (0..n).into_par_iter().map(fold).unzip()
+    };
+
+    Self {
+      num: MLE::new(next_num),
+      den: MLE::new(next_den),
+    }
+  }
+
+  /// Builds the full tree from this input layer, leaf→root. Result has
+  /// `log2(len) + 1` entries; `[0]` is the input layer, the last is the single
+  /// output cell.
+  pub fn build_tree(self) -> Vec<Self> {
+    let depth = self.num.get_num_vars() + 1;
+    let mut layers = Vec::with_capacity(depth);
+    let mut cur = self;
+    loop {
+      if cur.is_output() {
+        layers.push(cur);
+        break;
+      }
+      let next = cur.fold_up();
+      layers.push(cur);
+      cur = next;
+    }
+    layers
+  }
+
+  /// The output cell's fraction `(num, den)` as a two-element claim vector,
+  /// used to seed the verifier's fold-down (`initial_claims`).
+  pub fn output_fraction(&self) -> (E::Scalar, E::Scalar) {
+    debug_assert!(self.is_output());
+    (self.num.Z[0], self.den.Z[0])
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::provider::Bn256EngineKZG;
+  use ff::Field;
+
+  type E = Bn256EngineKZG;
+  type Fr = <E as Engine>::Scalar;
+
+  // Reference: the rational sum Σ num[i]/den[i] as a single reduced fraction,
+  // computed with real field inversion (only for the test oracle).
+  fn ref_sum(num: &[Fr], den: &[Fr]) -> (Fr, Fr) {
+    // accumulate as projective fraction a/b + c/d = (ad+cb, bd)
+    let mut acc = (Fr::ZERO, Fr::ONE);
+    for i in 0..num.len() {
+      acc = (acc.0 * den[i] + num[i] * acc.1, acc.1 * den[i]);
+    }
+    acc
+  }
+
+  // Cross-multiplication equality for projective fractions.
+  fn frac_eq((n0, d0): (Fr, Fr), (n1, d1): (Fr, Fr)) -> bool {
+    n0 * d1 == n1 * d0
+  }
+
+  fn layer_from(num: Vec<u64>, den: Vec<u64>) -> Layer<E> {
+    Layer {
+      num: MultilinearPolynomial::new(num.into_iter().map(Fr::from).collect()),
+      den: MultilinearPolynomial::new(den.into_iter().map(Fr::from).collect()),
+    }
+  }
+
+  #[test]
+  fn fold_up_matches_reference_n4() {
+    let num = vec![1u64, 2, 3, 4];
+    let den = vec![5u64, 6, 7, 8];
+    let l = layer_from(num.clone(), den.clone());
+    let tree = l.build_tree();
+    assert_eq!(tree.len(), 3); // 2 vars → depth 3
+    let root = tree.last().unwrap().output_fraction();
+    let expected = ref_sum(
+      &num.iter().map(|&x| Fr::from(x)).collect::<Vec<_>>(),
+      &den.iter().map(|&x| Fr::from(x)).collect::<Vec<_>>(),
+    );
+    assert!(
+      frac_eq(root, expected),
+      "tree root fraction must equal the reference rational sum"
+    );
+  }
+
+  #[test]
+  fn fold_up_matches_reference_n8() {
+    let num: Vec<u64> = vec![3, 1, 4, 1, 5, 9, 2, 6];
+    let den: Vec<u64> = vec![2, 7, 1, 8, 2, 8, 1, 8];
+    let l = layer_from(num.clone(), den.clone());
+    let tree = l.build_tree();
+    assert_eq!(tree.len(), 4);
+    let root = tree.last().unwrap().output_fraction();
+    let expected = ref_sum(
+      &num.iter().map(|&x| Fr::from(x)).collect::<Vec<_>>(),
+      &den.iter().map(|&x| Fr::from(x)).collect::<Vec<_>>(),
+    );
+    assert!(frac_eq(root, expected));
+  }
+
+  #[test]
+  fn logup_balance_gives_zero_numerator() {
+    // A balanced multiset: table {a,b} with multiplicities {1,1}, lookups {a,b}.
+    // Σ 1/(α-a) + 1/(α-b) - 1/(α-a) - 1/(α-b) = 0. Encode as one instance's
+    // input layer with num = [+1,+1,-1,-1], den = [α-a, α-b, α-a, α-b].
+    let alpha = Fr::from(100);
+    let a = Fr::from(7);
+    let b = Fr::from(9);
+    let num = vec![Fr::ONE, Fr::ONE, -Fr::ONE, -Fr::ONE];
+    let den = vec![alpha - a, alpha - b, alpha - a, alpha - b];
+    let l = Layer::<E> {
+      num: MultilinearPolynomial::new(num),
+      den: MultilinearPolynomial::new(den),
+    };
+    let root = l.build_tree().last().unwrap().output_fraction();
+    assert_eq!(
+      root.0,
+      Fr::ZERO,
+      "balanced logup must have zero root numerator"
+    );
+    assert_ne!(root.1, Fr::ZERO, "root denominator must be non-zero");
+  }
+}

--- a/src/spartan/logup_gkr/mod.rs
+++ b/src/spartan/logup_gkr/mod.rs
@@ -1,0 +1,37 @@
+//! Logup-GKR fractional-sum memory-check argument.
+//!
+//! Replaces the inverse-logup memory-check in `ppsnark.rs` (the
+//! `MemorySumcheckInstance` 6-route sumcheck + 4 inverse-polynomial
+//! commitments) with four equal-height fractional-sum GKR trees: the table and
+//! access sides of the row and column relations. Projective fractions keep the
+//! circuit inversion-free and eliminate the four inverse-polynomial
+//! commitments.
+//!
+//! ## Module map
+//! - [`fraction`]: projective fraction + 2-to-1 gate (pure).
+//! - [`layer`]: the `Layer` type (one tree level: num/den MLEs).
+//! - [`proof`]: proof/claim interface.
+//! - [`prover`]: fold-up + batched sumcheck prover.
+//! - [`verifier`]: fold-down + root check, emits the shared opening claim.
+//!
+//! ## Boundary with ppSNARK (host reconcile contract)
+//! The argument owns no commitment scheme. Its verifier returns a
+//! [`proof::LogupGkrOpeningClaim`]: a single shared `eval_point` plus the
+//! four input-layer fractions `openings`, ordered `[row_table, row_access,
+//! col_table, col_access]`. The **host** then:
+//! 1. rerandomizes the seven claimed columns `[L_row, L_col, addr_row, addr_col,
+//!    ts_row, ts_col, mem_col]` from `eval_point` into the inner sumcheck and
+//!    binds them at `r_inner_batched` through the batched PCS opening;
+//! 2. recomputes the four fractions from those claims (`num = ts` on the table
+//!    sides, `num = -1` on the access sides) and checks them against `openings`;
+//! 3. runs the `0/den` zero-sum balance check.
+//!
+//! Steps 2-3 are the host's job, never the GKR verifier's.
+
+pub mod fraction;
+pub mod layer;
+pub mod proof;
+pub mod prover;
+pub mod verifier;
+
+pub use proof::{LogupGkrOpeningClaim, LogupGkrProof};

--- a/src/spartan/logup_gkr/proof.rs
+++ b/src/spartan/logup_gkr/proof.rs
@@ -1,0 +1,136 @@
+//! Proof objects for the Logup-GKR fractional-sum argument.
+//!
+//! # One batched proof over equal-height trees
+//! Each input [`Layer`](super::layer::Layer) defines a separate fractional-sum
+//! tree. All inputs must already have the same number of variables; the prover
+//! does not pad them. At each depth, the corresponding tree layers are batched
+//! into one sumcheck via a fresh `λ`, producing one shared evaluation point for
+//! all trees. Their claims are carried in a single proof rather than separate
+//! per-tree proofs. Sumcheck round polynomials use Nova's `CompressedUniPoly`.
+
+use crate::spartan::logup_gkr::fraction::Fraction;
+use crate::spartan::polys::univariate::CompressedUniPoly;
+use crate::traits::Engine;
+use serde::{Deserialize, Serialize};
+
+/// `rlc(a, b, r) = a + r·(b - a)` — the two-to-one fold of split claims.
+#[inline(always)]
+fn rlc<F: ff::Field>(a: F, b: F, r: F) -> F {
+  a + r * (b - a)
+}
+
+/// A claim about one instance's column pair after a layer: the fraction
+/// `num/den`.
+pub type LayerClaim<E> = Fraction<<E as Engine>::Scalar>;
+
+/// The split (even/odd) final claim of one instance at one layer: the `left`
+/// and `right` child fractions `(nL,dL)` and `(nR,dR)`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct LayerFinalClaim<E: Engine> {
+  /// Left child `(nL, dL)`.
+  pub left: Fraction<E::Scalar>,
+  /// Right child `(nR, dR)`.
+  pub right: Fraction<E::Scalar>,
+}
+
+impl<E: Engine> LayerFinalClaim<E> {
+  /// Builds from the four folded sumcheck evaluations `nL, nR, dL, dR`.
+  ///
+  /// WARNING: the layer sumcheck's `bound_evals` come out **interleaved** as
+  /// `[nL, dR, nR, dL]` (matching the flattened virtual-polynomial order
+  /// `numerator_left, denominator_right, numerator_right, denominator_left`).
+  /// Map them explicitly — `new(evals[0], evals[2], evals[3], evals[1])` —
+  /// never slice `evals[0..4]` into the parameters positionally.
+  pub fn new(nL: E::Scalar, nR: E::Scalar, dL: E::Scalar, dR: E::Scalar) -> Self {
+    Self {
+      left: Fraction::new(nL, dL),
+      right: Fraction::new(nR, dR),
+    }
+  }
+
+  /// Folds the split claim into the next layer's claim via `rlc` at `r`.
+  pub fn fold_into_next_claim(&self, r: E::Scalar) -> LayerClaim<E> {
+    Fraction::new(
+      rlc(self.left.num, self.right.num, r),
+      rlc(self.left.den, self.right.den, r),
+    )
+  }
+
+  /// The gate output `left + right` (projective fraction add).
+  pub fn compute_gate(&self) -> Fraction<E::Scalar> {
+    self.left + self.right
+  }
+}
+
+/// Sumcheck transcript for one batched tree layer: one compressed round
+/// polynomial per variable (the instances are batched into this single
+/// sumcheck via `λ`).
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct LayerSumcheck<E: Engine> {
+  /// Compressed round polynomials, one per sumcheck round of this layer.
+  pub round_polys: Vec<CompressedUniPoly<E::Scalar>>,
+}
+
+/// A single **batched** Logup-GKR proof over all input instances.
+///
+/// Instance-indexed vectors preserve the caller's input order; ppSNARK uses
+/// `[row_table, row_access, col_table, col_access]`. `initial_claims` are the
+/// per-instance output-layer fractions (observed first). `final_claims[layer]`
+/// holds one split claim per instance; `sumchecks[layer]` is the one batched
+/// sumcheck for that layer. Layers are ordered output→input, and the top
+/// transition (0-variable layer) carries no sumcheck, so
+/// `sumchecks.len() + 1 == final_claims.len()`.
+///
+/// The per-layer batching challenge `λ` is **not** stored here: it is a
+/// Fiat-Shamir challenge the verifier re-samples fresh at each layer (reusing
+/// one `λ` across layers would let the prover adaptively forge each layer's
+/// claims). Likewise `initial_claims` are not bound to committed data by this
+/// proof alone; soundness closes at the host's reconcile step, where the
+/// returned `openings` must match the fractions reconstructed from the host's
+/// claimed column evaluations at `eval_point`.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct LogupGkrProof<E: Engine> {
+  /// Per-instance output-layer claims (the root fractions before fold-down).
+  pub initial_claims: Vec<LayerClaim<E>>,
+  /// Per-layer, per-instance split final claims, output→input.
+  pub final_claims: Vec<Vec<LayerFinalClaim<E>>>,
+  /// Per-layer batched sumcheck (one fewer than `final_claims`).
+  pub sumchecks: Vec<LayerSumcheck<E>>,
+}
+
+/// Verifier output — a **continuation token** carrying the shared opening
+/// claim, with its point field named Nova's `eval_point`.
+///
+/// The host uses [`Self::eval_point`] to seed the opening-point reduction and
+/// uses `openings` to reconcile every reduced input-layer fraction against its
+/// claimed columns. The ppSNARK host also performs the `0/den` zero-sum check;
+/// neither operation belongs to the GKR verifier.
+#[derive(Clone, Debug)]
+pub struct LogupGkrOpeningClaim<E: Engine> {
+  eval_point: Vec<E::Scalar>,
+  openings: Vec<Fraction<E::Scalar>>,
+}
+
+impl<E: Engine> LogupGkrOpeningClaim<E> {
+  /// Constructs the token (only the GKR verifier should call this).
+  pub fn new(eval_point: Vec<E::Scalar>, openings: Vec<Fraction<E::Scalar>>) -> Self {
+    Self {
+      eval_point,
+      openings,
+    }
+  }
+
+  /// The shared evaluation point to which all input-layer claims are reduced.
+  pub fn eval_point(&self) -> &[E::Scalar] {
+    &self.eval_point
+  }
+
+  /// The reduced input-layer fractions in caller input order, which the host
+  /// reconstructs from its claimed column evaluations and compares against.
+  pub fn openings(&self) -> &[Fraction<E::Scalar>] {
+    &self.openings
+  }
+}

--- a/src/spartan/logup_gkr/prover.rs
+++ b/src/spartan/logup_gkr/prover.rs
@@ -1,9 +1,7 @@
 //! Prover for the Logup-GKR fractional-sum argument.
 //!
-//! **This prover satisfies the verifier.** The protocol — transcript order,
-//! challenge labels, and the per-layer sumcheck contract — is defined in
-//! `verifier.rs`; this file produces a proof the verifier accepts, importing the
-//! verifier's `spec` labels and `absorb_fraction` rather than restating them.
+//! Implements the prover side of the Logup-GKR protocol defined in
+//! `verifier.rs`, sharing its transcript labels and fraction-absorption order.
 //!
 //! It builds one equal-height tree per input, folds them leaf→root, and for each
 //! internal depth runs one transparent cubic sumcheck
@@ -44,10 +42,9 @@ use crate::spartan::logup_gkr::verifier::{absorb_fraction, spec};
 ///
 /// The `eq(τ, ·)` factor is handled by the shared `EqSumCheckInstance`
 /// (Gruen eq-factoring, eprint 2024/108: half-size eq tables + O(1) per-round
-/// bind), and each round polynomial is built from 2 N-scaling sums via BDDT
-/// claim derivation (eprint 2025/1117 §6.2) — `t(0)` and `t(∞)`, with `s(-1)`
-/// derived from the running claim. This matches the verifier's reconciliation
-/// of the final value as the transparent `eq(τ,r) · G(r)`.
+/// bind), and BDDT claim derivation (eprint 2025/1117 §6.2). The four-instance
+/// path reuses the preceding layer's left claims for round-0 `t(0)`, so that
+/// round scans only for `t(∞)`; later rounds normally scan for both values.
 ///
 /// The four half-MLEs are passed struct-of-arrays (`nl`/`nr`/`dl`/`dr`, one
 /// entry per instance) so the eq instance can index them directly. Returns the
@@ -56,7 +53,8 @@ use crate::spartan::logup_gkr::verifier::{absorb_fraction, spec};
 ///
 /// ppSNARK's four-sub-instance path caches each top-variable delta during
 /// evaluation and reuses it during binding; other instance counts retain the
-/// general non-mutating evaluation path.
+/// general non-mutating evaluation path. `previous_finals` must be the preceding
+/// parent reduction's claims in the same instance order as the four MLE slices.
 #[allow(clippy::type_complexity)]
 fn prove_layer_sumcheck<E: Engine>(
   claim: E::Scalar,
@@ -66,6 +64,7 @@ fn prove_layer_sumcheck<E: Engine>(
   dl: &mut [MultilinearPolynomial<E::Scalar>],
   dr: &mut [MultilinearPolynomial<E::Scalar>],
   lambda: E::Scalar,
+  previous_finals: &[LayerFinalClaim<E>],
   transcript: &mut E::TE,
 ) -> Result<
   (
@@ -101,11 +100,40 @@ fn prove_layer_sumcheck<E: Engine>(
     })
     .collect();
 
-  for _ in 0..num_rounds {
+  // The preceding layer's left claims are this layer's round-0 t(0)
+  // evaluations at `taus[1..]`.
+  let round0_t_0 = cache_deltas.then(|| {
+    assert_eq!(previous_finals.len(), m);
+    previous_finals
+      .iter()
+      .zip(&weights)
+      .map(|(fc, (w_num, w_den))| *w_num * fc.left.num + *w_den * fc.left.den)
+      .sum()
+  });
+
+  for round in 0..num_rounds {
     // Round polynomial s(X) = eq(τ,X) · G(X), degree 3. BDDT derivation returns
     // (s(0), cubic coeff, s(-1)); the verifier reconstructs s(1) = claim - s(0).
     let (s_0, s_cubic, s_m1) = if cache_deltas {
-      eq.evaluation_points_logup_gate_and_cache_deltas(nl, nr, dl, dr, &weights, claim_per_round)
+      match (round, round0_t_0) {
+        (0, Some(t_0)) => eq.evaluation_points_logup_gate_and_cache_deltas_with_t_0(
+          nl,
+          nr,
+          dl,
+          dr,
+          &weights,
+          t_0,
+          claim_per_round,
+        ),
+        _ => eq.evaluation_points_logup_gate_and_cache_deltas(
+          nl,
+          nr,
+          dl,
+          dr,
+          &weights,
+          claim_per_round,
+        ),
+      }
     } else {
       eq.evaluation_points_logup_gate(nl, nr, dl, dr, &weights, claim_per_round)
     };
@@ -235,6 +263,9 @@ pub fn prove<E: Engine>(
     } else {
       // Sumcheck over (num_vars - j) variables. The 2m sub-claims are batched by
       // distinct powers of λ (Horner over [p_0,q_0,p_1,q_1,...]) — see verifier.
+      let previous_finals = final_claims_by_layer
+        .last()
+        .expect("every sumcheck layer follows a completed parent reduction");
       let claim: E::Scalar = {
         let mut acc = E::Scalar::ZERO;
         let mut pw = E::Scalar::ONE;
@@ -273,6 +304,7 @@ pub fn prove<E: Engine>(
         &mut dl,
         &mut dr,
         lambda,
+        previous_finals,
         transcript,
       )?;
 
@@ -337,10 +369,6 @@ mod tests {
     MultilinearPolynomial::new(v.into_iter().map(Fr::from).collect())
   }
 
-  fn frac_eq(n0: Fr, d0: Fr, n1: Fr, d1: Fr) -> bool {
-    n0 * d1 == n1 * d0
-  }
-
   // Full prove→verify round trip: the verifier must accept, and its returned
   // openings must equal the prover's actual input-layer fractions at the shared
   // evaluation point.
@@ -364,7 +392,8 @@ mod tests {
     let mut tr_v = <E as Engine>::TE::new(b"gkr-test");
     let vclaim = verifier::verify::<E>(&proof, &mut tr_v).expect("verify");
 
-    // Verifier's eval_point and openings must match the prover's.
+    // The verifier point must match the prover point; opening components must
+    // match direct input-MLE evaluations there.
     assert_eq!(
       vclaim.eval_point(),
       claim.eval_point(),
@@ -375,10 +404,8 @@ mod tests {
       let en = n.evaluate(pt);
       let ed = d.evaluate(pt);
       let op = vclaim.openings()[i];
-      assert!(
-        frac_eq(en, ed, op.num, op.den),
-        "opening[{i}] must equal input layer fraction at eval_point"
-      );
+      assert_eq!(op.num, en, "opening[{i}] numerator mismatch");
+      assert_eq!(op.den, ed, "opening[{i}] denominator mismatch");
     }
   }
 
@@ -402,6 +429,24 @@ mod tests {
       (vec![3, 1, 4, 1, 5, 9, 2, 6], vec![2, 7, 1, 8, 2, 8, 1, 8]),
       (vec![1, 1, 1, 1, 1, 1, 1, 1], vec![3, 1, 4, 1, 5, 9, 2, 6]),
     ]);
+  }
+
+  // Exercises cached sumchecks with 1-4 rounds and both eq-factor branches.
+  #[test]
+  fn round_trip_four_instances_n32() {
+    let gen = |seed: u64| -> (Vec<u64>, Vec<u64>) {
+      let mut s = seed.wrapping_mul(0x9e3779b97f4a7c15).wrapping_add(1);
+      let mut next = || {
+        s = s
+          .wrapping_mul(6364136223846793005)
+          .wrapping_add(1442695040888963407);
+        (s >> 33) | 1
+      };
+      let num = (0..32).map(|_| next()).collect();
+      let den = (0..32).map(|_| next()).collect();
+      (num, den)
+    };
+    round_trip(vec![gen(5), gen(6), gen(7), gen(8)]);
   }
 
   #[test]

--- a/src/spartan/logup_gkr/prover.rs
+++ b/src/spartan/logup_gkr/prover.rs
@@ -1,0 +1,459 @@
+//! Prover for the Logup-GKR fractional-sum argument.
+//!
+//! **This prover satisfies the verifier.** The protocol — transcript order,
+//! challenge labels, and the per-layer sumcheck contract — is defined in
+//! `verifier.rs`; this file produces a proof the verifier accepts, importing the
+//! verifier's `spec` labels and `absorb_fraction` rather than restating them.
+//!
+//! It builds one equal-height tree per input, folds them leaf→root, and for each
+//! internal depth runs one transparent cubic sumcheck
+//! (`prove_layer_sumcheck`) reducing the merged fraction-sum claim to the next
+//! layer.
+//!
+//! ## Per-layer gate (the verifier's contract)
+//! A layer proves, for all instances batched by a per-layer `λ`,
+//! `Σ_i (v_p_i + λ v_q_i) = Σ_x eq(τ,x) · Σ_i [nL·dR + nR·dL + λ·dL·dR]_i`.
+//! The `eq(τ, ·)` factor is carried as an explicit MLE so the sumcheck's final
+//! value reconciles as the verifier demands: `eq(τ,r)·G(r)`. Round polynomials
+//! are degree 3 (`eq` deg 1 × gate deg 2 = `spec::LAYER_SC_DEGREE`).
+//!
+//! ## Endianness
+//! The tree folds MSB-first (`Layer::fold_up`, halves `i`/`i+n`), and the
+//! sumcheck binds the top variable first, so the sumcheck point is directly the
+//! fraction evaluation point of the next layer.
+
+use crate::errors::NovaError;
+use crate::spartan::logup_gkr::layer::Layer;
+use crate::spartan::logup_gkr::proof::{
+  LayerClaim, LayerFinalClaim, LayerSumcheck, LogupGkrOpeningClaim, LogupGkrProof,
+};
+use crate::spartan::polys::multilinear::MultilinearPolynomial;
+use crate::traits::{Engine, TranscriptEngineTrait};
+use ff::Field;
+use rayon::prelude::*;
+
+// The prover satisfies the protocol defined by the verifier: it uses the
+// verifier's transcript labels (`spec`) and fraction-absorb order, and produces
+// a sumcheck whose final value reconciles as `eq(τ,r)·G(r)` (the verifier's
+// contract).
+use crate::spartan::logup_gkr::verifier::{absorb_fraction, spec};
+
+/// Transparent cubic sumcheck for one GKR layer, proving
+/// `claim = Σ_x eq(τ, x) · Σ_i [ nLᵢ·dRᵢ + nRᵢ·dLᵢ + λ·dLᵢ·dRᵢ ](x)`
+/// over `num_rounds = |τ|` variables.
+///
+/// The `eq(τ, ·)` factor is handled by the shared `EqSumCheckInstance`
+/// (Gruen eq-factoring, eprint 2024/108: half-size eq tables + O(1) per-round
+/// bind), and each round polynomial is built from 2 N-scaling sums via BDDT
+/// claim derivation (eprint 2025/1117 §6.2) — `t(0)` and `t(∞)`, with `s(-1)`
+/// derived from the running claim. This matches the verifier's reconciliation
+/// of the final value as the transparent `eq(τ,r) · G(r)`.
+///
+/// The four half-MLEs are passed struct-of-arrays (`nl`/`nr`/`dl`/`dr`, one
+/// entry per instance) so the eq instance can index them directly. Returns the
+/// compressed round polynomials, the sumcheck point `r`, and each instance's
+/// `(nL, nR, dL, dR)` evaluated at `r`.
+///
+/// ppSNARK's four-sub-instance path caches each top-variable delta during
+/// evaluation and reuses it during binding; other instance counts retain the
+/// general non-mutating evaluation path.
+#[allow(clippy::type_complexity)]
+fn prove_layer_sumcheck<E: Engine>(
+  claim: E::Scalar,
+  taus: &[E::Scalar],
+  nl: &mut [MultilinearPolynomial<E::Scalar>],
+  nr: &mut [MultilinearPolynomial<E::Scalar>],
+  dl: &mut [MultilinearPolynomial<E::Scalar>],
+  dr: &mut [MultilinearPolynomial<E::Scalar>],
+  lambda: E::Scalar,
+  transcript: &mut E::TE,
+) -> Result<
+  (
+    Vec<crate::spartan::polys::univariate::CompressedUniPoly<E::Scalar>>,
+    Vec<E::Scalar>,
+    Vec<[E::Scalar; 4]>,
+  ),
+  NovaError,
+> {
+  use crate::spartan::polys::univariate::{CompressedUniPoly, UniPoly};
+  use crate::spartan::sumcheck::eq_sumcheck::EqSumCheckInstance;
+
+  let num_rounds = taus.len();
+  let m = nl.len();
+
+  let mut r: Vec<E::Scalar> = Vec::with_capacity(num_rounds);
+  let mut polys: Vec<CompressedUniPoly<E::Scalar>> = Vec::with_capacity(num_rounds);
+  let mut claim_per_round = claim;
+
+  let mut eq = EqSumCheckInstance::<E>::new(taus.to_vec());
+  let cache_deltas = m == 4;
+
+  // Per-instance λ-powers: instance i's numerator gets λ^{2i}, denominator
+  // λ^{2i+1}. λ^{2i} accumulates by a running product (O(m) muls) instead of
+  // per-instance pow_vartime.
+  let mut w_num = E::Scalar::ONE;
+  let weights: Vec<(E::Scalar, E::Scalar)> = (0..m)
+    .map(|_| {
+      let w_den = w_num * lambda;
+      let pair = (w_num, w_den);
+      w_num = w_den * lambda;
+      pair
+    })
+    .collect();
+
+  for _ in 0..num_rounds {
+    // Round polynomial s(X) = eq(τ,X) · G(X), degree 3. BDDT derivation returns
+    // (s(0), cubic coeff, s(-1)); the verifier reconstructs s(1) = claim - s(0).
+    let (s_0, s_cubic, s_m1) = if cache_deltas {
+      eq.evaluation_points_logup_gate_and_cache_deltas(nl, nr, dl, dr, &weights, claim_per_round)
+    } else {
+      eq.evaluation_points_logup_gate(nl, nr, dl, dr, &weights, claim_per_round)
+    };
+
+    let poly = UniPoly::from_evals_deg3(&[s_0, claim_per_round - s_0, s_cubic, s_m1]);
+
+    transcript.absorb(spec::ROUND_POLY, &poly);
+    let r_i = transcript.squeeze(spec::ROUND_CHALLENGE)?;
+    r.push(r_i);
+    polys.push(poly.compress());
+    claim_per_round = poly.evaluate(&r_i);
+
+    // Bind the top variable of every half-MLE (eq binds in O(1) via the instance).
+    nl.par_iter_mut()
+      .chain(nr.par_iter_mut())
+      .chain(dl.par_iter_mut())
+      .chain(dr.par_iter_mut())
+      .for_each(|p| {
+        if cache_deltas {
+          p.bind_poly_var_top_with_cached_delta(&r_i);
+        } else {
+          p.bind_poly_var_top(&r_i);
+        }
+      });
+    eq.bound(&r_i);
+  }
+
+  let _ = claim_per_round;
+  let finals: Vec<[E::Scalar; 4]> = (0..m)
+    .map(|i| [nl[i].Z[0], nr[i].Z[0], dl[i].Z[0], dr[i].Z[0]])
+    .collect();
+  Ok((polys, r, finals))
+}
+
+/// Proves the fractional-sum identity `Σ p/q = root` for all equal-height input
+/// trees in one batched proof, returning the proof and the shared opening claim.
+///
+/// `inputs` holds one input [`Layer`] per instance. Every layer must have the
+/// same positive `num_vars`, so every coefficient vector has the same
+/// power-of-two length of at least two. The soundness invariant is to absorb
+/// every root and layer claim before sampling the challenge that depends on it;
+/// `initial_claims` and each layer's `final_claims` enforce this order.
+pub fn prove<E: Engine>(
+  inputs: Vec<Layer<E>>,
+  transcript: &mut E::TE,
+) -> Result<(LogupGkrProof<E>, LogupGkrOpeningClaim<E>), NovaError> {
+  let m = inputs.len();
+  if m == 0 {
+    return Err(NovaError::InvalidNumInstances);
+  }
+  let num_vars = inputs[0].num_vars();
+  if num_vars == 0 {
+    // A single-cell input has nothing to fold; the argument needs height ≥ 2.
+    return Err(NovaError::InvalidSumcheckProof);
+  }
+  for inp in &inputs {
+    if inp.num_vars() != num_vars {
+      return Err(NovaError::InvalidSumcheckProof);
+    }
+  }
+
+  // Build every instance's tree, leaf→root. trees[instance][layer], where
+  // trees[i][j] has (num_vars - j) variables; [0] = input, [num_vars] = root.
+  //
+  // Memory: layers are consumed root→leaf (step j reads layer j-1, for
+  // j = num_vars … 1), which is exactly descending index. So each tree is drained
+  // via `pop()` — the just-proven layer is dropped the instant it is consumed,
+  // instead of every layer staying live for the whole proof. Peak during the
+  // sumcheck loop drops from ~3N to ~N per instance (the build itself is still
+  // bottom-up, so the transient right after `build_tree` is unavoidable).
+  let mut trees: Vec<Vec<Layer<E>>> = inputs.into_iter().map(|l| l.build_tree()).collect();
+
+  // initial_claims = each instance's output (root) fraction, absorbed first. The
+  // root layer (index num_vars, a single cell) is popped and dropped here; only
+  // its two scalars survive in `initial_claims`.
+  let initial_claims: Vec<LayerClaim<E>> = trees
+    .iter_mut()
+    .map(|t| {
+      let root = t.pop().expect("tree has a root layer");
+      let (n, d) = root.output_fraction();
+      LayerClaim::<E>::new(n, d)
+    })
+    .collect();
+  for c in &initial_claims {
+    absorb_fraction::<E>(transcript, *c);
+  }
+
+  // Running per-instance claims (v_p_i, v_q_i) about `layers[j]` at `eval_point`.
+  // Start at the root (j = num_vars, empty point).
+  let mut running: Vec<(E::Scalar, E::Scalar)> =
+    initial_claims.iter().map(|c| (c.num, c.den)).collect();
+  let mut eval_point: Vec<E::Scalar> = Vec::new();
+
+  // Ordered output→input as we go: step j reduces a claim about layers[j] to
+  // layers[j-1], for j = num_vars, num_vars-1, ..., 1.
+  let mut sumchecks: Vec<LayerSumcheck<E>> = Vec::with_capacity(num_vars.saturating_sub(1));
+  let mut final_claims_by_layer: Vec<Vec<LayerFinalClaim<E>>> = Vec::with_capacity(num_vars);
+
+  for j in (1..=num_vars).rev() {
+    // Fresh λ per layer, after the previous claims were absorbed.
+    let lambda = transcript.squeeze(spec::LAMBDA)?;
+
+    // Children are the two halves of layers[j-1] (which has num_vars-j+1 vars,
+    // so each half has num_vars-j vars). nL/nR = num halves, dL/dR = den halves.
+    // Pop layer j-1 off each tree: the loop consumes layers strictly root→leaf
+    // (descending index), so once popped, layer j-1 is never read again and its
+    // buffers can be moved into the sumcheck (and dropped at end of iteration).
+    let mut children: Vec<Layer<E>> = trees.iter_mut().map(|t| t.pop().unwrap()).collect();
+    let child_len = 1usize << (num_vars - j + 1);
+    let n = child_len / 2;
+
+    // final claims (nL, nR, dL, dR) per instance for this layer.
+    let mut layer_finals: Vec<LayerFinalClaim<E>> = Vec::with_capacity(m);
+
+    if num_vars - j == 0 {
+      // Base case (j = num_vars, root reduction): the child layer has exactly
+      // two cells; read the split directly, no sumcheck.
+      for c in &children {
+        layer_finals.push(LayerFinalClaim::<E>::new(
+          c.num.Z[0], // nL
+          c.num.Z[1], // nR
+          c.den.Z[0], // dL
+          c.den.Z[1], // dR
+        ));
+      }
+      let _ = (lambda, n); // λ unused at the base (single term, no batching)
+    } else {
+      // Sumcheck over (num_vars - j) variables. The 2m sub-claims are batched by
+      // distinct powers of λ (Horner over [p_0,q_0,p_1,q_1,...]) — see verifier.
+      let claim: E::Scalar = {
+        let mut acc = E::Scalar::ZERO;
+        let mut pw = E::Scalar::ONE;
+        for (p, q) in &running {
+          acc += pw * *p;
+          pw *= lambda;
+          acc += pw * *q;
+          pw *= lambda;
+        }
+        acc
+      };
+
+      // Half-MLEs struct-of-arrays: nL/nR = numerator halves, dL/dR = den halves.
+      // Move the child buffers into the halves (split each Z at n) instead of
+      // cloning: `children` is dropped at the end of this iteration anyway.
+      let mut nl: Vec<MultilinearPolynomial<E::Scalar>> = Vec::with_capacity(m);
+      let mut nr: Vec<MultilinearPolynomial<E::Scalar>> = Vec::with_capacity(m);
+      let mut dl: Vec<MultilinearPolynomial<E::Scalar>> = Vec::with_capacity(m);
+      let mut dr: Vec<MultilinearPolynomial<E::Scalar>> = Vec::with_capacity(m);
+      for c in children.drain(..) {
+        let mut num_z = c.num.Z;
+        let mut den_z = c.den.Z;
+        let num_hi = num_z.split_off(n);
+        let den_hi = den_z.split_off(n);
+        nl.push(MultilinearPolynomial::new(num_z));
+        nr.push(MultilinearPolynomial::new(num_hi));
+        dl.push(MultilinearPolynomial::new(den_z));
+        dr.push(MultilinearPolynomial::new(den_hi));
+      }
+
+      let (round_polys, r, finals) = prove_layer_sumcheck::<E>(
+        claim,
+        &eval_point,
+        &mut nl,
+        &mut nr,
+        &mut dl,
+        &mut dr,
+        lambda,
+        transcript,
+      )?;
+
+      for f in &finals {
+        layer_finals.push(LayerFinalClaim::<E>::new(f[0], f[1], f[2], f[3]));
+      }
+      sumchecks.push(LayerSumcheck { round_polys });
+      eval_point = r; // sumcheck point (length num_vars - j)
+    }
+
+    // Absorb final claims, sample fold challenge, update running claims + point.
+    for fc in &layer_finals {
+      absorb_fraction::<E>(transcript, fc.left);
+      absorb_fraction::<E>(transcript, fc.right);
+    }
+    let fold_r = transcript.squeeze(spec::FOLD)?;
+
+    running = layer_finals
+      .iter()
+      .map(|fc| {
+        let c = fc.fold_into_next_claim(fold_r);
+        (c.num, c.den)
+      })
+      .collect();
+    // New point for layers[j-1] is [fold_r, ...sumcheck_point] (fold_r as MSB).
+    let mut next_point = Vec::with_capacity(eval_point.len() + 1);
+    next_point.push(fold_r);
+    next_point.extend_from_slice(&eval_point);
+    eval_point = next_point;
+
+    final_claims_by_layer.push(layer_finals);
+  }
+
+  // Proof is ordered output→input (the order we produced).
+  // openings = each instance's input-layer fraction at the final eval_point
+  // (length num_vars); equals the last running claim by construction.
+  let openings: Vec<LayerClaim<E>> = running
+    .iter()
+    .map(|(n, d)| LayerClaim::<E>::new(*n, *d))
+    .collect();
+
+  let proof = LogupGkrProof {
+    initial_claims,
+    final_claims: final_claims_by_layer,
+    sumchecks,
+  };
+  let claim = LogupGkrOpeningClaim::new(eval_point, openings);
+  Ok((proof, claim))
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::spartan::logup_gkr::verifier;
+  use crate::spartan::polys::multilinear::MultilinearPolynomial;
+  use crate::traits::TranscriptEngineTrait;
+
+  type E = crate::provider::Bn256EngineKZG;
+  type Fr = <E as Engine>::Scalar;
+
+  fn mle(v: Vec<u64>) -> MultilinearPolynomial<Fr> {
+    MultilinearPolynomial::new(v.into_iter().map(Fr::from).collect())
+  }
+
+  fn frac_eq(n0: Fr, d0: Fr, n1: Fr, d1: Fr) -> bool {
+    n0 * d1 == n1 * d0
+  }
+
+  // Full prove→verify round trip: the verifier must accept, and its returned
+  // openings must equal the prover's actual input-layer fractions at the shared
+  // evaluation point.
+  fn round_trip(inputs: Vec<(Vec<u64>, Vec<u64>)>) {
+    let layers: Vec<Layer<E>> = inputs
+      .iter()
+      .map(|(n, d)| Layer::<E> {
+        num: mle(n.clone()),
+        den: mle(d.clone()),
+      })
+      .collect();
+    // Keep copies to independently evaluate at the eval_point.
+    let raw: Vec<(MultilinearPolynomial<Fr>, MultilinearPolynomial<Fr>)> = inputs
+      .iter()
+      .map(|(n, d)| (mle(n.clone()), mle(d.clone())))
+      .collect();
+
+    let mut tr_p = <E as Engine>::TE::new(b"gkr-test");
+    let (proof, claim) = prove::<E>(layers, &mut tr_p).expect("prove");
+
+    let mut tr_v = <E as Engine>::TE::new(b"gkr-test");
+    let vclaim = verifier::verify::<E>(&proof, &mut tr_v).expect("verify");
+
+    // Verifier's eval_point and openings must match the prover's.
+    assert_eq!(
+      vclaim.eval_point(),
+      claim.eval_point(),
+      "eval_point mismatch"
+    );
+    let pt = vclaim.eval_point();
+    for (i, (n, d)) in raw.iter().enumerate() {
+      let en = n.evaluate(pt);
+      let ed = d.evaluate(pt);
+      let op = vclaim.openings()[i];
+      assert!(
+        frac_eq(en, ed, op.num, op.den),
+        "opening[{i}] must equal input layer fraction at eval_point"
+      );
+    }
+  }
+
+  // Full prove -> verify round trips over the transparent-eq layer sumcheck.
+  #[test]
+  fn round_trip_single_instance_n4() {
+    round_trip(vec![(vec![1, 2, 3, 4], vec![5, 6, 7, 8])]);
+  }
+
+  #[test]
+  fn round_trip_two_instances_n4() {
+    round_trip(vec![
+      (vec![1, 2, 3, 4], vec![5, 6, 7, 8]),
+      (vec![9, 8, 7, 6], vec![2, 3, 4, 5]),
+    ]);
+  }
+
+  #[test]
+  fn round_trip_two_instances_n8() {
+    round_trip(vec![
+      (vec![3, 1, 4, 1, 5, 9, 2, 6], vec![2, 7, 1, 8, 2, 8, 1, 8]),
+      (vec![1, 1, 1, 1, 1, 1, 1, 1], vec![3, 1, 4, 1, 5, 9, 2, 6]),
+    ]);
+  }
+
+  #[test]
+  fn verify_rejects_tampered_final_claim() {
+    let layers = vec![Layer::<E> {
+      num: mle(vec![1, 2, 3, 4]),
+      den: mle(vec![5, 6, 7, 8]),
+    }];
+    let mut tr_p = <E as Engine>::TE::new(b"gkr-test");
+    let (mut proof, _) = prove::<E>(layers, &mut tr_p).unwrap();
+    // Corrupt one final claim.
+    proof.final_claims[0][0].left.num += Fr::from(1);
+    let mut tr_v = <E as Engine>::TE::new(b"gkr-test");
+    assert!(verifier::verify::<E>(&proof, &mut tr_v).is_err());
+  }
+
+  // Tamper-rejection with m >= 2: mutating per-instance final claims makes the
+  // verifier reject (caught by transcript binding + the gate's bilinearity).
+  #[test]
+  fn verify_rejects_complementary_instance_offset() {
+    let inputs = [
+      (vec![1u64, 2, 3, 4], vec![5u64, 6, 7, 8]),
+      (vec![9u64, 8, 7, 6], vec![2u64, 3, 4, 5]),
+    ];
+    let layers: Vec<Layer<E>> = inputs
+      .iter()
+      .map(|(n, d)| Layer::<E> {
+        num: mle(n.clone()),
+        den: mle(d.clone()),
+      })
+      .collect();
+    let mut tr_p = <E as Engine>::TE::new(b"gkr-test");
+    let (proof_ok, _) = prove::<E>(layers, &mut tr_p).unwrap();
+
+    // Sanity: the honest proof verifies.
+    let mut tr_v0 = <E as Engine>::TE::new(b"gkr-test");
+    assert!(verifier::verify::<E>(&proof_ok, &mut tr_v0).is_ok());
+
+    // Target a SUMCHECK layer (final_claims index >= 1; index 0 is the base
+    // case whose per-instance cross-mult check is not batched). For num_vars=2,
+    // index 1 is the input-layer reduction. Apply a complementary offset to the
+    // two instances' left numerators.
+    let mut proof = proof_ok.clone();
+    assert!(proof.final_claims.len() >= 2 && proof.final_claims[1].len() == 2);
+    let delta = Fr::from(7);
+    proof.final_claims[1][0].left.num += delta;
+    proof.final_claims[1][1].left.num -= delta;
+
+    let mut tr_v = <E as Engine>::TE::new(b"gkr-test");
+    assert!(
+      verifier::verify::<E>(&proof, &mut tr_v).is_err(),
+      "tampered per-instance final claims must be rejected"
+    );
+  }
+}

--- a/src/spartan/logup_gkr/verifier.rs
+++ b/src/spartan/logup_gkr/verifier.rs
@@ -1,0 +1,319 @@
+//! Verifier for the Logup-GKR fractional-sum argument.
+//!
+//! **This file defines the protocol.** It is written independently of any
+//! prover: every check is derived from the GKR fractional-sum argument, and the
+//! Fiat-Shamir transcript order is fixed here by soundness reasoning (see the
+//! module docs below). A prover is correct **iff** it produces a transcript and
+//! claims that make this verifier accept; the prover must satisfy this file, not
+//! the other way around.
+//!
+//! ## What is proven
+//! For each logup instance `i`, an input layer of projective fractions folds
+//! through a binary tree to a single root fraction `(v_p_i, v_q_i)`. The
+//! verifier reduces the per-instance root claims down to a single evaluation of
+//! the input layer at a shared point, checking each tree layer with one batched
+//! sumcheck. It returns that point and the reduced per-instance fractions; the
+//! `0/den` zero-sum balance check is the host's job (this argument owns no PCS).
+//!
+//! ## Layer reduction (the sumcheck contract)
+//! A non-root layer with `t` variables, reduced at evaluation point `τ`
+//! (`|τ| = t`), carries a per-instance running claim `(v_p_i, v_q_i)`. The
+//! verifier samples a fresh batching challenge `λ` and **demands** a sumcheck
+//! proving
+//! ```text
+//!   Σ_i (λ^{2i}·v_p_i + λ^{2i+1}·v_q_i)  =  Σ_x eq(τ, x) · Σ_i G_i(x),
+//!   G_i(x) = λ^{2i}·(nL_i·dR_i + nR_i·dL_i)(x) + λ^{2i+1}·(dL_i·dR_i)(x),
+//! ```
+//! where `(nL_i, nR_i, dL_i, dR_i)` are the num/den halves of instance `i`'s
+//! child layer. The 2m per-instance sub-claims (each instance's numerator and
+//! denominator relation) are batched by **distinct powers of λ** — a Horner
+//! combination over the flattened `[p_0,q_0,p_1,q_1,…]`. This is essential for
+//! soundness with m ≥ 2 instances: a plain `Σ_i (v_p_i + λ·v_q_i)` would expose
+//! only `Σ v_p` and `Σ v_q` (two slots regardless of m), so a prover could shift
+//! one instance's numerator up and another's down and stay undetected. Distinct
+//! λ-powers bind every instance's num and den separately.
+//!
+//! The sumcheck's final value must equal `eq(τ, r)·Σ_i G_i(r)`, reconstructed
+//! here from the prover's claimed `(nL,nR,dL,dR)` at `r`. This is a demand on
+//! the sumcheck backend: whatever the prover uses, its final evaluation must
+//! reconcile transparently against this expression (Nova's
+//! `prove_cubic_with_three_inputs` has this shape; see ppSNARK's outer check).
+//!
+//! ## Fiat-Shamir order (soundness)
+//! The transcript order is chosen so each challenge is unpredictable given the
+//! values it must bind — a prover cannot adaptively forge later messages:
+//! 1. absorb all root claims `(v_p_i, v_q_i)` before anything is sampled;
+//! 2. per layer (root→input): sample `λ` (bound to all prior claims/challenges,
+//!    so the layer's claims cannot be chosen after `λ`), run the layer sumcheck
+//!    (each round absorbs its polynomial then samples), absorb this layer's
+//!    final claims, then sample the fold challenge `r_fold` (bound to those
+//!    claims, so the two children cannot be chosen after `r_fold`).
+//!
+//! Reusing one `λ` across layers, or sampling `r_fold` before the claims it
+//! folds, would each break soundness (adaptive-forgery gaps).
+
+use crate::errors::NovaError;
+use crate::spartan::logup_gkr::fraction::Fraction;
+use crate::spartan::logup_gkr::proof::{LayerClaim, LogupGkrOpeningClaim, LogupGkrProof};
+use crate::spartan::polys::eq::EqPolynomial;
+use crate::spartan::sumcheck::SumcheckProof;
+use crate::traits::{Engine, TranscriptEngineTrait};
+use ff::Field;
+
+/// The protocol's Fiat-Shamir transcript labels and sumcheck degree, defined by
+/// the verifier. The prover must use exactly these.
+pub mod spec {
+  /// Round-polynomial label inside a layer sumcheck.
+  pub const ROUND_POLY: &[u8] = b"p";
+  /// Per-round sumcheck challenge label.
+  pub const ROUND_CHALLENGE: &[u8] = b"c";
+  /// Per-layer batching challenge `λ`.
+  pub const LAMBDA: &[u8] = b"l";
+  /// Per-layer fold challenge.
+  pub const FOLD: &[u8] = b"f";
+  /// Fraction numerator label.
+  pub const NUM: &[u8] = b"n";
+  /// Fraction denominator label.
+  pub const DEN: &[u8] = b"d";
+  /// Degree bound of each layer's batched sumcheck round polynomial:
+  /// `eq` (degree 1) × gate (degree 2) = degree 3.
+  pub const LAYER_SC_DEGREE: usize = 3;
+}
+
+/// Absorbs a fraction `(num, den)` into the transcript, in the order the
+/// protocol fixes. Shared with the prover (which imports this).
+pub fn absorb_fraction<E: Engine>(transcript: &mut E::TE, frac: Fraction<E::Scalar>) {
+  transcript.absorb(spec::NUM, &frac.num);
+  transcript.absorb(spec::DEN, &frac.den);
+}
+
+/// Evaluates `Σ_k coeffs[k] · lambda^k` by Horner's method over the coefficient
+/// stream (lowest power first). Callers flatten their per-instance components
+/// into this order — e.g. the layer sumcheck feeds `[num_0, den_0, num_1,
+/// den_1, ...]`, so instance `i`'s numerator lands on `λ^{2i}` and its
+/// denominator on `λ^{2i+1}` (a distinct power per component; see the layer
+/// comment for why a shared power would be unsound).
+fn horner_eval<F: Field>(coeffs: impl IntoIterator<Item = F>, lambda: F) -> F {
+  let mut acc = F::ZERO;
+  let mut pw = F::ONE;
+  for c in coeffs {
+    acc += pw * c;
+    pw *= lambda;
+  }
+  acc
+}
+
+/// Verifies the batched fractional-sum proof and returns the shared opening
+/// claim (evaluation point + per-instance input-layer fractions). Accepts iff
+/// the proof satisfies the protocol defined in this module.
+pub fn verify<E: Engine>(
+  proof: &LogupGkrProof<E>,
+  transcript: &mut E::TE,
+) -> Result<LogupGkrOpeningClaim<E>, NovaError> {
+  let m = proof.initial_claims.len();
+  if m == 0 {
+    return Err(NovaError::InvalidNumInstances);
+  }
+  // Structural well-formedness: `final_claims` has one entry per reduction step
+  // (num_vars entries). The root reduction (index 0) carries no sumcheck, so
+  // `sumchecks.len() + 1 == final_claims.len()`, and every layer carries one
+  // split claim per instance.
+  let num_vars = proof.final_claims.len();
+  if num_vars == 0 || proof.sumchecks.len() + 1 != num_vars {
+    return Err(NovaError::InvalidSumcheckProof);
+  }
+  if proof.final_claims.iter().any(|layer| layer.len() != m) {
+    return Err(NovaError::InvalidSumcheckProof);
+  }
+
+  // (1) Bind the root claims before any challenge is drawn.
+  for c in &proof.initial_claims {
+    absorb_fraction::<E>(transcript, *c);
+  }
+
+  // running[i] = v_p_i / v_q_i: the claim about the current layer at `point`.
+  let mut running: Vec<LayerClaim<E>> = proof.initial_claims.clone();
+  let mut point: Vec<E::Scalar> = Vec::new();
+
+  // (2) Reduce root → input. Step `t` reduces the layer with `t` variables;
+  // t = 0 is the root reduction (no sumcheck), t >= 1 uses `sumchecks[t-1]`.
+  for (t, layer_finals) in proof.final_claims.iter().enumerate() {
+    let lambda = transcript.squeeze(spec::LAMBDA)?;
+
+    if t == 0 {
+      // Root reduction: the claimed root must equal the fraction-add gate of its
+      // two child cells **component-wise** (`num` and `den` separately).
+      // Cross-multiplication is unsound here: `(0,0)` cross-equals any
+      // `(a,b)`, so a prover could post roots `(0,1)` with all-zero children and
+      // later vacuously pass host reconcile against real columns. HyperPlonk
+      // uses the same exact check; honesty already produces matching MLE
+      // components, so this rejects only degenerate / scaled forgeries.
+      for i in 0..m {
+        let gate = layer_finals[i].compute_gate();
+        let r = running[i];
+        if r.num != gate.num || r.den != gate.den {
+          return Err(NovaError::InvalidSumcheckProof);
+        }
+      }
+    } else {
+      // Layer sumcheck. The 2m per-instance sub-claims are batched by DISTINCT
+      // powers of λ: instance i's numerator gets λ^{2i}, its denominator λ^{2i+1}
+      // (Horner over the flattened `[p_0,q_0,p_1,q_1,...]`). A distinct power per
+      // component binds every instance separately — a plain `Σ_i (p_i + λ q_i)`
+      // would only expose `Σ p` and `Σ q` (two slots regardless of m), letting a
+      // prover offset one instance's numerator up and another's down undetected.
+      let claim: E::Scalar = horner_eval(running.iter().flat_map(|f| [f.num, f.den]), lambda);
+      let sc = SumcheckProof::<E>::new(proof.sumchecks[t - 1].round_polys.clone());
+      // The layer at step `t` has `t` variables, and `point` (its evaluation
+      // point, i.e. the sumcheck's τ) has length `t`.
+      let num_rounds = point.len();
+      let (sc_eval, r) = sc.verify(claim, num_rounds, spec::LAYER_SC_DEGREE, transcript)?;
+
+      // The sumcheck contract: its final value must equal
+      //   eq(τ, r) · Σ_i [ λ^{2i}·gate_i.num + λ^{2i+1}·gate_i.den ]
+      // where gate_i is the fraction-add of instance i's two children.
+      let eq_at_r = EqPolynomial::new(point.clone()).evaluate(&r);
+      let gate_sum: E::Scalar = horner_eval(
+        layer_finals.iter().flat_map(|fc| {
+          let g = fc.compute_gate();
+          [g.num, g.den]
+        }),
+        lambda,
+      );
+      if sc_eval != eq_at_r * gate_sum {
+        return Err(NovaError::InvalidSumcheckProof);
+      }
+      point = r;
+    }
+
+    // Bind this layer's claims, then draw the fold challenge (so the children
+    // cannot be chosen after it), then fold to the next layer's claims/point.
+    for fc in layer_finals {
+      absorb_fraction::<E>(transcript, fc.left);
+      absorb_fraction::<E>(transcript, fc.right);
+    }
+    let r_fold = transcript.squeeze(spec::FOLD)?;
+
+    running = layer_finals
+      .iter()
+      .map(|fc| fc.fold_into_next_claim(r_fold))
+      .collect();
+    // The next layer's point prepends the fold challenge as the new top (MSB)
+    // variable: point' = [r_fold, ...point].
+    let mut next_point = Vec::with_capacity(point.len() + 1);
+    next_point.push(r_fold);
+    next_point.extend_from_slice(&point);
+    point = next_point;
+  }
+
+  Ok(LogupGkrOpeningClaim::new(point, running))
+}
+
+#[cfg(test)]
+mod tests {
+  //! Independence tests: these build a valid proof **by hand** (from the tree
+  //! fold in `layer.rs` plus the transcript spec in this module) with no use of
+  //! the `prover` module, demonstrating that the verifier stands on its own.
+  use super::*;
+  use crate::spartan::logup_gkr::layer::Layer;
+  use crate::spartan::logup_gkr::proof::{LayerFinalClaim, LogupGkrProof};
+  use crate::spartan::polys::multilinear::MultilinearPolynomial;
+
+  type E = crate::provider::Bn256EngineKZG;
+  type Fr = <E as Engine>::Scalar;
+
+  fn mle(v: Vec<u64>) -> MultilinearPolynomial<Fr> {
+    MultilinearPolynomial::new(v.into_iter().map(Fr::from).collect())
+  }
+
+  // Hand-build the proof for a single-instance, 2-leaf tree (num_vars = 1):
+  // only the root reduction (base case) runs — no sumcheck — so the whole proof
+  // is constructible from `layer.rs` alone, following this module's spec.
+  fn hand_built_2leaf(num: Vec<u64>, den: Vec<u64>) -> LogupGkrProof<E> {
+    assert_eq!(num.len(), 2);
+    let input = Layer::<E> {
+      num: mle(num.clone()),
+      den: mle(den.clone()),
+    };
+    let tree = input.build_tree(); // [input(1 var), root(0 var)]
+    let (rn, rd) = tree[1].output_fraction();
+    // Base layer split claim = the two child cells directly (nL,nR,dL,dR).
+    let child = &tree[0];
+    let final_claim = LayerFinalClaim::<E>::new(
+      child.num.Z[0],
+      child.num.Z[1],
+      child.den.Z[0],
+      child.den.Z[1],
+    );
+    LogupGkrProof {
+      initial_claims: vec![LayerClaim::<E>::new(rn, rd)],
+      final_claims: vec![vec![final_claim]],
+      sumchecks: vec![],
+    }
+  }
+
+  #[test]
+  fn verifier_accepts_hand_built_valid_proof() {
+    let proof = hand_built_2leaf(vec![3, 5], vec![7, 11]);
+    let mut tr = <E as Engine>::TE::new(b"gkr-indep");
+    let claim =
+      verify::<E>(&proof, &mut tr).expect("verifier must accept a valid hand-built proof");
+    // One instance, one variable → eval_point has length 1, one opening.
+    assert_eq!(claim.eval_point().len(), 1);
+    assert_eq!(claim.openings().len(), 1);
+  }
+
+  #[test]
+  fn verifier_rejects_wrong_root() {
+    let mut proof = hand_built_2leaf(vec![3, 5], vec![7, 11]);
+    // Corrupt the root claim so it no longer equals the gate of its children.
+    proof.initial_claims[0].num += Fr::from(1);
+    let mut tr = <E as Engine>::TE::new(b"gkr-indep");
+    assert!(verify::<E>(&proof, &mut tr).is_err());
+  }
+
+  #[test]
+  fn verifier_rejects_malformed_shape() {
+    let mut proof = hand_built_2leaf(vec![3, 5], vec![7, 11]);
+    // sumchecks.len() + 1 must equal final_claims.len(); break it.
+    proof
+      .sumchecks
+      .push(crate::spartan::logup_gkr::proof::LayerSumcheck {
+        round_polys: vec![],
+      });
+    let mut tr = <E as Engine>::TE::new(b"gkr-indep");
+    assert!(verify::<E>(&proof, &mut tr).is_err());
+  }
+
+  #[test]
+  fn verifier_rejects_zero_zero_children_of_unit_root() {
+    // P0 forgery fragment: root `(0,1)` with children `(0,0)`. Under
+    // cross-multiplication `0·0 == 0·1` this would pass; exact equality
+    // rejects it. gate = (0,0) ≠ (0,1).
+    let zero = Fraction::new(Fr::ZERO, Fr::ZERO);
+    let proof = LogupGkrProof {
+      initial_claims: vec![Fraction::new(Fr::ZERO, Fr::ONE)],
+      final_claims: vec![vec![LayerFinalClaim {
+        left: zero,
+        right: zero,
+      }]],
+      sumchecks: vec![],
+    };
+    let mut tr = <E as Engine>::TE::new(b"gkr-p0");
+    assert!(
+      verify::<E>(&proof, &mut tr).is_err(),
+      "must reject (0,1) root with (0,0) children"
+    );
+  }
+
+  #[test]
+  fn verifier_rejects_scaled_root() {
+    // Exact equality also rejects a nonzero scale of an otherwise valid gate
+    // (cross-mult would accept).
+    let mut proof = hand_built_2leaf(vec![3, 5], vec![7, 11]);
+    proof.initial_claims[0].num *= Fr::from(2);
+    proof.initial_claims[0].den *= Fr::from(2);
+    let mut tr = <E as Engine>::TE::new(b"gkr-indep");
+    assert!(verify::<E>(&proof, &mut tr).is_err());
+  }
+}

--- a/src/spartan/mem_check_logup.rs
+++ b/src/spartan/mem_check_logup.rs
@@ -1,0 +1,557 @@
+//! Inverse-logup memory-check for ppSNARK (the original Microsoft Nova
+//! implementation).
+//!
+//! Selected when the `logup-no-gkr` feature is enabled; otherwise ppSNARK uses
+//! the Logup-GKR memory-check in [`super::mem_check_logup_gkr`]. This module
+//! holds the pieces specific to the inverse-logup approach — the
+//! [`MemorySumcheckInstance`] (six-route sumcheck proving
+//! `Σ TS[i]/(T[i]+r) − 1/(W[i]+r) = 0` per row/col via committed inverse
+//! oracles) and the [`LogupProofData`] bundle of its proof fields — so they can
+//! be feature-gated out of the SNARK cleanly.
+
+use crate::{
+  errors::NovaError,
+  spartan::{
+    batch_invert,
+    math::Math,
+    polys::{
+      eq::EqPolynomial, identity::IdentityPolynomial, multilinear::MultilinearPolynomial,
+      multilinear::SparsePolynomial,
+    },
+    sumcheck::{eq_sumcheck::EqSumCheckInstance, SumcheckEngine, SumcheckProof},
+  },
+  traits::{
+    commitment::CommitmentEngineTrait, evm_serde::EvmCompatSerde, Engine, TranscriptEngineTrait,
+  },
+  zip_with, Commitment, CommitmentKey,
+};
+use ff::Field;
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+/// The inverse-logup memory-check proof fields carried in the ppSNARK proof:
+/// commitments to the four inverse oracles (`1/(T+r)·TS`, `1/(W+r)` for row/col)
+/// and their evaluations at the shared inner point. Bundled so the SNARK can
+/// gate the whole inverse-logup path behind one field.
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct LogupProofData<E: Engine> {
+  /// Commitment to `TS_row/(T_row+r)`.
+  pub comm_t_plus_r_inv_row: Commitment<E>,
+  /// Commitment to `1/(W_row+r)`.
+  pub comm_w_plus_r_inv_row: Commitment<E>,
+  /// Commitment to `TS_col/(T_col+r)`.
+  pub comm_t_plus_r_inv_col: Commitment<E>,
+  /// Commitment to `1/(W_col+r)`.
+  pub comm_w_plus_r_inv_col: Commitment<E>,
+  /// Evaluation of `TS_row/(T_row+r)` at the inner point.
+  #[serde_as(as = "EvmCompatSerde")]
+  pub eval_t_plus_r_inv_row: E::Scalar,
+  /// Evaluation of `1/(W_row+r)` at the inner point.
+  #[serde_as(as = "EvmCompatSerde")]
+  pub eval_w_plus_r_inv_row: E::Scalar,
+  /// Evaluation of `TS_col/(T_col+r)` at the inner point.
+  #[serde_as(as = "EvmCompatSerde")]
+  pub eval_t_plus_r_inv_col: E::Scalar,
+  /// Evaluation of `1/(W_col+r)` at the inner point.
+  #[serde_as(as = "EvmCompatSerde")]
+  pub eval_w_plus_r_inv_col: E::Scalar,
+}
+
+/// Memory sumcheck instance for PPSNARK LogUp
+pub struct MemorySumcheckInstance<E: Engine> {
+  // row
+  w_plus_r_row: MultilinearPolynomial<E::Scalar>,
+  t_plus_r_row: MultilinearPolynomial<E::Scalar>,
+  t_plus_r_inv_row: MultilinearPolynomial<E::Scalar>,
+  w_plus_r_inv_row: MultilinearPolynomial<E::Scalar>,
+  ts_row: MultilinearPolynomial<E::Scalar>,
+
+  // col
+  w_plus_r_col: MultilinearPolynomial<E::Scalar>,
+  t_plus_r_col: MultilinearPolynomial<E::Scalar>,
+  t_plus_r_inv_col: MultilinearPolynomial<E::Scalar>,
+  w_plus_r_inv_col: MultilinearPolynomial<E::Scalar>,
+  ts_col: MultilinearPolynomial<E::Scalar>,
+
+  eq_sumcheck: EqSumCheckInstance<E>,
+
+  // Per-claim running claims and saved evaluation points (BDDT, eprint 2025/1117 Section 6.2)
+  running_claims: [E::Scalar; 6],
+  saved_evals: [[E::Scalar; 3]; 6],
+}
+
+impl<E: Engine> MemorySumcheckInstance<E> {
+  /// Computes witnesses for MemoryInstanceSumcheck
+  ///
+  /// # Description
+  /// We use the logUp protocol to prove that
+  /// sum TS\[i\]/(T\[i\] + r) - 1/(W\[i\] + r) = 0
+  /// where
+  ///   T_row\[i\] = mem_row\[i\]      * gamma + i
+  ///            = eq(tau)\[i\]      * gamma + i
+  ///   W_row\[i\] = L_row\[i\]        * gamma + addr_row\[i\]
+  ///            = eq(tau)\[row\[i\]\] * gamma + addr_row\[i\]
+  ///   T_col\[i\] = mem_col\[i\]      * gamma + i
+  ///            = z\[i\]            * gamma + i
+  ///   W_col\[i\] = L_col\[i\]     * gamma + addr_col\[i\]
+  ///            = z\[col\[i\]\]       * gamma + addr_col\[i\]
+  /// and
+  ///   TS_row, TS_col are integer-valued vectors representing the number of reads
+  ///   to each memory cell of L_row, L_col
+  ///
+  /// The function returns oracles for the polynomials TS\[i\]/(T\[i\] + r), 1/(W\[i\] + r),
+  /// as well as auxiliary polynomials T\[i\] + r, W\[i\] + r
+  pub fn compute_oracles(
+    ck: &CommitmentKey<E>,
+    r: &E::Scalar,
+    gamma: &E::Scalar,
+    mem_row: &[E::Scalar],
+    addr_row: &[E::Scalar],
+    L_row: &[E::Scalar],
+    ts_row: &[E::Scalar],
+    mem_col: &[E::Scalar],
+    addr_col: &[E::Scalar],
+    L_col: &[E::Scalar],
+    ts_col: &[E::Scalar],
+  ) -> Result<([Commitment<E>; 4], [Vec<E::Scalar>; 4], [Vec<E::Scalar>; 4]), NovaError> {
+    // hash the tuples of (addr,val) memory contents and read responses into a single field element using `hash_func`
+    let hash_func_vec = |mem: &[E::Scalar],
+                         addr: &[E::Scalar],
+                         lookups: &[E::Scalar]|
+     -> (Vec<E::Scalar>, Vec<E::Scalar>) {
+      let hash_func = |addr: &E::Scalar, val: &E::Scalar| -> E::Scalar { *val * gamma + *addr };
+      assert_eq!(addr.len(), lookups.len());
+      rayon::join(
+        || {
+          (0..mem.len())
+            .map(|i| hash_func(&E::Scalar::from(i as u64), &mem[i]))
+            .collect::<Vec<E::Scalar>>()
+        },
+        || {
+          (0..addr.len())
+            .map(|i| hash_func(&addr[i], &lookups[i]))
+            .collect::<Vec<E::Scalar>>()
+        },
+      )
+    };
+
+    let ((T_row, W_row), (T_col, W_col)) = rayon::join(
+      || hash_func_vec(mem_row, addr_row, L_row),
+      || hash_func_vec(mem_col, addr_col, L_col),
+    );
+
+    // compute vectors TS[i]/(T[i] + r) and 1/(W[i] + r)
+    let helper = |T: &[E::Scalar],
+                  W: &[E::Scalar],
+                  TS: &[E::Scalar],
+                  r: &E::Scalar|
+     -> Result<
+      (
+        Vec<E::Scalar>,
+        Vec<E::Scalar>,
+        Vec<E::Scalar>,
+        Vec<E::Scalar>,
+      ),
+      NovaError,
+    > {
+      let t_plus_r_and_w_plus_r = T
+        .par_iter()
+        .chain(W.par_iter())
+        .map(|e| *e + *r)
+        .collect::<Vec<E::Scalar>>();
+
+      let inv = batch_invert(&t_plus_r_and_w_plus_r)?;
+
+      let mut t_plus_r = t_plus_r_and_w_plus_r;
+      let w_plus_r = t_plus_r.split_off(T.len());
+
+      let mut t_plus_r_inv = inv;
+      let w_plus_r_inv = t_plus_r_inv.split_off(T.len());
+
+      // compute inv[i] * TS[i] in parallel
+      t_plus_r_inv = zip_with!((t_plus_r_inv.into_par_iter(), TS.par_iter()), |e1, e2| e1
+        * *e2)
+      .collect::<Vec<_>>();
+
+      Ok((t_plus_r_inv, w_plus_r_inv, t_plus_r, w_plus_r))
+    };
+
+    let (row, col) = rayon::join(
+      || helper(&T_row, &W_row, ts_row, r),
+      || helper(&T_col, &W_col, ts_col, r),
+    );
+
+    let (t_plus_r_inv_row, w_plus_r_inv_row, t_plus_r_row, w_plus_r_row) = row?;
+    let (t_plus_r_inv_col, w_plus_r_inv_col, t_plus_r_col, w_plus_r_col) = col?;
+
+    let (
+      (comm_t_plus_r_inv_row, comm_w_plus_r_inv_row),
+      (comm_t_plus_r_inv_col, comm_w_plus_r_inv_col),
+    ) = rayon::join(
+      || {
+        rayon::join(
+          || E::CE::commit(ck, &t_plus_r_inv_row, &E::Scalar::ZERO),
+          || E::CE::commit(ck, &w_plus_r_inv_row, &E::Scalar::ZERO),
+        )
+      },
+      || {
+        rayon::join(
+          || E::CE::commit(ck, &t_plus_r_inv_col, &E::Scalar::ZERO),
+          || E::CE::commit(ck, &w_plus_r_inv_col, &E::Scalar::ZERO),
+        )
+      },
+    );
+
+    let comm_vec = [
+      comm_t_plus_r_inv_row,
+      comm_w_plus_r_inv_row,
+      comm_t_plus_r_inv_col,
+      comm_w_plus_r_inv_col,
+    ];
+
+    let poly_vec = [
+      t_plus_r_inv_row,
+      w_plus_r_inv_row,
+      t_plus_r_inv_col,
+      w_plus_r_inv_col,
+    ];
+
+    let aux_poly_vec = [t_plus_r_row, w_plus_r_row, t_plus_r_col, w_plus_r_col];
+
+    Ok((comm_vec, poly_vec, aux_poly_vec))
+  }
+
+  /// Create a new memory sumcheck instance
+  pub fn new(
+    polys_oracle: [Vec<E::Scalar>; 4],
+    polys_aux: [Vec<E::Scalar>; 4],
+    rhos: Vec<E::Scalar>,
+    ts_row: Vec<E::Scalar>,
+    ts_col: Vec<E::Scalar>,
+  ) -> Self {
+    let [t_plus_r_inv_row, w_plus_r_inv_row, t_plus_r_inv_col, w_plus_r_inv_col] = polys_oracle;
+    let [t_plus_r_row, w_plus_r_row, t_plus_r_col, w_plus_r_col] = polys_aux;
+
+    Self {
+      w_plus_r_row: MultilinearPolynomial::new(w_plus_r_row),
+      t_plus_r_row: MultilinearPolynomial::new(t_plus_r_row),
+      t_plus_r_inv_row: MultilinearPolynomial::new(t_plus_r_inv_row),
+      w_plus_r_inv_row: MultilinearPolynomial::new(w_plus_r_inv_row),
+      ts_row: MultilinearPolynomial::new(ts_row),
+      w_plus_r_col: MultilinearPolynomial::new(w_plus_r_col),
+      t_plus_r_col: MultilinearPolynomial::new(t_plus_r_col),
+      t_plus_r_inv_col: MultilinearPolynomial::new(t_plus_r_inv_col),
+      w_plus_r_inv_col: MultilinearPolynomial::new(w_plus_r_inv_col),
+      ts_col: MultilinearPolynomial::new(ts_col),
+      eq_sumcheck: EqSumCheckInstance::new(rhos),
+      running_claims: [E::Scalar::ZERO; 6],
+      saved_evals: [[E::Scalar::ZERO; 3]; 6],
+    }
+  }
+}
+
+impl<E: Engine> SumcheckEngine<E> for MemorySumcheckInstance<E> {
+  fn initial_claims(&self) -> Vec<E::Scalar> {
+    vec![E::Scalar::ZERO; 6]
+  }
+
+  fn degree(&self) -> usize {
+    3
+  }
+
+  fn size(&self) -> usize {
+    // sanity checks
+    assert_eq!(self.w_plus_r_row.len(), self.t_plus_r_row.len());
+    assert_eq!(self.w_plus_r_row.len(), self.ts_row.len());
+    assert_eq!(self.w_plus_r_row.len(), self.w_plus_r_col.len());
+    assert_eq!(self.w_plus_r_row.len(), self.t_plus_r_col.len());
+    assert_eq!(self.w_plus_r_row.len(), self.ts_col.len());
+
+    self.w_plus_r_row.len()
+  }
+
+  fn evaluation_points(&mut self) -> Vec<Vec<E::Scalar>> {
+    // Pre-borrow all fields as shared references for parallel access
+    let eq = &self.eq_sumcheck;
+    let running_claims = &self.running_claims;
+    let t_plus_r_inv_row = &self.t_plus_r_inv_row;
+    let w_plus_r_inv_row = &self.w_plus_r_inv_row;
+    let t_plus_r_row = &self.t_plus_r_row;
+    let w_plus_r_row = &self.w_plus_r_row;
+    let ts_row = &self.ts_row;
+    let t_plus_r_inv_col = &self.t_plus_r_inv_col;
+    let w_plus_r_inv_col = &self.w_plus_r_inv_col;
+    let t_plus_r_col = &self.t_plus_r_col;
+    let w_plus_r_col = &self.w_plus_r_col;
+    let ts_col = &self.ts_col;
+
+    // inv related evaluation points for linear (A - B) pattern (no claim derivation)
+    // 0 = sum TS[i]/(T[i] + r) - 1/(W[i] + r)
+    let (
+      ((eval_inv_0_row, eval_inv_3_row), (eval_inv_0_col, eval_inv_3_col)),
+      (
+        ((eval_T_0_row, eval_T_2_row, eval_T_3_row), (eval_W_0_row, eval_W_2_row, eval_W_3_row)),
+        ((eval_T_0_col, eval_T_2_col, eval_T_3_col), (eval_W_0_col, eval_W_2_col, eval_W_3_col)),
+      ),
+    ) = rayon::join(
+      || {
+        rayon::join(
+          || SumcheckProof::<E>::compute_eval_points_linear(t_plus_r_inv_row, w_plus_r_inv_row),
+          || SumcheckProof::<E>::compute_eval_points_linear(t_plus_r_inv_col, w_plus_r_inv_col),
+        )
+      },
+      || {
+        rayon::join(
+          || {
+            // Row evaluation points (claim-derived, BDDT Section 6.2)
+            rayon::join(
+              || {
+                // 0 = sum eq[i] * (inv_T[i] * (T[i] + r) - TS[i]))
+                eq.evaluation_points_cubic_with_three_inputs(
+                  t_plus_r_inv_row,
+                  t_plus_r_row,
+                  ts_row,
+                  running_claims[2],
+                )
+              },
+              || {
+                // 0 = sum eq[i] * (inv_W[i] * (W[i] + r) - 1))
+                eq.evaluation_points_cubic_with_two_inputs(
+                  w_plus_r_inv_row,
+                  w_plus_r_row,
+                  running_claims[3],
+                )
+              },
+            )
+          },
+          || {
+            // Column evaluation points (claim-derived, BDDT Section 6.2)
+            rayon::join(
+              || {
+                eq.evaluation_points_cubic_with_three_inputs(
+                  t_plus_r_inv_col,
+                  t_plus_r_col,
+                  ts_col,
+                  running_claims[4],
+                )
+              },
+              || {
+                eq.evaluation_points_cubic_with_two_inputs(
+                  w_plus_r_inv_col,
+                  w_plus_r_col,
+                  running_claims[5],
+                )
+              },
+            )
+          },
+        )
+      },
+    );
+
+    // Save evaluation points for running claim updates in bound()
+    self.saved_evals = [
+      [eval_inv_0_row, E::Scalar::ZERO, eval_inv_3_row],
+      [eval_inv_0_col, E::Scalar::ZERO, eval_inv_3_col],
+      [eval_T_0_row, eval_T_2_row, eval_T_3_row],
+      [eval_W_0_row, eval_W_2_row, eval_W_3_row],
+      [eval_T_0_col, eval_T_2_col, eval_T_3_col],
+      [eval_W_0_col, eval_W_2_col, eval_W_3_col],
+    ];
+
+    self.saved_evals.iter().map(|e| e.to_vec()).collect()
+  }
+
+  fn bound(&mut self, r: &E::Scalar) {
+    for j in 0..6 {
+      self.running_claims[j] =
+        SumcheckProof::<E>::update_claim(self.running_claims[j], &self.saved_evals[j], r);
+    }
+
+    [
+      &mut self.t_plus_r_row,
+      &mut self.t_plus_r_inv_row,
+      &mut self.w_plus_r_row,
+      &mut self.w_plus_r_inv_row,
+      &mut self.ts_row,
+      &mut self.t_plus_r_col,
+      &mut self.t_plus_r_inv_col,
+      &mut self.w_plus_r_col,
+      &mut self.w_plus_r_inv_col,
+      &mut self.ts_col,
+    ]
+    .par_iter_mut()
+    .for_each(|poly| poly.bind_poly_var_top(r));
+
+    self.eq_sumcheck.bound(r);
+  }
+
+  fn final_claims(&self) -> Vec<Vec<E::Scalar>> {
+    let poly_row_final = vec![
+      self.t_plus_r_inv_row[0],
+      self.w_plus_r_inv_row[0],
+      self.ts_row[0],
+    ];
+
+    let poly_col_final = vec![
+      self.t_plus_r_inv_col[0],
+      self.w_plus_r_inv_col[0],
+      self.ts_col[0],
+    ];
+
+    vec![poly_row_final, poly_col_final]
+  }
+}
+
+/// Prover side of the inverse-logup memory-check: builds the inverse oracles,
+/// commits to them, absorbs the commitments, squeezes the `rho` challenges, and
+/// returns the `MemorySumcheckInstance` (the first `prove_helper` slot) plus the
+/// oracle commitments and polynomials (needed later for the batched PCS
+/// opening). `addr_row`/`addr_col` are `S_repr.row`/`col`.
+#[allow(clippy::too_many_arguments)]
+pub fn prove_step<E: Engine>(
+  ck: &CommitmentKey<E>,
+  r: E::Scalar,
+  gamma: E::Scalar,
+  mem_row: &[E::Scalar],
+  addr_row: &[E::Scalar],
+  L_row: &[E::Scalar],
+  ts_row: &[E::Scalar],
+  mem_col: &[E::Scalar],
+  addr_col: &[E::Scalar],
+  L_col: &[E::Scalar],
+  ts_col: &[E::Scalar],
+  num_rounds_inner: usize,
+  transcript: &mut E::TE,
+) -> Result<
+  (
+    MemorySumcheckInstance<E>,
+    [Commitment<E>; 4],
+    [Vec<E::Scalar>; 4],
+  ),
+  NovaError,
+> {
+  let (comm_mem_oracles, mem_oracles, mem_aux) = MemorySumcheckInstance::<E>::compute_oracles(
+    ck, &r, &gamma, mem_row, addr_row, L_row, ts_row, mem_col, addr_col, L_col, ts_col,
+  )?;
+  transcript.absorb(b"l", &comm_mem_oracles.as_slice());
+  let rho = (0..num_rounds_inner)
+    .map(|_| transcript.squeeze(b"r"))
+    .collect::<Result<Vec<_>, NovaError>>()?;
+  let inst = MemorySumcheckInstance::new(
+    mem_oracles.clone(),
+    mem_aux,
+    rho,
+    ts_row.to_vec(),
+    ts_col.to_vec(),
+  );
+  Ok((inst, comm_mem_oracles, mem_oracles))
+}
+
+/// Number of batched-inner claims the memory-check slot contributes (the six
+/// inverse-logup routes at coeffs `[0, 6)`). `prove_helper` places the
+/// memory-check slot first, so the inner/witness claims come after these.
+pub const NUM_MEM_CLAIMS: usize = 6;
+
+/// The inverse-logup contribution to the batched inner sumcheck's **initial**
+/// claim. The six memory routes prove `0 = Σ ...`, so their combined initial
+/// claim is zero — this exists for symmetry with the Logup-GKR slot's
+/// `verify_initial_claim`, so the caller adds one memory-check contribution
+/// regardless of which implementation is active.
+pub fn verify_initial_claim<E: Engine>(_coeffs: &[E::Scalar]) -> E::Scalar {
+  E::Scalar::ZERO
+}
+
+/// Verifier side, transcript phase: absorbs the four inverse-oracle commitments
+/// and squeezes the `rho` challenges (the eq randomness for the memory
+/// sumcheck), mirroring [`prove_step`]. Must run before the inner sumcheck's `s`
+/// challenge is drawn.
+pub fn verify_pre_inner<E: Engine>(
+  data: &LogupProofData<E>,
+  num_rounds_inner: usize,
+  transcript: &mut E::TE,
+) -> Result<Vec<E::Scalar>, NovaError> {
+  transcript.absorb(
+    b"l",
+    &vec![
+      data.comm_t_plus_r_inv_row,
+      data.comm_w_plus_r_inv_row,
+      data.comm_t_plus_r_inv_col,
+      data.comm_w_plus_r_inv_col,
+    ]
+    .as_slice(),
+  );
+  (0..num_rounds_inner)
+    .map(|_| transcript.squeeze(b"r"))
+    .collect()
+}
+
+/// Verifier side, final-claim phase: reconstructs the memory-check contribution
+/// to the batched inner sumcheck's final claim — the six routes at coeff indices
+/// `0..6`, proving `Σ TS/(T+r) − 1/(W+r) = 0` and the well-formedness of the
+/// four inverse oracles. `rho` is from [`verify_pre_inner`]; the eval arguments
+/// are the shared evaluations at `r_inner_batched`.
+#[allow(clippy::too_many_arguments)]
+pub fn verify_final_claim<E: Engine>(
+  data: &LogupProofData<E>,
+  coeffs: &[E::Scalar],
+  rho: Vec<E::Scalar>,
+  gamma: E::Scalar,
+  r: E::Scalar,
+  r_outer_full: &[E::Scalar],
+  r_inner_batched: &[E::Scalar],
+  num_rounds_inner: usize,
+  num_vars: usize,
+  n: usize,
+  eval_W: E::Scalar,
+  eval_L_row: E::Scalar,
+  eval_L_col: E::Scalar,
+  eval_row: E::Scalar,
+  eval_col: E::Scalar,
+  eval_ts_row: E::Scalar,
+  eval_ts_col: E::Scalar,
+  x: &[E::Scalar],
+) -> E::Scalar {
+  let rand_eq_bound = EqPolynomial::new(rho).evaluate(r_inner_batched);
+  let eq_r_outer = EqPolynomial::new(r_outer_full.to_vec());
+  let eq_r_outer_at_r_inner = eq_r_outer.evaluate(r_inner_batched);
+
+  // mem_col = z at r_inner_batched, reconstructed from eval_W and public IO.
+  let eval_mem_col_at_r_inner = {
+    let (fac, unpad) = {
+      let l = n.log_2() - (2 * num_vars).log_2();
+      let mut fac = E::Scalar::ONE;
+      for r_p in r_inner_batched.iter().take(l) {
+        fac *= E::Scalar::ONE - r_p
+      }
+      (fac, r_inner_batched[l..].to_vec())
+    };
+    let eval_x = {
+      let poly_x = SparsePolynomial::new(unpad.len() - 1, x.to_vec());
+      poly_x.evaluate(&unpad[1..])
+    };
+    eval_W + fac * unpad[0] * eval_x
+  };
+
+  let eval_t_plus_r_row = {
+    let eval_addr = IdentityPolynomial::new(num_rounds_inner).evaluate(r_inner_batched);
+    eval_addr + gamma * eq_r_outer_at_r_inner + r // mem_row = eq(r_outer_full, ·)
+  };
+  let eval_w_plus_r_row = eval_row + gamma * eval_L_row + r;
+  let eval_t_plus_r_col = {
+    let eval_addr = IdentityPolynomial::new(num_rounds_inner).evaluate(r_inner_batched);
+    eval_addr + gamma * eval_mem_col_at_r_inner + r
+  };
+  let eval_w_plus_r_col = eval_col + gamma * eval_L_col + r;
+
+  coeffs[0] * (data.eval_t_plus_r_inv_row - data.eval_w_plus_r_inv_row)
+    + coeffs[1] * (data.eval_t_plus_r_inv_col - data.eval_w_plus_r_inv_col)
+    + coeffs[2] * (rand_eq_bound * (data.eval_t_plus_r_inv_row * eval_t_plus_r_row - eval_ts_row))
+    + coeffs[3]
+      * (rand_eq_bound * (data.eval_w_plus_r_inv_row * eval_w_plus_r_row - E::Scalar::ONE))
+    + coeffs[4] * (rand_eq_bound * (data.eval_t_plus_r_inv_col * eval_t_plus_r_col - eval_ts_col))
+    + coeffs[5]
+      * (rand_eq_bound * (data.eval_w_plus_r_inv_col * eval_w_plus_r_col - E::Scalar::ONE))
+}

--- a/src/spartan/mem_check_logup_gkr.rs
+++ b/src/spartan/mem_check_logup_gkr.rs
@@ -1,0 +1,1083 @@
+//! Bridge layer wiring Logup-GKR to ppSNARK's memory-check.
+//!
+//! This module is the *host* half of the Logup-GKR memory-check. The
+//! `logup_gkr` core owns the fractional-sum reduction but no PCS; `ppsnark` owns
+//! the commitments and inner sumcheck. This bridge supplies ppSNARK's four
+//! equal-height sub-instances and rerandomizes all seven columns needed for
+//! reconcile into the inner sumcheck.
+//!
+//! The verifier closes soundness by (1) reconstructing each input-layer
+//! fraction from the seven column evaluations claimed at the GKR `eval_point`,
+//! (2) comparing those fractions with the GKR reduction, and (3) checking the
+//! two fractional balances. [`MemCheckOpenings`] fixes the claimed columns and
+//! their order; the rerandomize sumcheck and batched PCS opening bind those
+//! claims to the committed columns at `r_inner_batched`.
+//!
+//! ## The four sub-instances (why four, not two)
+//! ppSNARK's memory-check is two logup relations (`row`, `col`), each a balance
+//! `Σ ts/(T+r) = Σ 1/(W+r)`. We encode each relation as **two** height-N
+//! fractional-sum sub-instances — a *table* side and an *access* side — so all
+//! four share one GKR depth `log N`, as required by the batched GKR verifier;
+//! every side is exactly N because ppSNARK pads every memory-check column to N
+//! in setup. A single
+//! 2N-leaf signed-multiplicity tree would instead emit a `log(2N)` point, which
+//! cannot be rerandomized against the N-variable inner sumcheck; the two N-leaf
+//! trees for each relation keep the point at `log N`. Instance order is fixed:
+//!
+//! | idx | name        | num       | den                         |
+//! |-----|-------------|-----------|-----------------------------|
+//! | 0   | row_table   | `ts_row`  | `mem_row·γ + id + r`        |
+//! | 1   | row_access  | `-1`      | `L_row·γ + addr_row + r`    |
+//! | 2   | col_table   | `ts_col`  | `mem_col·γ + id + r`        |
+//! | 3   | col_access  | `-1`      | `L_col·γ + addr_col + r`    |
+//!
+//! where `id = IdentityPolynomial` (the cell address `i`), `mem_row =
+//! eq(r_outer_full, ·)`, `mem_col = z`, `addr_row = row`, `addr_col = col`, and
+//! `(γ, r)` are the ppSNARK memory-check fingerprint challenges.
+//!
+//! ## Balance (the host's `0/den` check)
+//! The GKR verifier reduces each sub-instance to a root fraction but does **not**
+//! check the relation balances — that is this module's job. Balance is a
+//! property of the whole relation, i.e. the *root* fractions (the proof's
+//! `initial_claims`, bound to the reduction by the GKR verifier), not the
+//! input-layer evaluations. The access side carries `num = -1`, so `root_table +
+//! root_access = Σ ts/(T+r) − Σ 1/(W+r)`, which must vanish. In projective form
+//! that means the *sum's numerator* is zero (the denominator, a product of
+//! nonzero dens, cannot be), checked for the row pair `(0,1)` and the col pair
+//! `(2,3)`.
+
+use crate::errors::NovaError;
+use crate::spartan::logup_gkr::fraction::Fraction;
+use crate::spartan::logup_gkr::layer::Layer;
+use crate::spartan::logup_gkr::proof::LogupGkrProof;
+use crate::spartan::logup_gkr::verifier;
+use crate::spartan::polys::eq::EqPolynomial;
+use crate::spartan::polys::identity::IdentityPolynomial;
+use crate::spartan::polys::multilinear::MultilinearPolynomial;
+use crate::spartan::sumcheck::eq_sumcheck::EqSumCheckInstance;
+use crate::spartan::sumcheck::{SumcheckEngine, SumcheckProof};
+use crate::traits::evm_serde::EvmCompatSerde;
+use crate::traits::{Engine, TranscriptEngineTrait};
+use ff::Field;
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+/// The Logup-GKR memory-check proof fields carried in the ppSNARK proof: the
+/// fractional-sum proof plus the prover-claimed column values at the GKR
+/// `eval_point` (the rerandomize instance's initial claims, in
+/// [`MemCheckOpenings::rerand_claims`] order). Bundled so the SNARK can gate the
+/// whole GKR path behind one field.
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(bound = "")]
+pub struct GkrProofData<E: Engine> {
+  /// The GKR fractional-sum proof.
+  pub proof: LogupGkrProof<E>,
+  /// Prover-claimed column values at the GKR `eval_point`, in
+  /// [`MemCheckOpenings::rerand_claims`] order. The verifier reads these;
+  /// reconcile + the inner sumcheck bind them to the real committed columns.
+  #[serde_as(as = "[EvmCompatSerde; NUM_RERAND_COLUMNS]")]
+  pub rerand_claims: [E::Scalar; NUM_RERAND_COLUMNS],
+}
+
+/// Fixed sub-instance count (`row_table, row_access, col_table, col_access`).
+pub const NUM_SUB_INSTANCES: usize = 4;
+
+/// Number of columns the rerandomize instance carries from the GKR `eval_point`
+/// into the inner sumcheck. These are every column reconcile needs at the GKR
+/// point that the verifier cannot self-compute (it computes only `mem_row = eq`
+/// and the identity `id`): `L_row, L_col, addr_row, addr_col, ts_row, ts_col,
+/// mem_col`. The order is fixed by [`MemCheckOpenings::rerand_claims`] and must
+/// match between prover and verifier.
+pub const NUM_RERAND_COLUMNS: usize = 7;
+
+/// The column evaluations a prover claims at the GKR
+/// [`eval_point`](crate::spartan::logup_gkr::LogupGkrOpeningClaim::eval_point).
+///
+/// Every field is one column evaluated at the shared GKR point. The host uses
+/// them to reconstruct the four sub-instance fractions, while the rerandomize
+/// sumcheck carries the same claims to `r_inner_batched` for the batched PCS
+/// opening. The verifier computes `id` and `mem_row = eq(r_outer_full, ·)`
+/// directly, so neither needs a claim here.
+#[derive(Clone, Copy, Debug)]
+pub struct MemCheckOpenings<E: Engine> {
+  /// `L_row(eval_point)` — the row lookup column.
+  pub eval_L_row: E::Scalar,
+  /// `L_col(eval_point)` — the col lookup column.
+  pub eval_L_col: E::Scalar,
+  /// `row(eval_point)` — the row access-address column (`addr_row`).
+  pub eval_row: E::Scalar,
+  /// `col(eval_point)` — the col access-address column (`addr_col`).
+  pub eval_col: E::Scalar,
+  /// `ts_row(eval_point)` — the row multiplicity column.
+  pub eval_ts_row: E::Scalar,
+  /// `ts_col(eval_point)` — the col multiplicity column.
+  pub eval_ts_col: E::Scalar,
+  /// `mem_col(eval_point) = z(eval_point)` — the col table-value column.
+  ///
+  /// `mem_row` is `eq(r_outer_full, ·)`, which the verifier evaluates directly,
+  /// so only `mem_col` needs a claim.
+  pub eval_mem_col: E::Scalar,
+}
+
+impl<E: Engine> MemCheckOpenings<E> {
+  /// The claimed column values at the GKR `eval_point`, in the fixed
+  /// [`NUM_RERAND_COLUMNS`] order the rerandomize instance and the verifier both
+  /// use: `[L_row, L_col, addr_row, addr_col, ts_row, ts_col, mem_col]`.
+  pub fn rerand_claims(&self) -> [E::Scalar; NUM_RERAND_COLUMNS] {
+    [
+      self.eval_L_row,
+      self.eval_L_col,
+      self.eval_row,
+      self.eval_col,
+      self.eval_ts_row,
+      self.eval_ts_col,
+      self.eval_mem_col,
+    ]
+  }
+}
+
+/// The prover's memory-check witness: the raw length-N columns fed into
+/// Logup-GKR.
+///
+/// These are exactly ppSNARK's padded memory-check columns (all length
+/// `N = 2^{log N}`). [`build_input_layers`]
+/// turns them into the four GKR input layers, and [`prove`] consumes the
+/// witness while claiming the seven evaluations named by [`MemCheckOpenings`]
+/// at the shared point. Field meanings match the four-sub-instance table in the
+/// module docs:
+/// - `mem_row = eq(r_outer_full, ·)`, `mem_col = z` (table values);
+/// - `L_row`/`L_col` the lookup columns, `addr_row = row`/`addr_col = col` the
+///   access addresses, `ts_row`/`ts_col` the multiplicities.
+#[derive(Clone)]
+pub struct MemCheckWitness<E: Engine> {
+  /// Row table values `mem_row = eq(r_outer_full, ·)`.
+  pub mem_row: Vec<E::Scalar>,
+  /// Col table values `mem_col = z`.
+  pub mem_col: Vec<E::Scalar>,
+  /// Row lookup column `L_row`.
+  pub L_row: Vec<E::Scalar>,
+  /// Col lookup column `L_col`.
+  pub L_col: Vec<E::Scalar>,
+  /// Row access addresses `addr_row = row`.
+  pub addr_row: Vec<E::Scalar>,
+  /// Col access addresses `addr_col = col`.
+  pub addr_col: Vec<E::Scalar>,
+  /// Row multiplicities `ts_row`.
+  pub ts_row: Vec<E::Scalar>,
+  /// Col multiplicities `ts_col`.
+  pub ts_col: Vec<E::Scalar>,
+}
+
+/// Builds the four GKR input layers `[row_table, row_access, col_table,
+/// col_access]` from the raw columns and the fingerprint `(gamma, r)`.
+///
+/// This is the prover-side dual of the verifier's per-instance reconstruction
+/// in [`verify`]: it must produce, for every leaf `i`, exactly the fractions the
+/// verifier recomputes at `eval_point`. The layers, in order (matching the
+/// module-doc table and [`NUM_SUB_INSTANCES`]):
+///
+/// | idx | name        | num        | den                         |
+/// |-----|-------------|------------|-----------------------------|
+/// | 0   | row_table   | `ts_row`   | `mem_row·γ + id + r`        |
+/// | 1   | row_access  | `-1`       | `L_row·γ + addr_row + r`    |
+/// | 2   | col_table   | `ts_col`   | `mem_col·γ + id + r`        |
+/// | 3   | col_access  | `-1`       | `L_col·γ + addr_col + r`    |
+///
+/// `id[i] = i` is the cell address. All columns must share one length `N`, a
+/// power of two (`debug_assert`ed); the returned layers each have `log N`
+/// variables, the shared GKR depth.
+pub fn build_input_layers<E: Engine>(
+  cols: &MemCheckWitness<E>,
+  gamma: E::Scalar,
+  r: E::Scalar,
+) -> Vec<Layer<E>> {
+  let n = cols.mem_row.len();
+  debug_assert!(
+    n.is_power_of_two() && n >= 2,
+    "N must be a power of two >= 2"
+  );
+  for col in [
+    &cols.mem_col,
+    &cols.L_row,
+    &cols.L_col,
+    &cols.addr_row,
+    &cols.addr_col,
+    &cols.ts_row,
+    &cols.ts_col,
+  ] {
+    debug_assert_eq!(col.len(), n, "all memory-check columns must share length N");
+  }
+
+  let neg_one = -E::Scalar::ONE;
+  // Table-side den: mem·γ + id + r, where id[i] = i (the cell address).
+  //
+  // `id[i]` is built by per-chunk accumulation instead of `Scalar::from(i)` per
+  // element: each chunk pays ONE `from` for its base index, then walks its cells
+  // with a field `+ ONE`, which is far cheaper than a u64→Montgomery conversion.
+  // The chunks run in parallel (`par_chunks_mut`), so this keeps full width
+  // while dropping N `from`s to `N / chunk_size`.
+  let one = E::Scalar::ONE;
+  let chunk_size = 1 + n / rayon::current_num_threads().max(1);
+  let den_table = |mem: &[E::Scalar]| -> Vec<E::Scalar> {
+    let mut out = vec![E::Scalar::ZERO; n];
+    out
+      .par_chunks_mut(chunk_size)
+      .enumerate()
+      .for_each(|(c, chunk)| {
+        let mut id = E::Scalar::from((c * chunk_size) as u64); // base index of this chunk
+        for (out_i, mem_i) in chunk.iter_mut().zip(&mem[c * chunk_size..]) {
+          *out_i = *mem_i * gamma + id + r;
+          id += one;
+        }
+      });
+    out
+  };
+  // Access-side den: L·γ + addr + r.
+  let den_access = |l: &[E::Scalar], addr: &[E::Scalar]| -> Vec<E::Scalar> {
+    (0..n)
+      .into_par_iter()
+      .map(|i| l[i] * gamma + addr[i] + r)
+      .collect()
+  };
+  let mle = |v: Vec<E::Scalar>| MultilinearPolynomial::new(v);
+
+  vec![
+    // idx 0: row_table
+    Layer::<E> {
+      num: mle(cols.ts_row.clone()),
+      den: mle(den_table(&cols.mem_row)),
+    },
+    // idx 1: row_access
+    Layer::<E> {
+      num: mle(vec![neg_one; n]),
+      den: mle(den_access(&cols.L_row, &cols.addr_row)),
+    },
+    // idx 2: col_table
+    Layer::<E> {
+      num: mle(cols.ts_col.clone()),
+      den: mle(den_table(&cols.mem_col)),
+    },
+    // idx 3: col_access
+    Layer::<E> {
+      num: mle(vec![neg_one; n]),
+      den: mle(den_access(&cols.L_col, &cols.addr_col)),
+    },
+  ]
+}
+
+/// Verifies the ppSNARK memory-check via Logup-GKR.
+///
+/// Steps: (1) run the GKR verifier to get the shared `eval_point` and four
+/// reduced input-layer fractions; (2) reconstruct those fractions from the
+/// prover's claimed columns ([`MemCheckOpenings`]) and the fingerprint
+/// `(gamma, r)`, and require they match; (3) check the two balances. The
+/// returned `eval_point` seeds the rerandomize final-claim check in the inner
+/// sumcheck. The transcript must be positioned immediately before the GKR
+/// proof.
+///
+/// `r_outer_full` is ppSNARK's extended outer challenge, defining `mem_row =
+/// eq(r_outer_full, ·)`; the verifier evaluates it at `eval_point` itself.
+pub fn verify<E: Engine>(
+  proof: &LogupGkrProof<E>,
+  gamma: E::Scalar,
+  r: E::Scalar,
+  r_outer_full: &[E::Scalar],
+  openings: &MemCheckOpenings<E>,
+  transcript: &mut E::TE,
+) -> Result<Vec<E::Scalar>, NovaError> {
+  // (1) GKR verifier: shape-check, root gates, per-layer sumchecks.
+  let claim = verifier::verify::<E>(proof, transcript)?;
+  let eval_point = claim.eval_point();
+  let reduced = claim.openings();
+  if reduced.len() != NUM_SUB_INSTANCES {
+    return Err(NovaError::InvalidNumInstances);
+  }
+  // Bind GKR depth to the trusted `log N` from vk / outer challenge. The proof
+  // alone can claim any `final_claims.len()`; without this check a forged depth
+  // would panic inside `EqPolynomial::evaluate` (assert on length mismatch)
+  // rather than return `NovaError`.
+  if eval_point.len() != r_outer_full.len() {
+    return Err(NovaError::InvalidSumcheckProof);
+  }
+
+  // (2) Recompute the four input-layer fractions from the claimed columns.
+  // Pieces the verifier evaluates itself at eval_point:
+  let eval_id = IdentityPolynomial::<E::Scalar>::new(eval_point.len()).evaluate(eval_point);
+  let eval_mem_row = EqPolynomial::new(r_outer_full.to_vec()).evaluate(eval_point);
+
+  let neg_one = -E::Scalar::ONE;
+
+  // idx 0: row_table    num = ts_row    den = mem_row·γ + id + r
+  let row_table = {
+    let num = openings.eval_ts_row;
+    let den = eval_mem_row * gamma + eval_id + r;
+    Fraction::new(num, den)
+  };
+
+  // idx 1: row_access   num = -1        den = L_row·γ + addr_row + r
+  let row_access = {
+    let num = neg_one;
+    let den = openings.eval_L_row * gamma + openings.eval_row + r;
+    Fraction::new(num, den)
+  };
+
+  // idx 2: col_table    num = ts_col    den = mem_col·γ + id + r
+  let col_table = {
+    let num = openings.eval_ts_col;
+    let den = openings.eval_mem_col * gamma + eval_id + r;
+    Fraction::new(num, den)
+  };
+
+  // idx 3: col_access   num = -1        den = L_col·γ + addr_col + r
+  let col_access = {
+    let num = neg_one;
+    let den = openings.eval_L_col * gamma + openings.eval_col + r;
+    Fraction::new(num, den)
+  };
+
+  let recomputed = [row_table, row_access, col_table, col_access];
+
+  // Each recomputed fraction must match the GKR-reduced input-layer claim
+  // **component-wise**. Cross-multiplication is unsound: a reduced `(0,0)`
+  // would cross-equal any recomputed `(a,b)` and disconnect the GKR root from
+  // the committed columns (see logup_gkr verifier root-gate comment).
+  for (rc, red) in recomputed.iter().zip(reduced.iter()) {
+    if rc.num != red.num || rc.den != red.den {
+      return Err(NovaError::InvalidSumcheckProof);
+    }
+  }
+
+  // (3) Balance: table side + access side = 0, for the row relation and the col
+  // relation. Balance is a property of the whole relation, i.e. the *root*
+  // fractions (`Σ ts/(T+r)` and `Σ -1/(W+r)`) — these are the GKR proof's
+  // `initial_claims`, NOT the input-layer `recomputed` fractions from step (2)
+  // (those are single-point evaluations at eval_point, a different quantity).
+  // The roots are already bound to the reduction by the GKR verifier's root-gate
+  // + per-layer sumcheck checks in step (1). The access side carries num = -1,
+  // so `root_table + root_access = Σ ts/(T+r) − Σ 1/(W+r)`, which must vanish:
+  // in projective form the sum's numerator is zero once its denominator (a
+  // product of dens) is confirmed nonzero — checked explicitly just below.
+  let [row_table_root, row_access_root, col_table_root, col_access_root] = proof.initial_claims[..]
+  else {
+    return Err(NovaError::InvalidNumInstances);
+  };
+
+  // Guard against a spurious `0/0` balance: `(t+a).num == 0` only certifies the
+  // rational `t + a` is zero when its denominator `t.den · a.den` is nonzero.
+  // Each root den is `Π_i (fingerprint_i + r)` with `r` a Fiat-Shamir challenge
+  // drawn after the prover fixed its columns, so a zero factor happens with
+  // probability ≤ N/|F| (negligible) for an honest prover and cannot be forced
+  // by a malicious one — but the check is 4 comparisons and closes the path.
+  let all_dens_nonzero = [
+    row_table_root,
+    row_access_root,
+    col_table_root,
+    col_access_root,
+  ]
+  .iter()
+  .all(|f| f.den != E::Scalar::ZERO);
+  if !all_dens_nonzero {
+    return Err(NovaError::InvalidSumcheckProof);
+  }
+
+  let row_balanced = (row_table_root + row_access_root).num == E::Scalar::ZERO;
+  let col_balanced = (col_table_root + col_access_root).num == E::Scalar::ZERO;
+  if !row_balanced || !col_balanced {
+    return Err(NovaError::InvalidSumcheckProof);
+  }
+
+  Ok(eval_point.to_vec())
+}
+
+/// First rerandomize coeff index in the batched inner sumcheck. `prove_helper`
+/// places the memory-check slot first, so under Logup-GKR the seven rerandomize
+/// columns occupy coeffs `[0, NUM_RERAND_COLUMNS)`, and the inner (ABC, E) and
+/// witness claims follow at `NUM_RERAND_COLUMNS ..`.
+pub const RERAND_BASE: usize = 0;
+
+/// Number of batched-inner claims the memory-check slot contributes (the seven
+/// rerandomize columns). The inner/witness claims come after these.
+pub const NUM_MEM_CLAIMS: usize = NUM_RERAND_COLUMNS;
+
+/// Prover side of the Logup-GKR memory-check: folds the four sub-instances into
+/// GKR trees, absorbs the claimed column values, and returns the rerandomize
+/// instance (the first `prove_helper` slot) and the proof data to store (which
+/// itself carries the claimed column values in `rerand_claims`).
+pub fn prove_step<E: Engine>(
+  witness: MemCheckWitness<E>,
+  gamma: E::Scalar,
+  r: E::Scalar,
+  transcript: &mut E::TE,
+) -> Result<(RerandomizeSumcheckInstance<E>, GkrProofData<E>), NovaError> {
+  let out = prove::<E>(witness, gamma, r, transcript)?;
+  let rerand_claims = out.openings.rerand_claims();
+  // Absorb the claimed column values before the inner sumcheck's `s` so the
+  // verifier binds the same values in the same order.
+  transcript.absorb(b"gkrL", &rerand_claims.as_slice());
+  let data = GkrProofData {
+    proof: out.proof,
+    rerand_claims,
+  };
+  Ok((out.rerandomize, data))
+}
+
+/// Verifier side, transcript phase: replays the GKR proof, reconciles the
+/// claimed columns against the reduction, runs the balance check, and absorbs
+/// the claimed values — mirroring [`prove_step`]. Returns the shared GKR
+/// `eval_point`. Must run before the inner sumcheck's `s` challenge is drawn.
+pub fn verify_pre_inner<E: Engine>(
+  data: &GkrProofData<E>,
+  gamma: E::Scalar,
+  r: E::Scalar,
+  r_outer_full: &[E::Scalar],
+  transcript: &mut E::TE,
+) -> Result<Vec<E::Scalar>, NovaError> {
+  let c = data.rerand_claims;
+  let openings = MemCheckOpenings::<E> {
+    eval_L_row: c[0],
+    eval_L_col: c[1],
+    eval_row: c[2],
+    eval_col: c[3],
+    eval_ts_row: c[4],
+    eval_ts_col: c[5],
+    eval_mem_col: c[6],
+  };
+  let eval_point = verify::<E>(&data.proof, gamma, r, r_outer_full, &openings, transcript)?;
+  transcript.absorb(b"gkrL", &data.rerand_claims.as_slice());
+  Ok(eval_point)
+}
+
+/// The Logup-GKR contribution to the batched inner sumcheck's **initial** claim:
+/// `Σ_i coeffs[RERAND_BASE + i] · claimed_column_i(eval_point)`.
+pub fn verify_initial_claim<E: Engine>(data: &GkrProofData<E>, coeffs: &[E::Scalar]) -> E::Scalar {
+  (0..NUM_RERAND_COLUMNS)
+    .map(|i| coeffs[RERAND_BASE + i] * data.rerand_claims[i])
+    .sum()
+}
+
+/// The Logup-GKR contribution to the batched inner sumcheck's **final** claim:
+/// `Σ_i coeffs[RERAND_BASE + i] · eq(eval_point, r_inner_batched) ·
+/// column_i(r_inner_batched)`, mirroring the E claim. `rerand_col_evals` are the
+/// seven columns' values at `r_inner_batched` in RERAND order.
+///
+/// `eval_point` and `r_inner_batched` must share length `log N` (already enforced
+/// when [`verify`] / [`verify_pre_inner`] returned `eval_point`, and by the
+/// inner sumcheck round count). Mismatch returns [`NovaError`] instead of
+/// panicking in `EqPolynomial::evaluate`.
+pub fn verify_final_claim<E: Engine>(
+  coeffs: &[E::Scalar],
+  eval_point: &[E::Scalar],
+  r_inner_batched: &[E::Scalar],
+  rerand_col_evals: &[E::Scalar; NUM_RERAND_COLUMNS],
+) -> Result<E::Scalar, NovaError> {
+  if eval_point.len() != r_inner_batched.len() {
+    return Err(NovaError::InvalidSumcheckProof);
+  }
+  let eq_gkr = EqPolynomial::new(eval_point.to_vec()).evaluate(r_inner_batched);
+  Ok(
+    (0..NUM_RERAND_COLUMNS)
+      .map(|i| coeffs[RERAND_BASE + i] * eq_gkr * rerand_col_evals[i])
+      .sum(),
+  )
+}
+
+/// Prover output for the Logup-GKR memory-check.
+///
+/// Bundles the three values consumed by ppSNARK integration:
+/// - `proof`: the GKR proof, absorbed into the SNARK and replayed by [`verify`];
+/// - `openings`: the seven column evaluations at the GKR `eval_point` that the
+///   host reconcile step checks;
+/// - `rerandomize`: the [`RerandomizeSumcheckInstance`] that carries those seven
+///   claims into the inner sumcheck and binds them at `r_inner_batched`.
+pub struct MemCheckProverOutput<E: Engine> {
+  /// The GKR fractional-sum proof.
+  pub proof: LogupGkrProof<E>,
+  /// Column evaluations at the GKR `eval_point` (host reconcile input).
+  pub openings: MemCheckOpenings<E>,
+  /// Seven-column opening-point reduction into the inner sumcheck.
+  pub rerandomize: RerandomizeSumcheckInstance<E>,
+  /// The shared GKR evaluation point (length `log N`).
+  pub eval_point: Vec<E::Scalar>,
+}
+
+/// Proves the ppSNARK memory-check via Logup-GKR from the raw columns.
+///
+/// This is the prover-side entry point mirroring [`verify`]. It:
+/// 1. builds the four GKR input layers ([`build_input_layers`]);
+/// 2. runs the GKR prover to fold them and emit the proof plus the shared
+///    `eval_point`;
+/// 3. evaluates the seven claimed columns at `eval_point` to form
+///    [`MemCheckOpenings`];
+/// 4. builds the [`RerandomizeSumcheckInstance`] that carries those claims into
+///    the inner sumcheck.
+///
+/// The transcript must be in the same state the verifier expects at the GKR
+/// slot (the GKR prover absorbs exactly what [`verify`] replays). `(gamma, r)`
+/// are ppSNARK's memory-check fingerprint challenges.
+pub fn prove<E: Engine>(
+  witness: MemCheckWitness<E>,
+  gamma: E::Scalar,
+  r: E::Scalar,
+  transcript: &mut E::TE,
+) -> Result<MemCheckProverOutput<E>, NovaError> {
+  // (1)+(2) Build the four input layers and fold them through the GKR trees.
+  let layers = build_input_layers(&witness, gamma, r);
+  let (proof, claim) = crate::spartan::logup_gkr::prover::prove::<E>(layers, transcript)?;
+  let eval_point = claim.eval_point().to_vec();
+
+  // (3) Assemble the opened columns at the shared point. The prover is honest
+  // and owns every column, so each opening is taken by the cheapest route that
+  // yields the same value:
+  // - `ts_row`/`ts_col` ARE the table-side numerators the GKR reduction already
+  //   produced (openings 0, 2), so reuse them directly;
+  // - `addr_row`/`addr_col`/`mem_col` are fused into the GKR dens
+  //   (`L·γ + addr + r`, `mem·γ + id + r`), so invert those closed forms instead
+  //   of re-evaluating the MLEs — one field op vs an N-wide evaluation;
+  // - `L_row`/`L_col` must be evaluated directly (they seed the rerandomize
+  //   claims and are the other unknown in the access dens), so they stay `ev`.
+  // This is a pure prover-side shortcut: soundness lives in the verifier, which
+  // opens each column against its own commitment (see `verify`).
+  let ev = |v: &[E::Scalar]| MultilinearPolynomial::evaluate_with(v, &eval_point);
+  let [row_table, row_access, col_table, col_access] = claim.openings()[..] else {
+    return Err(NovaError::InvalidNumInstances);
+  };
+  let eval_L_row = ev(&witness.L_row);
+  let eval_L_col = ev(&witness.L_col);
+  let eval_id = IdentityPolynomial::<E::Scalar>::new(eval_point.len()).evaluate(&eval_point);
+  let gamma_inv = gamma.invert().expect("fingerprint gamma is nonzero");
+  let openings = MemCheckOpenings {
+    eval_L_row,
+    eval_L_col,
+    // row_access.den = L_row·γ + addr_row + r  ⇒  addr_row = den − L_row·γ − r
+    eval_row: row_access.den - eval_L_row * gamma - r,
+    // col_access.den = L_col·γ + addr_col + r  ⇒  addr_col = den − L_col·γ − r
+    eval_col: col_access.den - eval_L_col * gamma - r,
+    eval_ts_row: row_table.num, // row_table numerator
+    eval_ts_col: col_table.num, // col_table numerator
+    // col_table.den = mem_col·γ + id + r  ⇒  mem_col = (den − id − r)·γ⁻¹
+    eval_mem_col: (col_table.den - eval_id - r) * gamma_inv,
+  };
+
+  // (4) Rerandomize instance: carry every column reconcile needs from the GKR
+  // eval_point into the inner sumcheck. Columns and claims share the fixed
+  // RERAND order [L_row, L_col, addr_row, addr_col, ts_row, ts_col, mem_col].
+  // The witness is consumed here, so its columns are moved in (no clone).
+  let claims = openings.rerand_claims().to_vec();
+  let columns = vec![
+    witness.L_row,
+    witness.L_col,
+    witness.addr_row,
+    witness.addr_col,
+    witness.ts_row,
+    witness.ts_col,
+    witness.mem_col,
+  ];
+  let rerandomize = RerandomizeSumcheckInstance::new(eval_point.clone(), columns, claims);
+
+  Ok(MemCheckProverOutput {
+    proof,
+    openings,
+    rerandomize,
+    eval_point,
+  })
+}
+
+/// Rerandomizes the GKR verifier's per-column evaluation requests at the GKR
+/// `eval_point` into the inner sumcheck, so every column reconcile needs is
+/// opened at the shared inner point `r_inner_batched` instead of at
+/// `eval_point`.
+///
+/// # Why several columns, not just L
+/// The host reconcile ([`verify`]) checks the four GKR-reduced fractions at
+/// `eval_point`. Each fraction's num/den is a fingerprint of several columns
+/// (`ts`, `L`, `addr`, `mem_col`); the verifier can self-compute only `mem_row =
+/// eq(r_outer_full, ·)` and the identity `id`. Every other column it needs at
+/// `eval_point` must be carried there. So this instance rerandomizes **all** of
+/// them (order fixed by [`MemCheckOpenings::rerand_claims`]): each column `X` becomes one
+/// sumcheck `Σ_y eq(eval_point, y) · X(y)` over the same `y ∈ {0,1}^{log N}`
+/// domain as the inner ABC/E sumcheck, folding into the shared `prove_helper`
+/// bundle and landing at `r_inner_batched`. This is exactly ppSNARK's E-claim
+/// mechanism (`Σ eq(r_outer, y) · E(y)`) applied to each column, all sharing one
+/// `eq_sumcheck` because they use the same `eval_point`.
+///
+/// # Degree
+/// Each summand `eq(eval_point, ·) · X(·)` is a product of two multilinears, so
+/// the true round-polynomial degree is **2**. [`prove_helper`] hardcodes degree
+/// 3 (it interpolates every instance with `from_evals_deg3` and asserts all
+/// bundled instances share a degree), so [`Self::degree`] reports 3 and the
+/// quadratic evals carry a zero cubic coefficient — identical to how the E-claim
+/// rides in the degree-3 inner instance.
+///
+/// [`prove_helper`]: super::ppsnark
+pub struct RerandomizeSumcheckInstance<E: Engine> {
+  /// Transparent `eq(eval_point, ·)` factor, shared by all columns.
+  eq_sumcheck: EqSumCheckInstance<E>,
+  /// The columns being rerandomized, order [`MemCheckOpenings::rerand_claims`].
+  polys: Vec<MultilinearPolynomial<E::Scalar>>,
+  /// Running claim per column (BDDT, eprint 2025/1117 §6.2).
+  running_claims: Vec<E::Scalar>,
+  /// Saved `[p(0), 0, p(-1)]` per column, used by [`SumcheckEngine::bound`].
+  saved_evals: Vec<[E::Scalar; 3]>,
+  /// Set by [`SumcheckEngine::fuse_with_coeffs`]. Once the batch coefficients are
+  /// known, the seven columns collapse into one random linear combination so the
+  /// prover scans and binds a single polynomial per round instead of seven. The
+  /// per-round output is still reported as seven triples (the combined triple in
+  /// slot 0, zeros elsewhere), so the batched prover's positional
+  /// `Σ coeffs[i]·evals[i]` stays byte-identical to the unfused per-column sum.
+  fused: Option<FusedRerandomize<E>>,
+}
+
+/// Fused single-column state for [`RerandomizeSumcheckInstance`]. Holds the
+/// coefficient-weighted combination of all columns and its running claim.
+struct FusedRerandomize<E: Engine> {
+  /// `Σ_i coeffs[i] · column_i`, bound in lockstep with `eq_sumcheck`.
+  poly: MultilinearPolynomial<E::Scalar>,
+  /// `Σ_i coeffs[i] · claim_i`, the running claim of the combined column.
+  running_claim: E::Scalar,
+  /// Saved `[p(0), 0, p(-1)]` of the combined column for [`SumcheckEngine::bound`].
+  saved: [E::Scalar; 3],
+}
+
+impl<E: Engine> RerandomizeSumcheckInstance<E> {
+  /// Builds the instance from the GKR `eval_point`, the columns (order
+  /// [`MemCheckOpenings::rerand_claims`]), and their claimed values `X(eval_point)` (the GKR
+  /// verifier's requested values, which seed the running claims and are the
+  /// instance's initial sumcheck claims). Every column must have length
+  /// `N = 2^{eval_point.len()}`.
+  pub fn new(
+    eval_point: Vec<E::Scalar>,
+    columns: Vec<Vec<E::Scalar>>,
+    claims: Vec<E::Scalar>,
+  ) -> Self {
+    assert_eq!(columns.len(), claims.len());
+    let saved_evals = vec![[E::Scalar::ZERO; 3]; columns.len()];
+    Self {
+      eq_sumcheck: EqSumCheckInstance::new(eval_point),
+      polys: columns
+        .into_iter()
+        .map(MultilinearPolynomial::new)
+        .collect(),
+      running_claims: claims,
+      saved_evals,
+      fused: None,
+    }
+  }
+}
+
+impl<E: Engine> SumcheckEngine<E> for RerandomizeSumcheckInstance<E> {
+  fn initial_claims(&self) -> Vec<E::Scalar> {
+    self.running_claims.clone()
+  }
+
+  fn degree(&self) -> usize {
+    // True degree is 2 (eq · X); reported as 3 to ride in the degree-3
+    // prove_helper bundle. See the type docs.
+    3
+  }
+
+  fn size(&self) -> usize {
+    let n = self.polys[0].len();
+    debug_assert!(self.polys.iter().all(|p| p.len() == n));
+    n
+  }
+
+  fn fuse_with_coeffs(&mut self, coeffs: &[E::Scalar]) {
+    assert_eq!(coeffs.len(), self.polys.len());
+    // Collapse the columns into `Σ_i coeffs[i] · column_i` and the claims into
+    // `Σ_i coeffs[i] · claim_i`. Both the BDDT derivation and the N-scaling sum
+    // that feed `evaluation_points_quadratic_with_one_input` are linear in
+    // `(column, claim)`, so evaluating the combined column at the combined claim
+    // equals summing the per-column triples — this makes the fused prover's
+    // per-round message byte-identical to the unfused one.
+    let n = self.polys[0].len();
+    let mut combined = vec![E::Scalar::ZERO; n];
+    combined.par_iter_mut().enumerate().for_each(|(idx, out)| {
+      *out = self
+        .polys
+        .iter()
+        .zip(coeffs.iter())
+        .map(|(poly, &c)| c * poly[idx])
+        .sum();
+    });
+    let running_claim = self
+      .running_claims
+      .iter()
+      .zip(coeffs.iter())
+      .map(|(&claim, &c)| c * claim)
+      .sum();
+    self.fused = Some(FusedRerandomize {
+      poly: MultilinearPolynomial::new(combined),
+      running_claim,
+      saved: [E::Scalar::ZERO; 3],
+    });
+  }
+
+  fn evaluation_points(&mut self) -> Vec<Vec<E::Scalar>> {
+    // Each column is one quadratic `eq(eval_point, ·) · X(·)`, sampled the same
+    // way as the E-claim. The cubic coefficient is zero (degree 2).
+    if let Some(fused) = self.fused.as_mut() {
+      // Fused: evaluate the single combined column, report its triple in slot 0
+      // and zeros elsewhere. `prove_helper` computes `Σ coeffs[i]·evals[i]`; with
+      // coeffs[0] == 1 (the slot leads the batch) this equals the combined triple
+      // — identical to summing the seven per-column triples.
+      let (e0, _, einf) = self
+        .eq_sumcheck
+        .evaluation_points_quadratic_with_one_input(&fused.poly, fused.running_claim);
+      fused.saved = [e0, E::Scalar::ZERO, einf];
+      let mut out = vec![vec![E::Scalar::ZERO; 3]; self.polys.len()];
+      out[0] = vec![e0, E::Scalar::ZERO, einf];
+      return out;
+    }
+
+    let evals: Vec<[E::Scalar; 3]> = self
+      .polys
+      .par_iter_mut()
+      .zip(self.running_claims.par_iter())
+      .map(|(poly, &claim)| {
+        let (e0, _, einf) = self
+          .eq_sumcheck
+          .evaluation_points_quadratic_with_one_input_and_cached_delta(poly, claim);
+        [e0, E::Scalar::ZERO, einf]
+      })
+      .collect();
+
+    self.saved_evals = evals.clone();
+    evals.into_iter().map(|e| e.to_vec()).collect()
+  }
+
+  fn bound(&mut self, r: &E::Scalar) {
+    if let Some(fused) = self.fused.as_mut() {
+      fused.running_claim = SumcheckProof::<E>::update_claim(fused.running_claim, &fused.saved, r);
+      fused.poly.bind_poly_var_top(r);
+      self.eq_sumcheck.bound(r);
+      return;
+    }
+
+    self.running_claims = self
+      .running_claims
+      .iter()
+      .zip(self.saved_evals.iter())
+      .map(|(&claim, saved)| SumcheckProof::<E>::update_claim(claim, saved, r))
+      .collect();
+
+    self
+      .polys
+      .par_iter_mut()
+      .for_each(|poly| poly.bind_poly_var_top_with_cached_delta(r));
+
+    self.eq_sumcheck.bound(r);
+  }
+
+  fn final_claims(&self) -> Vec<Vec<E::Scalar>> {
+    // Fused: only the combined column survives; the ppSNARK GKR path reads
+    // ts_row/ts_col directly from the PK columns rather than from here. Return the
+    // combined final in slot 0 for symmetry.
+    if let Some(fused) = self.fused.as_ref() {
+      return vec![vec![fused.poly[0]]];
+    }
+    self.polys.iter().map(|p| vec![p[0]]).collect()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  //! End-to-end tests through the top-level [`prove`]/[`verify`] pair. Each test
+  //! builds four N=4 sub-instances and checks the host accepts a balanced witness
+  //! while rejecting tampered multiplicities or mismatched column claims. This
+  //! covers input-layer construction, reconcile, balance, and rerandomize claim
+  //! ordering.
+  use super::*;
+  use crate::spartan::logup_gkr::proof::LayerFinalClaim;
+  use crate::traits::TranscriptEngineTrait;
+
+  type E = crate::provider::Bn256EngineKZG;
+  type Fr = <E as Engine>::Scalar;
+
+  /// A hand-built N=4 memory-check witness whose row and col relations both
+  /// balance. We choose the fingerprint pieces directly (γ, r and the per-cell
+  /// columns) and derive `mem_row`/`mem_col`/dens so that `Σ ts/(T+r) =
+  /// Σ 1/(W+r)` holds on each side.
+  ///
+  /// Construction: pick 4 distinct table dens `T[i]` freely; the access side is
+  /// a multiset of reads into those cells with multiplicities `ts`, so the
+  /// access dens are exactly the `T` values repeated per read. With N=4 reads
+  /// over the 4 cells and `ts = [ts0..ts3]` summing to 4, the balance is
+  /// `Σ ts[i]/(T[i]+r) = Σ_reads 1/(T[read]+r)` — identical multisets, so it
+  /// holds by construction. Here we use `ts = [2,1,1,0]` and reads
+  /// `[cell0, cell0, cell1, cell2]`.
+  struct Witness {
+    gamma: Fr,
+    r: Fr,
+    r_outer_full: Vec<Fr>,
+    cols: MemCheckWitness<E>,
+  }
+
+  // A balanced N=4 witness. mem_row is eq(r_outer_full, ·) so the verifier can
+  // recompute it; we set r_outer_full = [0,0] giving mem_row = [1,0,0,0].
+  fn balanced_witness() -> Witness {
+    let r_outer_full = vec![Fr::ZERO, Fr::ZERO];
+    let mem_row = EqPolynomial::new(r_outer_full.clone()).evals(); // [1,0,0,0]
+    let mem_col = vec![Fr::from(5), Fr::from(6), Fr::from(7), Fr::from(8)];
+    // reads = [cell0, cell0, cell1, cell2]; ts = [2,1,1,0].
+    let reads = [0usize, 0, 1, 2];
+    let ts_row = vec![Fr::from(2), Fr::from(1), Fr::from(1), Fr::ZERO];
+    let ts_col = ts_row.clone();
+    let addr_row: Vec<Fr> = reads.iter().map(|&i| Fr::from(i as u64)).collect();
+    let addr_col = addr_row.clone();
+    // access lookup value = the table value at the read cell.
+    let L_row: Vec<Fr> = reads.iter().map(|&i| mem_row[i]).collect();
+    let L_col: Vec<Fr> = reads.iter().map(|&i| mem_col[i]).collect();
+    Witness {
+      gamma: Fr::from(3),
+      r: Fr::from(9),
+      r_outer_full,
+      cols: MemCheckWitness {
+        mem_row,
+        mem_col,
+        L_row,
+        L_col,
+        addr_row,
+        addr_col,
+        ts_row,
+        ts_col,
+      },
+    }
+  }
+
+  fn run(w: &Witness) -> Result<Vec<Fr>, NovaError> {
+    let mut tr_p = <E as Engine>::TE::new(b"memcheck-test");
+    let out = prove::<E>(w.cols.clone(), w.gamma, w.r, &mut tr_p).expect("prove");
+    let mut tr_v = <E as Engine>::TE::new(b"memcheck-test");
+    verify::<E>(
+      &out.proof,
+      w.gamma,
+      w.r,
+      &w.r_outer_full,
+      &out.openings,
+      &mut tr_v,
+    )
+  }
+
+  #[test]
+  fn accepts_balanced_witness() {
+    let w = balanced_witness();
+    let pt = run(&w).expect("host verifier must accept a balanced witness");
+    assert_eq!(pt.len(), 2, "eval_point has log N = 2 variables");
+  }
+
+  #[test]
+  fn rejects_tampered_ts() {
+    // Break the row balance by bumping a multiplicity: Σ ts/(T+r) no longer
+    // equals Σ 1/(W+r). The GKR proof is still built from the tampered layers,
+    // so the balance check (not reconcile) is what fails.
+    let mut w = balanced_witness();
+    w.cols.ts_row[0] += Fr::ONE;
+    assert!(run(&w).is_err(), "must reject an unbalanced multiplicity");
+  }
+
+  #[test]
+  fn rejects_mismatched_opening() {
+    // Keep the layers balanced but feed the host a wrong opened column, so the
+    // reconcile step (recomputed fraction vs GKR opening) fails.
+    let w = balanced_witness();
+    let mut tr_p = <E as Engine>::TE::new(b"memcheck-test");
+    let mut out = prove::<E>(w.cols.clone(), w.gamma, w.r, &mut tr_p).expect("prove");
+    out.openings.eval_L_row += Fr::ONE; // inconsistent with the committed layer
+    let mut tr_v = <E as Engine>::TE::new(b"memcheck-test");
+    assert!(
+      verify::<E>(
+        &out.proof,
+        w.gamma,
+        w.r,
+        &w.r_outer_full,
+        &out.openings,
+        &mut tr_v
+      )
+      .is_err(),
+      "must reject an opening that disagrees with the GKR reduction"
+    );
+  }
+
+  /// Zero cubic round poly whose `g(0)+g(1)=0` (valid for a zero sumcheck claim).
+  fn zero_cubic_compressed() -> crate::spartan::polys::univariate::CompressedUniPoly<Fr> {
+    use crate::spartan::polys::univariate::UniPoly;
+    UniPoly::from_evals_deg3(&[Fr::ZERO, Fr::ZERO, Fr::ZERO, Fr::ZERO]).compress()
+  }
+
+  /// All-`(0,0)` intermediate GKR forged for `num_vars = 2`, `m = 4`.
+  /// Variant A: roots `(0,1)` — the documented P0 shape (blocked at root gate).
+  /// Variant B: roots `(0,0)` — passes GKR exact root check but fails host reconcile.
+  fn forged_zero_gkr(roots_den_one: bool) -> LogupGkrProof<E> {
+    let zero = Fraction::new(Fr::ZERO, Fr::ZERO);
+    let split = LayerFinalClaim {
+      left: zero,
+      right: zero,
+    };
+    let root = if roots_den_one {
+      Fraction::new(Fr::ZERO, Fr::ONE)
+    } else {
+      zero
+    };
+    LogupGkrProof {
+      initial_claims: vec![root; 4],
+      final_claims: vec![vec![split; 4], vec![split; 4]],
+      sumchecks: vec![crate::spartan::logup_gkr::proof::LayerSumcheck {
+        round_polys: vec![zero_cubic_compressed()],
+      }],
+    }
+  }
+
+  #[test]
+  fn rejects_p0_zero_zero_chain_with_unit_roots() {
+    // Classic P0: roots `(0,1)`, every split `(0,0)`, zero sumchecks, real
+    // column openings. Cross-mult accepted this end-to-end; exact equality must
+    // reject (at the GKR root gate).
+    let w = balanced_witness();
+    let mut tr_p = <E as Engine>::TE::new(b"memcheck-p0");
+    let out = prove::<E>(w.cols.clone(), w.gamma, w.r, &mut tr_p).expect("prove");
+    let forged = forged_zero_gkr(true);
+    let mut tr_v = <E as Engine>::TE::new(b"memcheck-p0");
+    assert!(
+      verify::<E>(
+        &forged,
+        w.gamma,
+        w.r,
+        &w.r_outer_full,
+        &out.openings,
+        &mut tr_v
+      )
+      .is_err(),
+      "must reject P0 (0,1)/(0,0) forgery"
+    );
+  }
+
+  #[test]
+  fn rejects_all_zero_gkr_chain_against_real_openings() {
+    // Roots `(0,0)` make the root gate pass under exact equality too, but host
+    // reconcile must still refuse `(a,b) == (0,0)`.
+    let w = balanced_witness();
+    let mut tr_p = <E as Engine>::TE::new(b"memcheck-p0b");
+    let out = prove::<E>(w.cols.clone(), w.gamma, w.r, &mut tr_p).expect("prove");
+    // Openings are at the honest eval_point; forged proof yields a different
+    // point, but reconcile compares fraction components before that matters —
+    // and even if GKR completed, reduced is `(0,0)` ≠ recomputed dens.
+    // Rebuild openings for the forged eval_point by re-proving is unnecessary:
+    // any nonzero fingerprint den against reduced `(0,0)` fails exact match.
+    let forged = forged_zero_gkr(false);
+    let mut tr_v = <E as Engine>::TE::new(b"memcheck-p0b");
+    // Transcript label matches prove so this is a clean replay attempt; GKR
+    // absorbs forged claims first. Real openings (wrong point) still give
+    // nonzero dens almost surely vs reduced `(0,0)`.
+    assert!(
+      verify::<E>(
+        &forged,
+        w.gamma,
+        w.r,
+        &w.r_outer_full,
+        &out.openings,
+        &mut tr_v
+      )
+      .is_err(),
+      "must reject all-(0,0) GKR against real column openings"
+    );
+  }
+
+  #[test]
+  fn rejects_wrong_gkr_depth() {
+    // Forged depth-1 proof against trusted `r_outer_full` of length 2: must
+    // return `Err`, not panic in `EqPolynomial::evaluate`.
+    let w = balanced_witness();
+    let mut tr_p = <E as Engine>::TE::new(b"memcheck-depth");
+    let out = prove::<E>(w.cols.clone(), w.gamma, w.r, &mut tr_p).expect("prove");
+    // Root `(0,1)` with children that gate to `(0,1)` so GKR accepts at depth 1.
+    let one = Fraction::new(Fr::ZERO, Fr::ONE);
+    let split = LayerFinalClaim {
+      left: one,
+      right: one, // gate = (0,1)+(0,1) = (0,1)
+    };
+    let forged = LogupGkrProof {
+      initial_claims: vec![one; 4],
+      final_claims: vec![vec![split; 4]],
+      sumchecks: vec![],
+    };
+    let mut tr_v = <E as Engine>::TE::new(b"memcheck-depth");
+    assert!(
+      verify::<E>(
+        &forged,
+        w.gamma,
+        w.r,
+        &w.r_outer_full,
+        &out.openings,
+        &mut tr_v
+      )
+      .is_err(),
+      "must reject GKR depth ≠ log N without panicking"
+    );
+  }
+
+  #[test]
+  fn rerandomize_claims_match_openings() {
+    // The rerandomize instance's initial claims must be exactly the claimed
+    // column values at eval_point, in the fixed RERAND order.
+    let w = balanced_witness();
+    let mut tr_p = <E as Engine>::TE::new(b"memcheck-test");
+    let out = prove::<E>(w.cols.clone(), w.gamma, w.r, &mut tr_p).expect("prove");
+    let claims = out.rerandomize.initial_claims();
+    assert_eq!(claims, out.openings.rerand_claims().to_vec());
+    assert_eq!(claims.len(), NUM_RERAND_COLUMNS);
+  }
+
+  #[cfg(feature = "evm")]
+  #[test]
+  fn gkr_proof_data_has_big_endian_scalar_golden_encoding() {
+    let data = GkrProofData::<E> {
+      proof: LogupGkrProof {
+        initial_claims: vec![Fraction::new(Fr::from(1), Fr::from(2))],
+        final_claims: vec![vec![LayerFinalClaim {
+          left: Fraction::new(Fr::from(3), Fr::from(4)),
+          right: Fraction::new(Fr::from(5), Fr::from(6)),
+        }]],
+        sumchecks: vec![],
+      },
+      rerand_claims: core::array::from_fn(|i| Fr::from(i as u64 + 7)),
+    };
+    let config = bincode::config::legacy()
+      .with_big_endian()
+      .with_fixed_int_encoding();
+    let bytes = bincode::serde::encode_to_vec(&data, config).expect("serialize GKR proof data");
+
+    fn push_len(bytes: &mut Vec<u8>, len: u64) {
+      bytes.extend_from_slice(&len.to_be_bytes());
+    }
+
+    fn push_scalar(bytes: &mut Vec<u8>, value: u8) {
+      bytes.extend_from_slice(&[0u8; 31]);
+      bytes.push(value);
+    }
+
+    let mut expected = Vec::new();
+    push_len(&mut expected, 1); // initial_claims
+    push_scalar(&mut expected, 1);
+    push_scalar(&mut expected, 2);
+    push_len(&mut expected, 1); // final_claims layers
+    push_len(&mut expected, 1); // final claims in the layer
+    for value in 3..=6 {
+      push_scalar(&mut expected, value);
+    }
+    push_len(&mut expected, 0); // sumchecks
+    for value in 7..=13 {
+      push_scalar(&mut expected, value);
+    }
+    assert_eq!(bytes, expected);
+
+    let (decoded, consumed): (GkrProofData<E>, usize) =
+      bincode::serde::decode_from_slice(&bytes, config).expect("deserialize GKR proof data");
+    assert_eq!(consumed, expected.len());
+    assert_eq!(
+      bincode::serde::encode_to_vec(decoded, config).expect("re-serialize GKR proof data"),
+      expected
+    );
+  }
+}

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -6,6 +6,9 @@
 //!
 //! In polynomial.rs we also provide foundational types and functions for manipulating multilinear polynomials.
 pub mod direct;
+pub mod logup_gkr;
+pub mod mem_check_logup;
+pub mod mem_check_logup_gkr;
 pub mod ppsnark;
 pub mod snark;
 

--- a/src/spartan/polys/multilinear.rs
+++ b/src/spartan/polys/multilinear.rs
@@ -83,6 +83,39 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
     self.num_vars -= 1;
   }
 
+  /// Binds the top variable after the high half has been replaced by
+  /// `high - low`.
+  ///
+  /// This is the second half of an explicit evaluate-then-bind optimization:
+  /// the round-polynomial evaluation stores each top-variable slope in the
+  /// corresponding high-half slot, then this method reuses it once the
+  /// verifier challenge is known.
+  ///
+  /// # Preconditions
+  ///
+  /// The high half must contain `high - low` from the matching cached-delta
+  /// evaluation in the current round. Calling this after a non-caching
+  /// evaluation silently produces the wrong polynomial.
+  pub(crate) fn bind_poly_var_top_with_cached_delta(&mut self, r: &Scalar) {
+    assert!(self.num_vars > 0);
+
+    let n = self.len() / 2;
+    let (left, deltas) = self.Z.split_at_mut(n);
+
+    if n < PARALLEL_THRESHOLD {
+      left.iter_mut().zip(deltas.iter()).for_each(|(low, delta)| {
+        *low += *r * delta;
+      });
+    } else {
+      zip_with_for_each!((left.par_iter_mut(), deltas.par_iter()), |low, delta| {
+        *low += *r * delta;
+      });
+    }
+
+    self.Z.resize(n, Scalar::ZERO);
+    self.num_vars -= 1;
+  }
+
   /// Evaluates the polynomial at the given point.
   /// Returns Z(r) in O(n) time using O(sqrt(n)) memory for eq tables.
   ///
@@ -409,6 +442,35 @@ mod tests {
     bind_and_evaluate_with::<pallas::Scalar>();
     bind_and_evaluate_with::<bn256::Scalar>();
     bind_and_evaluate_with::<secp256k1::Scalar>();
+  }
+
+  fn cached_delta_bind_matches_with<F: PrimeField>() {
+    for num_vars in [7, 13] {
+      let mut rng = ChaCha20Rng::from_seed([num_vars as u8; 32]);
+      let poly = random(num_vars, &mut rng);
+      let r = F::random(&mut rng);
+
+      let mut expected = poly.clone();
+      expected.bind_poly_var_top(&r);
+
+      let mut actual = poly;
+      let half = actual.len() / 2;
+      let (low, high) = actual.Z.split_at_mut(half);
+      high
+        .iter_mut()
+        .zip(low.iter())
+        .for_each(|(high, low)| *high -= low);
+      actual.bind_poly_var_top_with_cached_delta(&r);
+
+      assert_eq!(actual, expected);
+    }
+  }
+
+  #[test]
+  fn test_cached_delta_bind_matches() {
+    cached_delta_bind_matches_with::<pallas::Scalar>();
+    cached_delta_bind_matches_with::<bn256::Scalar>();
+    cached_delta_bind_matches_with::<secp256k1::Scalar>();
   }
 
   fn test_multi_evaluate_with_matches_single<F: PrimeField>() {

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -768,11 +768,8 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
 
     // Step 1: Outer sum-check (standalone, degree-3) on size-m polynomials
     // Proves: 0 = Σ_{x∈{0,1}^log(m)} eq(τ,x) * (Az(x) * Bz(x) - (u·Cz(x) + E(x)))
-    let uCz_E: Vec<E::Scalar> = Cz
-      .iter()
-      .zip(W_padded.E.iter())
-      .map(|(cz, e)| U.u * *cz + *e)
-      .collect();
+    let uCz_E: Vec<E::Scalar> =
+      zip_with!(par_iter, (Cz, W_padded.E), |cz, e| U.u * *cz + *e).collect();
     let mut poly_Az = MultilinearPolynomial::new(Az);
     let mut poly_Bz = MultilinearPolynomial::new(Bz);
     let mut poly_uCz_E = MultilinearPolynomial::new(uCz_E);

--- a/src/spartan/ppsnark.rs
+++ b/src/spartan/ppsnark.rs
@@ -3,19 +3,24 @@
 //! The verifier in this preprocessing SNARK maintains a commitment to R1CS matrices. This is beneficial when using a
 //! polynomial commitment scheme in which the verifier's costs is succinct.
 //! The SNARK implemented here is described in the MicroNova paper.
+#[cfg(feature = "logup-no-gkr")]
+use crate::spartan::mem_check_logup;
+#[cfg(not(feature = "logup-no-gkr"))]
+use crate::spartan::{
+  mem_check_logup_gkr::{self, MemCheckWitness},
+  polys::multilinear::SparsePolynomial,
+};
 use crate::traits::evm_serde::EvmCompatSerde;
 use crate::{
   digest::{DigestComputer, SimpleDigestible},
   errors::NovaError,
   r1cs::{R1CSShape, RelaxedR1CSInstance, RelaxedR1CSWitness},
   spartan::{
-    batch_invert,
     math::Math,
     polys::{
       eq::EqPolynomial,
-      identity::IdentityPolynomial,
       masked_eq::MaskedEqPolynomial,
-      multilinear::{MultilinearPolynomial, SparsePolynomial},
+      multilinear::MultilinearPolynomial,
       univariate::{CompressedUniPoly, UniPoly},
     },
     powers,
@@ -324,351 +329,6 @@ impl<E: Engine> SumcheckEngine<E> for WitnessBoundSumcheck<E> {
   }
 }
 
-/// Memory sumcheck instance for PPSNARK LogUp
-pub struct MemorySumcheckInstance<E: Engine> {
-  // row
-  w_plus_r_row: MultilinearPolynomial<E::Scalar>,
-  t_plus_r_row: MultilinearPolynomial<E::Scalar>,
-  t_plus_r_inv_row: MultilinearPolynomial<E::Scalar>,
-  w_plus_r_inv_row: MultilinearPolynomial<E::Scalar>,
-  ts_row: MultilinearPolynomial<E::Scalar>,
-
-  // col
-  w_plus_r_col: MultilinearPolynomial<E::Scalar>,
-  t_plus_r_col: MultilinearPolynomial<E::Scalar>,
-  t_plus_r_inv_col: MultilinearPolynomial<E::Scalar>,
-  w_plus_r_inv_col: MultilinearPolynomial<E::Scalar>,
-  ts_col: MultilinearPolynomial<E::Scalar>,
-
-  eq_sumcheck: EqSumCheckInstance<E>,
-
-  // Per-claim running claims and saved evaluation points (BDDT, eprint 2025/1117 Section 6.2)
-  running_claims: [E::Scalar; 6],
-  saved_evals: [[E::Scalar; 3]; 6],
-}
-
-impl<E: Engine> MemorySumcheckInstance<E> {
-  /// Computes witnesses for MemoryInstanceSumcheck
-  ///
-  /// # Description
-  /// We use the logUp protocol to prove that
-  /// sum TS\[i\]/(T\[i\] + r) - 1/(W\[i\] + r) = 0
-  /// where
-  ///   T_row\[i\] = mem_row\[i\]      * gamma + i
-  ///            = eq(tau)\[i\]      * gamma + i
-  ///   W_row\[i\] = L_row\[i\]        * gamma + addr_row\[i\]
-  ///            = eq(tau)\[row\[i\]\] * gamma + addr_row\[i\]
-  ///   T_col\[i\] = mem_col\[i\]      * gamma + i
-  ///            = z\[i\]            * gamma + i
-  ///   W_col\[i\] = L_col\[i\]     * gamma + addr_col\[i\]
-  ///            = z\[col\[i\]\]       * gamma + addr_col\[i\]
-  /// and
-  ///   TS_row, TS_col are integer-valued vectors representing the number of reads
-  ///   to each memory cell of L_row, L_col
-  ///
-  /// The function returns oracles for the polynomials TS\[i\]/(T\[i\] + r), 1/(W\[i\] + r),
-  /// as well as auxiliary polynomials T\[i\] + r, W\[i\] + r
-  pub fn compute_oracles(
-    ck: &CommitmentKey<E>,
-    r: &E::Scalar,
-    gamma: &E::Scalar,
-    mem_row: &[E::Scalar],
-    addr_row: &[E::Scalar],
-    L_row: &[E::Scalar],
-    ts_row: &[E::Scalar],
-    mem_col: &[E::Scalar],
-    addr_col: &[E::Scalar],
-    L_col: &[E::Scalar],
-    ts_col: &[E::Scalar],
-  ) -> Result<([Commitment<E>; 4], [Vec<E::Scalar>; 4], [Vec<E::Scalar>; 4]), NovaError> {
-    // hash the tuples of (addr,val) memory contents and read responses into a single field element using `hash_func`
-    let hash_func_vec = |mem: &[E::Scalar],
-                         addr: &[E::Scalar],
-                         lookups: &[E::Scalar]|
-     -> (Vec<E::Scalar>, Vec<E::Scalar>) {
-      let hash_func = |addr: &E::Scalar, val: &E::Scalar| -> E::Scalar { *val * gamma + *addr };
-      assert_eq!(addr.len(), lookups.len());
-      rayon::join(
-        || {
-          (0..mem.len())
-            .map(|i| hash_func(&E::Scalar::from(i as u64), &mem[i]))
-            .collect::<Vec<E::Scalar>>()
-        },
-        || {
-          (0..addr.len())
-            .map(|i| hash_func(&addr[i], &lookups[i]))
-            .collect::<Vec<E::Scalar>>()
-        },
-      )
-    };
-
-    let ((T_row, W_row), (T_col, W_col)) = rayon::join(
-      || hash_func_vec(mem_row, addr_row, L_row),
-      || hash_func_vec(mem_col, addr_col, L_col),
-    );
-
-    // compute vectors TS[i]/(T[i] + r) and 1/(W[i] + r)
-    let helper = |T: &[E::Scalar],
-                  W: &[E::Scalar],
-                  TS: &[E::Scalar],
-                  r: &E::Scalar|
-     -> Result<
-      (
-        Vec<E::Scalar>,
-        Vec<E::Scalar>,
-        Vec<E::Scalar>,
-        Vec<E::Scalar>,
-      ),
-      NovaError,
-    > {
-      let t_plus_r_and_w_plus_r = T
-        .par_iter()
-        .chain(W.par_iter())
-        .map(|e| *e + *r)
-        .collect::<Vec<E::Scalar>>();
-
-      let inv = batch_invert(&t_plus_r_and_w_plus_r)?;
-
-      let mut t_plus_r = t_plus_r_and_w_plus_r;
-      let w_plus_r = t_plus_r.split_off(T.len());
-
-      let mut t_plus_r_inv = inv;
-      let w_plus_r_inv = t_plus_r_inv.split_off(T.len());
-
-      // compute inv[i] * TS[i] in parallel
-      t_plus_r_inv = zip_with!((t_plus_r_inv.into_par_iter(), TS.par_iter()), |e1, e2| e1
-        * *e2)
-      .collect::<Vec<_>>();
-
-      Ok((t_plus_r_inv, w_plus_r_inv, t_plus_r, w_plus_r))
-    };
-
-    let (row, col) = rayon::join(
-      || helper(&T_row, &W_row, ts_row, r),
-      || helper(&T_col, &W_col, ts_col, r),
-    );
-
-    let (t_plus_r_inv_row, w_plus_r_inv_row, t_plus_r_row, w_plus_r_row) = row?;
-    let (t_plus_r_inv_col, w_plus_r_inv_col, t_plus_r_col, w_plus_r_col) = col?;
-
-    let (
-      (comm_t_plus_r_inv_row, comm_w_plus_r_inv_row),
-      (comm_t_plus_r_inv_col, comm_w_plus_r_inv_col),
-    ) = rayon::join(
-      || {
-        rayon::join(
-          || E::CE::commit(ck, &t_plus_r_inv_row, &E::Scalar::ZERO),
-          || E::CE::commit(ck, &w_plus_r_inv_row, &E::Scalar::ZERO),
-        )
-      },
-      || {
-        rayon::join(
-          || E::CE::commit(ck, &t_plus_r_inv_col, &E::Scalar::ZERO),
-          || E::CE::commit(ck, &w_plus_r_inv_col, &E::Scalar::ZERO),
-        )
-      },
-    );
-
-    let comm_vec = [
-      comm_t_plus_r_inv_row,
-      comm_w_plus_r_inv_row,
-      comm_t_plus_r_inv_col,
-      comm_w_plus_r_inv_col,
-    ];
-
-    let poly_vec = [
-      t_plus_r_inv_row,
-      w_plus_r_inv_row,
-      t_plus_r_inv_col,
-      w_plus_r_inv_col,
-    ];
-
-    let aux_poly_vec = [t_plus_r_row, w_plus_r_row, t_plus_r_col, w_plus_r_col];
-
-    Ok((comm_vec, poly_vec, aux_poly_vec))
-  }
-
-  /// Create a new memory sumcheck instance
-  pub fn new(
-    polys_oracle: [Vec<E::Scalar>; 4],
-    polys_aux: [Vec<E::Scalar>; 4],
-    rhos: Vec<E::Scalar>,
-    ts_row: Vec<E::Scalar>,
-    ts_col: Vec<E::Scalar>,
-  ) -> Self {
-    let [t_plus_r_inv_row, w_plus_r_inv_row, t_plus_r_inv_col, w_plus_r_inv_col] = polys_oracle;
-    let [t_plus_r_row, w_plus_r_row, t_plus_r_col, w_plus_r_col] = polys_aux;
-
-    Self {
-      w_plus_r_row: MultilinearPolynomial::new(w_plus_r_row),
-      t_plus_r_row: MultilinearPolynomial::new(t_plus_r_row),
-      t_plus_r_inv_row: MultilinearPolynomial::new(t_plus_r_inv_row),
-      w_plus_r_inv_row: MultilinearPolynomial::new(w_plus_r_inv_row),
-      ts_row: MultilinearPolynomial::new(ts_row),
-      w_plus_r_col: MultilinearPolynomial::new(w_plus_r_col),
-      t_plus_r_col: MultilinearPolynomial::new(t_plus_r_col),
-      t_plus_r_inv_col: MultilinearPolynomial::new(t_plus_r_inv_col),
-      w_plus_r_inv_col: MultilinearPolynomial::new(w_plus_r_inv_col),
-      ts_col: MultilinearPolynomial::new(ts_col),
-      eq_sumcheck: EqSumCheckInstance::new(rhos),
-      running_claims: [E::Scalar::ZERO; 6],
-      saved_evals: [[E::Scalar::ZERO; 3]; 6],
-    }
-  }
-}
-
-impl<E: Engine> SumcheckEngine<E> for MemorySumcheckInstance<E> {
-  fn initial_claims(&self) -> Vec<E::Scalar> {
-    vec![E::Scalar::ZERO; 6]
-  }
-
-  fn degree(&self) -> usize {
-    3
-  }
-
-  fn size(&self) -> usize {
-    // sanity checks
-    assert_eq!(self.w_plus_r_row.len(), self.t_plus_r_row.len());
-    assert_eq!(self.w_plus_r_row.len(), self.ts_row.len());
-    assert_eq!(self.w_plus_r_row.len(), self.w_plus_r_col.len());
-    assert_eq!(self.w_plus_r_row.len(), self.t_plus_r_col.len());
-    assert_eq!(self.w_plus_r_row.len(), self.ts_col.len());
-
-    self.w_plus_r_row.len()
-  }
-
-  fn evaluation_points(&mut self) -> Vec<Vec<E::Scalar>> {
-    // Pre-borrow all fields as shared references for parallel access
-    let eq = &self.eq_sumcheck;
-    let running_claims = &self.running_claims;
-    let t_plus_r_inv_row = &self.t_plus_r_inv_row;
-    let w_plus_r_inv_row = &self.w_plus_r_inv_row;
-    let t_plus_r_row = &self.t_plus_r_row;
-    let w_plus_r_row = &self.w_plus_r_row;
-    let ts_row = &self.ts_row;
-    let t_plus_r_inv_col = &self.t_plus_r_inv_col;
-    let w_plus_r_inv_col = &self.w_plus_r_inv_col;
-    let t_plus_r_col = &self.t_plus_r_col;
-    let w_plus_r_col = &self.w_plus_r_col;
-    let ts_col = &self.ts_col;
-
-    // inv related evaluation points for linear (A - B) pattern (no claim derivation)
-    // 0 = sum TS[i]/(T[i] + r) - 1/(W[i] + r)
-    let (
-      ((eval_inv_0_row, eval_inv_3_row), (eval_inv_0_col, eval_inv_3_col)),
-      (
-        ((eval_T_0_row, eval_T_2_row, eval_T_3_row), (eval_W_0_row, eval_W_2_row, eval_W_3_row)),
-        ((eval_T_0_col, eval_T_2_col, eval_T_3_col), (eval_W_0_col, eval_W_2_col, eval_W_3_col)),
-      ),
-    ) = rayon::join(
-      || {
-        rayon::join(
-          || SumcheckProof::<E>::compute_eval_points_linear(t_plus_r_inv_row, w_plus_r_inv_row),
-          || SumcheckProof::<E>::compute_eval_points_linear(t_plus_r_inv_col, w_plus_r_inv_col),
-        )
-      },
-      || {
-        rayon::join(
-          || {
-            // Row evaluation points (claim-derived, BDDT Section 6.2)
-            rayon::join(
-              || {
-                // 0 = sum eq[i] * (inv_T[i] * (T[i] + r) - TS[i]))
-                eq.evaluation_points_cubic_with_three_inputs(
-                  t_plus_r_inv_row,
-                  t_plus_r_row,
-                  ts_row,
-                  running_claims[2],
-                )
-              },
-              || {
-                // 0 = sum eq[i] * (inv_W[i] * (W[i] + r) - 1))
-                eq.evaluation_points_cubic_with_two_inputs(
-                  w_plus_r_inv_row,
-                  w_plus_r_row,
-                  running_claims[3],
-                )
-              },
-            )
-          },
-          || {
-            // Column evaluation points (claim-derived, BDDT Section 6.2)
-            rayon::join(
-              || {
-                eq.evaluation_points_cubic_with_three_inputs(
-                  t_plus_r_inv_col,
-                  t_plus_r_col,
-                  ts_col,
-                  running_claims[4],
-                )
-              },
-              || {
-                eq.evaluation_points_cubic_with_two_inputs(
-                  w_plus_r_inv_col,
-                  w_plus_r_col,
-                  running_claims[5],
-                )
-              },
-            )
-          },
-        )
-      },
-    );
-
-    // Save evaluation points for running claim updates in bound()
-    self.saved_evals = [
-      [eval_inv_0_row, E::Scalar::ZERO, eval_inv_3_row],
-      [eval_inv_0_col, E::Scalar::ZERO, eval_inv_3_col],
-      [eval_T_0_row, eval_T_2_row, eval_T_3_row],
-      [eval_W_0_row, eval_W_2_row, eval_W_3_row],
-      [eval_T_0_col, eval_T_2_col, eval_T_3_col],
-      [eval_W_0_col, eval_W_2_col, eval_W_3_col],
-    ];
-
-    self.saved_evals.iter().map(|e| e.to_vec()).collect()
-  }
-
-  fn bound(&mut self, r: &E::Scalar) {
-    for j in 0..6 {
-      self.running_claims[j] =
-        SumcheckProof::<E>::update_claim(self.running_claims[j], &self.saved_evals[j], r);
-    }
-
-    [
-      &mut self.t_plus_r_row,
-      &mut self.t_plus_r_inv_row,
-      &mut self.w_plus_r_row,
-      &mut self.w_plus_r_inv_row,
-      &mut self.ts_row,
-      &mut self.t_plus_r_col,
-      &mut self.t_plus_r_inv_col,
-      &mut self.w_plus_r_col,
-      &mut self.w_plus_r_inv_col,
-      &mut self.ts_col,
-    ]
-    .par_iter_mut()
-    .for_each(|poly| poly.bind_poly_var_top(r));
-
-    self.eq_sumcheck.bound(r);
-  }
-
-  fn final_claims(&self) -> Vec<Vec<E::Scalar>> {
-    let poly_row_final = vec![
-      self.t_plus_r_inv_row[0],
-      self.w_plus_r_inv_row[0],
-      self.ts_row[0],
-    ];
-
-    let poly_col_final = vec![
-      self.t_plus_r_inv_col[0],
-      self.w_plus_r_inv_col[0],
-      self.ts_col[0],
-    ];
-
-    vec![poly_row_final, poly_col_final]
-  }
-}
-
 /// Inner batched sumcheck instance for PPSNARK
 ///
 /// Proves two claims:
@@ -739,16 +399,22 @@ impl<E: Engine> SumcheckEngine<E> for InnerBatchedSumcheckInstance<E> {
   }
 
   fn evaluation_points(&mut self) -> Vec<Vec<E::Scalar>> {
-    let (poly_A, poly_B, poly_C) = (&self.poly_L_row, &self.poly_L_col, &self.poly_val);
+    let running_claim_E = self.running_claim_E;
+    let eq_sumcheck = &self.eq_sumcheck;
+    let (poly_A, poly_B, poly_C, poly_E) = (
+      &mut self.poly_L_row,
+      &mut self.poly_L_col,
+      &mut self.poly_val,
+      &mut self.poly_E,
+    );
 
     // E claim: 1 N-scaling sum + claim-derived (BDDT, eprint 2025/1117 Section 6.2)
     let ((eval_point_0, bound_coeff, eval_point_inf), (eval_E_0, eval_E_bound_coeff, eval_E_inf)) =
       rayon::join(
-        || SumcheckProof::<E>::compute_eval_points_cubic(poly_A, poly_B, poly_C),
+        || SumcheckProof::<E>::compute_eval_points_cubic_with_cached_deltas(poly_A, poly_B, poly_C),
         || {
-          self
-            .eq_sumcheck
-            .evaluation_points_quadratic_with_one_input(&self.poly_E, self.running_claim_E)
+          eq_sumcheck
+            .evaluation_points_quadratic_with_one_input_and_cached_delta(poly_E, running_claim_E)
         },
       );
 
@@ -772,7 +438,7 @@ impl<E: Engine> SumcheckEngine<E> for InnerBatchedSumcheckInstance<E> {
       &mut self.poly_E,
     ]
     .par_iter_mut()
-    .for_each(|poly| poly.bind_poly_var_top(r));
+    .for_each(|poly| poly.bind_poly_var_top_with_cached_delta(r));
 
     self.eq_sumcheck.bound(r);
   }
@@ -820,11 +486,14 @@ pub struct RelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
   comm_L_row: Commitment<E>,
   comm_L_col: Commitment<E>,
 
-  // commitments to aid the memory checks
-  comm_t_plus_r_inv_row: Commitment<E>,
-  comm_w_plus_r_inv_row: Commitment<E>,
-  comm_t_plus_r_inv_col: Commitment<E>,
-  comm_w_plus_r_inv_col: Commitment<E>,
+  // Memory-check proof data, one field per implementation, feature-gated:
+  // inverse-logup (feature `logup-no-gkr`) carries the four inverse-oracle
+  // commitments + evals; Logup-GKR (default) carries the fractional-sum proof +
+  // the rerandomize claims.
+  #[cfg(feature = "logup-no-gkr")]
+  mem_check: mem_check_logup::LogupProofData<E>,
+  #[cfg(not(feature = "logup-no-gkr"))]
+  mem_check_gkr: mem_check_logup_gkr::GkrProofData<E>,
 
   // outer sum-check proof
   sc_outer: SumcheckProof<E>,
@@ -859,21 +528,14 @@ pub struct RelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
   #[serde_as(as = "EvmCompatSerde")]
   eval_W: E::Scalar,
 
-  #[serde_as(as = "EvmCompatSerde")]
-  eval_t_plus_r_inv_row: E::Scalar,
+  // Shared address/multiplicity evaluations (both memory-check implementations
+  // open these at the inner point).
   #[serde_as(as = "EvmCompatSerde")]
   eval_row: E::Scalar, // address
   #[serde_as(as = "EvmCompatSerde")]
-  eval_w_plus_r_inv_row: E::Scalar,
-  #[serde_as(as = "EvmCompatSerde")]
   eval_ts_row: E::Scalar,
-
-  #[serde_as(as = "EvmCompatSerde")]
-  eval_t_plus_r_inv_col: E::Scalar,
   #[serde_as(as = "EvmCompatSerde")]
   eval_col: E::Scalar, // address
-  #[serde_as(as = "EvmCompatSerde")]
-  eval_w_plus_r_inv_col: E::Scalar,
   #[serde_as(as = "EvmCompatSerde")]
   eval_ts_col: E::Scalar,
 
@@ -882,7 +544,12 @@ pub struct RelaxedR1CSSNARK<E: Engine, EE: EvaluationEngineTrait<E>> {
 }
 
 impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARK<E, EE> {
-  /// Batched inner sum-check prover for 3 instances: memory, inner_batched, and witness.
+  /// Batched inner sum-check prover for three instances: a memory-check slot,
+  /// the inner batched instance, and the witness-bound instance. The
+  /// memory-check slot is either the inverse-logup `MemorySumcheckInstance`
+  /// (feature `logup-no-gkr`) or the Logup-GKR `RerandomizeSumcheckInstance`
+  /// (default) — both are `SumcheckEngine`s of the same size/degree, folded
+  /// into one RLC'd sumcheck landing at the shared point `r_inner_batched`.
   fn prove_helper<T1, T2, T3>(
     mem: &mut T1,
     inner: &mut T2,
@@ -910,6 +577,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARK<E, EE> {
     assert_eq!(mem.degree(), witness.degree());
 
     // these claims are already added to the transcript, so we do not need to add
+    let num_mem_claims = mem.initial_claims().len();
     let claims = mem
       .initial_claims()
       .into_iter()
@@ -919,6 +587,14 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARK<E, EE> {
 
     let s = transcript.squeeze(b"r")?;
     let coeffs = powers::<E>(&s, claims.len());
+
+    // Let the memory-check slot collapse its equally-shaped claims into a single
+    // random linear combination now that the batch coefficients are known. This
+    // is a no-op for instances that don't override the hook. The slot leads the
+    // batch, so its coefficient slice starts at `coeffs[0] == 1`, keeping the
+    // fused round polynomial byte-identical to the per-column sum (see the trait
+    // doc on `fuse_with_coeffs`).
+    mem.fuse_with_coeffs(&coeffs[..num_mem_claims]);
 
     // compute the joint claim
     let claim = zip_with!((claims.iter(), coeffs.iter()), |c_1, c_2| *c_1 * c_2).sum();
@@ -1064,8 +740,11 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
     let S = S.pad();
     // sanity check that R1CSShape has all required size characteristics
     assert!(S.is_regular_shape());
+    // Capture `num_vars` up front so `S` can be released right after the
+    // evaluation oracles are built (the witness-bound sumcheck only needs this).
+    let num_vars = S.num_vars;
 
-    let W = W.pad(&S); // pad the witness
+    let W_padded = W.pad(&S); // pad the witness
     let mut transcript = E::TE::new(b"RelaxedR1CSSNARK");
 
     // append the verifier key (which includes commitment to R1CS matrices) and the RelaxedR1CSInstance to the transcript
@@ -1073,7 +752,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
     transcript.absorb(b"U", U);
 
     // compute the full satisfying assignment by concatenating W.W, U.u, and U.X
-    let z = [W.W.clone(), vec![U.u], U.X.clone()].concat();
+    let z = [W_padded.W.clone(), vec![U.u], U.X.clone()].concat();
 
     // compute Az, Bz, Cz
     let (Az, Bz, Cz) = S.multiply_vec(&z)?;
@@ -1091,7 +770,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
     // Proves: 0 = Σ_{x∈{0,1}^log(m)} eq(τ,x) * (Az(x) * Bz(x) - (u·Cz(x) + E(x)))
     let uCz_E: Vec<E::Scalar> = Cz
       .iter()
-      .zip(W.E.iter())
+      .zip(W_padded.E.iter())
       .map(|(cz, e)| U.u * *cz + *e)
       .collect();
     let mut poly_Az = MultilinearPolynomial::new(Az);
@@ -1112,6 +791,15 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
     let eval_Bz_at_r_outer = claims_outer[1];
     let eval_Cz_at_r_outer = MultilinearPolynomial::evaluate_with(&Cz, &r_outer);
     let eval_E_at_r_outer = claims_outer[2] - U.u * eval_Cz_at_r_outer;
+
+    // The outer sum-check polynomials are bound to length 1 but still hold
+    // ~m-capacity buffers, and `Cz` is no longer read after its evaluation above.
+    // Release them before the memory-check / inner phase allocates its N-sized
+    // buffers, so ~4m scalars do not stay resident across the peak.
+    drop(poly_Az);
+    drop(poly_Bz);
+    drop(poly_uCz_E);
+    drop(Cz);
 
     // Absorb outer sum-check claims into transcript
     transcript.absorb(
@@ -1141,8 +829,12 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
       .fold(E::Scalar::ONE, |acc, r| acc * (E::Scalar::ONE - r));
 
     // Pad E and W to size N for inner sum-check and PCS
-    let E = padded::<E>(&W.E, pk.S_repr.N, &E::Scalar::ZERO);
-    let W = padded::<E>(&W.W, pk.S_repr.N, &E::Scalar::ZERO);
+    let E = padded::<E>(&W_padded.E, pk.S_repr.N, &E::Scalar::ZERO);
+    let W = padded::<E>(&W_padded.W, pk.S_repr.N, &E::Scalar::ZERO);
+    // The length-m padded relaxed witness is no longer needed once the
+    // N-sized `E`/`W` are materialized. Drop it explicitly (rather than letting
+    // the `W` shadow above merely hide it) so ~2m scalars leave the working set.
+    drop(W_padded);
 
     // -----------------------------------------------------------------------
     // Step 2: Prepare the batched inner batched sum-check (memory + inner_batched + witness)
@@ -1152,9 +844,19 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
     // L_row(i) = eq(r_outer_full, row(i)) for all i
     // L_col(i) = z(col(i)) for all i, where z is the full satisfying assignment
     let (mem_row, mem_col, L_row, L_col) = pk.S_repr.evaluation_oracles(&S, &r_outer_full, &z);
+    // After the evaluation oracles are built, the local padded shape `S`
+    // and the assignment `z` are no longer used (only `S.num_vars` is needed
+    // later, saved above). Dropping `S` also frees the three sparse matrices and
+    // their lazily-built SpMV precompute caches, which can exceed the dense
+    // vectors in size. Overlap the release with the L_row/L_col MSMs.
     let (comm_L_row, comm_L_col) = rayon::join(
       || E::CE::commit(ck, &L_row, &E::Scalar::ZERO),
-      || E::CE::commit(ck, &L_col, &E::Scalar::ZERO),
+      || {
+        let comm = E::CE::commit(ck, &L_col, &E::Scalar::ZERO);
+        drop(z);
+        drop(S);
+        comm
+      },
     );
 
     // Absorb commitments to L_row and L_col
@@ -1167,79 +869,90 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
     let gamma = transcript.squeeze(b"g")?;
     let r = transcript.squeeze(b"r")?;
 
-    let (mut inner_batched_sc_inst, mem_res) = rayon::join(
-      || {
-        // Inner batched sum-check instance for:
-        // (a) ABC claim: factor·(v_A + c·v_B + c²·v_C) = Σ L_row(y) * (val_A + c·val_B + c²·val_C)(y) * L_col(y)
-        // (b) E claim: factor·eval_E = Σ eq(r_outer_full, y) * E(y)
-        // The claims are scaled by factor because the inner sum-check uses r_outer_full
-        // and eq(r_outer_full, j) = factor · eq(r_outer, j) for j < m.
-        let val = zip_with!(
-          par_iter,
-          (pk.S_repr.val_A, pk.S_repr.val_B, pk.S_repr.val_C),
-          |v_a, v_b, v_c| *v_a + c * *v_b + c * c * *v_c
+    // Build the inner-batched instance in parallel with the memory-check slot
+    // (both are independent of each other). The inner instance is:
+    // (a) ABC claim: factor·(v_A + c·v_B + c²·v_C) = Σ L_row(y) * (val_A + c·val_B + c²·val_C)(y) * L_col(y)
+    // (b) E claim: factor·eval_E = Σ eq(r_outer_full, y) * E(y)
+    // scaled by factor because the inner sum-check uses r_outer_full.
+    let build_inner = || {
+      let val = zip_with!(
+        par_iter,
+        (pk.S_repr.val_A, pk.S_repr.val_B, pk.S_repr.val_C),
+        |v_a, v_b, v_c| *v_a + c * *v_b + c * c * *v_c
+      )
+      .collect::<Vec<E::Scalar>>();
+
+      InnerBatchedSumcheckInstance::new(
+        factor * (eval_Az_at_r_outer + c * eval_Bz_at_r_outer + c * c * eval_Cz_at_r_outer),
+        L_row.clone(),
+        L_col.clone(),
+        val,
+        factor * eval_E_at_r_outer,
+        r_outer_full.clone(), // eq challenges for factored eq (Gruen)
+        E.clone(),
+      )
+    };
+
+    // Memory-check slot (the first prove_helper instance), built alongside the
+    // inner instance. Note: the slot's builder absorbs into the transcript, so it
+    // must be the join branch that owns `&mut transcript`.
+    #[cfg(feature = "logup-no-gkr")]
+    let (mut inner_batched_sc_inst, (mut mem, comm_mem_oracles, mem_oracles)) = {
+      let mem_res = rayon::join(build_inner, || {
+        // Inverse-logup: build the inverse oracles, commit, absorb, squeeze rho.
+        mem_check_logup::prove_step::<E>(
+          ck,
+          r,
+          gamma,
+          &mem_row,
+          &pk.S_repr.row,
+          &L_row,
+          &pk.S_repr.ts_row,
+          &mem_col,
+          &pk.S_repr.col,
+          &L_col,
+          &pk.S_repr.ts_col,
+          num_rounds_inner,
+          &mut transcript,
         )
-        .collect::<Vec<E::Scalar>>();
+      });
+      (mem_res.0, mem_res.1?)
+    };
 
-        InnerBatchedSumcheckInstance::new(
-          factor * (eval_Az_at_r_outer + c * eval_Bz_at_r_outer + c * c * eval_Cz_at_r_outer),
-          L_row.clone(),
-          L_col.clone(),
-          val,
-          factor * eval_E_at_r_outer,
-          r_outer_full.clone(), // eq challenges for factored eq (Gruen)
-          E.clone(),
-        )
-      },
-      || {
-        // Memory sum-check instance to prove L_row and L_col are well-formed
-        let (comm_mem_oracles, mem_oracles, mem_aux) =
-          MemorySumcheckInstance::<E>::compute_oracles(
-            ck,
-            &r,
-            &gamma,
-            &mem_row,
-            &pk.S_repr.row,
-            &L_row,
-            &pk.S_repr.ts_row,
-            &mem_col,
-            &pk.S_repr.col,
-            &L_col,
-            &pk.S_repr.ts_col,
-          )?;
-        // absorb the commitments
-        transcript.absorb(b"l", &comm_mem_oracles.as_slice());
-
-        let rho = (0..num_rounds_inner)
-          .map(|_| transcript.squeeze(b"r"))
-          .collect::<Result<Vec<_>, NovaError>>()?;
-
-        Ok::<_, NovaError>((
-          MemorySumcheckInstance::new(
-            mem_oracles.clone(),
-            mem_aux,
-            rho,
-            pk.S_repr.ts_row.clone(),
-            pk.S_repr.ts_col.clone(),
-          ),
-          comm_mem_oracles,
-          mem_oracles,
-        ))
-      },
-    );
-
-    let (mut mem_sc_inst, comm_mem_oracles, mem_oracles) = mem_res?;
+    #[cfg(not(feature = "logup-no-gkr"))]
+    let (mut inner_batched_sc_inst, (mut mem, gkr_proof_data)) = {
+      // Logup-GKR: fold the four sub-instances into GKR trees and emit the
+      // rerandomize instance carrying the reconcile columns into the inner
+      // sumcheck. Reuses the fingerprint (gamma, r); absorbs BEFORE the inner
+      // sumcheck.
+      // `mem_row`/`mem_col` are not used again on this path, so move them in;
+      // `L_row`/`L_col` are still needed by the inner instance and batch opening,
+      // so they are cloned.
+      let logup_gkr_witness = MemCheckWitness::<E> {
+        mem_row,
+        mem_col,
+        L_row: L_row.clone(),
+        L_col: L_col.clone(),
+        addr_row: pk.S_repr.row.clone(),
+        addr_col: pk.S_repr.col.clone(),
+        ts_row: pk.S_repr.ts_row.clone(),
+        ts_col: pk.S_repr.ts_col.clone(),
+      };
+      let mem_res = rayon::join(build_inner, || {
+        mem_check_logup_gkr::prove_step::<E>(logup_gkr_witness, gamma, r, &mut transcript)
+      });
+      (mem_res.0, mem_res.1?)
+    };
 
     // Witness bound sum-check using r_outer_full as the random evaluation point
-    let mut witness_sc_inst =
-      WitnessBoundSumcheck::new(r_outer_full.clone(), W.clone(), S.num_vars);
+    let mut witness_sc_inst = WitnessBoundSumcheck::new(r_outer_full.clone(), W.clone(), num_vars);
 
     // -----------------------------------------------------------------------
-    // Step 3: Run the batched inner batched sum-check (3 instances)
+    // Step 3: Run the batched inner sum-check (memory slot + inner + witness)
     // -----------------------------------------------------------------------
     let (sc_inner_batched, r_inner_batched, claims_mem, claims_inner_batched, claims_witness) =
       Self::prove_helper(
-        &mut mem_sc_inst,
+        &mut mem,
         &mut inner_batched_sc_inst,
         &mut witness_sc_inst,
         &mut transcript,
@@ -1250,14 +963,43 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
     let eval_L_col = claims_inner_batched[0][1];
     let eval_E = claims_inner_batched[1][0]; // E(r_inner_batched) — rerandomized to open at same point
 
-    let eval_t_plus_r_inv_row = claims_mem[0][0];
-    let eval_w_plus_r_inv_row = claims_mem[0][1];
-    let eval_ts_row = claims_mem[0][2];
-
-    let eval_t_plus_r_inv_col = claims_mem[1][0];
-    let eval_w_plus_r_inv_col = claims_mem[1][1];
-    let eval_ts_col = claims_mem[1][2];
+    // ts_row/ts_col at r_inner_batched: from the memory slot's final claims.
+    // Inverse-logup exposes (t+r inv, w+r inv, ts) per row/col; Logup-GKR exposes
+    // the rerandomized columns (ts_row is RERAND index 4, ts_col index 5).
+    #[cfg(feature = "logup-no-gkr")]
+    let (
+      eval_t_plus_r_inv_row,
+      eval_w_plus_r_inv_row,
+      eval_ts_row,
+      eval_t_plus_r_inv_col,
+      eval_w_plus_r_inv_col,
+      eval_ts_col,
+    ) = (
+      claims_mem[0][0],
+      claims_mem[0][1],
+      claims_mem[0][2],
+      claims_mem[1][0],
+      claims_mem[1][1],
+      claims_mem[1][2],
+    );
+    #[cfg(not(feature = "logup-no-gkr"))]
+    let (eval_ts_row, eval_ts_col) = {
+      // The fused rerandomize slot no longer exposes per-column final claims, so
+      // read ts_row/ts_col directly from the PK columns at r_inner_batched (same
+      // point, same polynomials). L_row/L_col already come from the inner ABC
+      // path above; the fused slot's combined final claim is a linear check the
+      // batched sumcheck already enforces.
+      let e = MultilinearPolynomial::multi_evaluate_with(
+        &[&pk.S_repr.ts_row, &pk.S_repr.ts_col],
+        &r_inner_batched,
+      );
+      (e[0], e[1])
+    };
     let eval_W = claims_witness[0][0];
+    // Under Logup-GKR the fused memory slot no longer exposes per-column final
+    // claims; keep the binding alive without a warning.
+    #[cfg(not(feature = "logup-no-gkr"))]
+    let _ = &claims_mem;
 
     // Compute evaluations at r_inner_batched that did not come for free from the sum-check
     let (eval_val_A, eval_val_B, eval_val_C, eval_row, eval_col) = {
@@ -1274,8 +1016,14 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
       (e[0], e[1], e[2], e[3], e[4])
     };
 
-    // All evaluations are at r_inner_batched — fold into one claim for batch PCS opening
-    let eval_vec = vec![
+    // All evaluations are at r_inner_batched — fold into one claim for batch PCS
+    // opening. Shared columns come first (both memory-check implementations open
+    // them); the four inverse-oracle columns, present only under inverse-logup,
+    // are appended at the end. The batch is an order-agnostic RLC, so any
+    // ordering is fine as long as prove and verify agree — see the verifier's
+    // matching construction.
+    #[cfg_attr(not(feature = "logup-no-gkr"), allow(unused_mut))]
+    let mut eval_vec = vec![
       eval_W,
       eval_E,
       eval_L_row,
@@ -1283,17 +1031,13 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
       eval_val_A,
       eval_val_B,
       eval_val_C,
-      eval_t_plus_r_inv_row,
       eval_row,
-      eval_w_plus_r_inv_row,
       eval_ts_row,
-      eval_t_plus_r_inv_col,
       eval_col,
-      eval_w_plus_r_inv_col,
       eval_ts_col,
     ];
-
-    let comm_vec = [
+    #[cfg_attr(not(feature = "logup-no-gkr"), allow(unused_mut))]
+    let mut comm_vec = vec![
       U.comm_W,
       U.comm_E,
       comm_L_row,
@@ -1301,16 +1045,13 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
       pk.S_comm.comm_val_A,
       pk.S_comm.comm_val_B,
       pk.S_comm.comm_val_C,
-      comm_mem_oracles[0],
       pk.S_comm.comm_row,
-      comm_mem_oracles[1],
       pk.S_comm.comm_ts_row,
-      comm_mem_oracles[2],
       pk.S_comm.comm_col,
-      comm_mem_oracles[3],
       pk.S_comm.comm_ts_col,
     ];
-    let poly_vec = [
+    #[cfg_attr(not(feature = "logup-no-gkr"), allow(unused_mut))]
+    let mut poly_vec: Vec<&Vec<E::Scalar>> = vec![
       &W,
       &E,
       &L_row,
@@ -1318,15 +1059,23 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
       &pk.S_repr.val_A,
       &pk.S_repr.val_B,
       &pk.S_repr.val_C,
-      mem_oracles[0].as_ref(),
       &pk.S_repr.row,
-      mem_oracles[1].as_ref(),
       &pk.S_repr.ts_row,
-      mem_oracles[2].as_ref(),
       &pk.S_repr.col,
-      mem_oracles[3].as_ref(),
       &pk.S_repr.ts_col,
     ];
+    #[cfg(feature = "logup-no-gkr")]
+    {
+      eval_vec.extend([
+        eval_t_plus_r_inv_row,
+        eval_w_plus_r_inv_row,
+        eval_t_plus_r_inv_col,
+        eval_w_plus_r_inv_col,
+      ]);
+      comm_vec.extend(comm_mem_oracles);
+      poly_vec.extend(mem_oracles.iter());
+    }
+
     transcript.absorb(b"e", &eval_vec.as_slice()); // comm_vec is already in the transcript
     let c = transcript.squeeze(b"c")?;
     let w: PolyEvalWitness<E> = PolyEvalWitness::batch(&poly_vec, &c);
@@ -1347,10 +1096,19 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
       comm_L_row,
       comm_L_col,
 
-      comm_t_plus_r_inv_row: comm_mem_oracles[0],
-      comm_w_plus_r_inv_row: comm_mem_oracles[1],
-      comm_t_plus_r_inv_col: comm_mem_oracles[2],
-      comm_w_plus_r_inv_col: comm_mem_oracles[3],
+      #[cfg(feature = "logup-no-gkr")]
+      mem_check: mem_check_logup::LogupProofData {
+        comm_t_plus_r_inv_row: comm_mem_oracles[0],
+        comm_w_plus_r_inv_row: comm_mem_oracles[1],
+        comm_t_plus_r_inv_col: comm_mem_oracles[2],
+        comm_w_plus_r_inv_col: comm_mem_oracles[3],
+        eval_t_plus_r_inv_row,
+        eval_w_plus_r_inv_row,
+        eval_t_plus_r_inv_col,
+        eval_w_plus_r_inv_col,
+      },
+      #[cfg(not(feature = "logup-no-gkr"))]
+      mem_check_gkr: gkr_proof_data,
 
       sc_outer,
 
@@ -1370,14 +1128,9 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
 
       eval_W,
 
-      eval_t_plus_r_inv_row,
       eval_row,
-      eval_w_plus_r_inv_row,
       eval_ts_row,
-
       eval_col,
-      eval_t_plus_r_inv_col,
-      eval_w_plus_r_inv_col,
       eval_ts_col,
 
       eval_arg,
@@ -1456,35 +1209,56 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
     let gamma = transcript.squeeze(b"g")?;
     let r = transcript.squeeze(b"r")?;
 
-    transcript.absorb(
-      b"l",
-      &vec![
-        self.comm_t_plus_r_inv_row,
-        self.comm_w_plus_r_inv_row,
-        self.comm_t_plus_r_inv_col,
-        self.comm_w_plus_r_inv_col,
-      ]
-      .as_slice(),
-    );
+    // Memory-check, transcript phase (before the inner sumcheck's `s`).
+    // Inverse-logup: absorb the inverse-oracle commitments and squeeze the memory
+    // sumcheck's eq randomness `rho`. Logup-GKR: replay the GKR proof, reconcile
+    // the claimed columns against the reduction, run the balance check, and
+    // absorb the claimed values; returns the shared GKR `eval_point`.
+    #[cfg(feature = "logup-no-gkr")]
+    let rho =
+      mem_check_logup::verify_pre_inner::<E>(&self.mem_check, num_rounds_inner, &mut transcript)?;
+    #[cfg(not(feature = "logup-no-gkr"))]
+    let gkr_eval_point = mem_check_logup_gkr::verify_pre_inner::<E>(
+      &self.mem_check_gkr,
+      gamma,
+      r,
+      &r_outer_full,
+      &mut transcript,
+    )?;
 
-    let rho = (0..num_rounds_inner)
-      .map(|_| transcript.squeeze(b"r"))
-      .collect::<Result<Vec<_>, NovaError>>()?;
-
-    // 9 claims: 6 memory + 2 inner (ABC + E) + 1 witness
-    let num_claims = 9;
+    // Batched-inner claim layout:
+    //
+    //   mode            | memory-check | ABC | E | witness
+    //   ----------------+--------------+-----+---+--------
+    //   inverse-logup   | [0, 6)       |  6  | 7 |    8
+    //   Logup-GKR       | [0, 7)       |  7  | 8 |    9
+    //
+    // `prove_helper` places the memory-check slot first, so its indices always
+    // start at zero. `mem_claims` selects the first shared-claim index.
+    #[cfg(feature = "logup-no-gkr")]
+    let mem_claims = mem_check_logup::NUM_MEM_CLAIMS;
+    #[cfg(not(feature = "logup-no-gkr"))]
+    let mem_claims = mem_check_logup_gkr::NUM_MEM_CLAIMS;
+    let abc_idx = mem_claims;
+    let e_idx = mem_claims + 1;
+    let wit_idx = mem_claims + 2;
+    let num_claims = mem_claims + 3;
     let s = transcript.squeeze(b"r")?;
     let coeffs = powers::<E>(&s, num_claims);
 
-    // Compute the combined initial claim
-    // Claims 0-5: memory (all zero)
-    // Claim 6: inner ABC = factor * (eval_Az + c * eval_Bz + c² * eval_Cz)
-    // Claim 7: inner E = factor * eval_E
-    // Claim 8: witness (zero)
+    // Compute the combined initial claim. The memory-check slot contributes one
+    // term (`mem_initial`; zero for inverse-logup, the rerandomize columns'
+    // claimed values for Logup-GKR); the ABC/E terms are shared.
     // The factor accounts for zero-padding: eval_P(r_outer_full) = factor * eval_P(r_outer)
     let claim_inner_batched_ABC = factor
       * (self.eval_Az_at_r_outer + c * self.eval_Bz_at_r_outer + c * c * self.eval_Cz_at_r_outer);
-    let claim = coeffs[6] * claim_inner_batched_ABC + coeffs[7] * factor * self.eval_E_at_r_outer;
+    #[cfg(feature = "logup-no-gkr")]
+    let mem_initial = mem_check_logup::verify_initial_claim::<E>(&coeffs);
+    #[cfg(not(feature = "logup-no-gkr"))]
+    let mem_initial = mem_check_logup_gkr::verify_initial_claim::<E>(&self.mem_check_gkr, &coeffs);
+    let claim = coeffs[abc_idx] * claim_inner_batched_ABC
+      + coeffs[e_idx] * factor * self.eval_E_at_r_outer
+      + mem_initial;
 
     // Verify inner batched sum-check
     let (claim_sc_inner_batched_final, r_inner_batched) =
@@ -1494,115 +1268,100 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
 
     // Verify inner batched sum-check final claim
     let claim_sc_inner_batched_expected = {
-      let rand_eq_bound_r_inner_batched = EqPolynomial::new(rho).evaluate(&r_inner_batched);
-
-      // eq(r_outer_full, r_inner_batched) for the E claim and memory row address check
       let eq_r_outer = EqPolynomial::new(r_outer_full.clone());
       let eq_r_outer_at_r_inner_batched = eq_r_outer.evaluate(&r_inner_batched);
-
-      // masked eq for witness bound check (using r_outer_full as random point)
       let taus_masked_bound_r_inner_batched =
         MaskedEqPolynomial::new(&eq_r_outer, vk.num_vars.log_2()).evaluate(&r_inner_batched);
 
-      let eval_t_plus_r_row = {
-        let eval_addr_row = IdentityPolynomial::new(num_rounds_inner).evaluate(&r_inner_batched);
-        let eval_val_row = eq_r_outer_at_r_inner_batched; // mem_row = eq(r_outer_full, ·)
-        let eval_t = eval_addr_row + gamma * eval_val_row;
-        eval_t + r
+      // Memory-check slot's final-claim contribution uses coeffs[0..6] for the
+      // inverse-logup routes or coeffs[0..7] for the seven GKR columns.
+      #[cfg(feature = "logup-no-gkr")]
+      let mem_final = {
+        let public_io: Vec<E::Scalar> = vec![U.u].into_iter().chain(U.X.iter().cloned()).collect();
+        mem_check_logup::verify_final_claim::<E>(
+          &self.mem_check,
+          &coeffs,
+          rho,
+          gamma,
+          r,
+          &r_outer_full,
+          &r_inner_batched,
+          num_rounds_inner,
+          vk.num_vars,
+          vk.S_comm.N,
+          self.eval_W,
+          self.eval_L_row,
+          self.eval_L_col,
+          self.eval_row,
+          self.eval_col,
+          self.eval_ts_row,
+          self.eval_ts_col,
+          &public_io,
+        )
       };
-
-      let eval_w_plus_r_row = {
-        let eval_addr_row = self.eval_row;
-        let eval_val_row = self.eval_L_row;
-        let eval_w = eval_addr_row + gamma * eval_val_row;
-        eval_w + r
-      };
-
-      let eval_t_plus_r_col = {
-        let eval_addr_col = IdentityPolynomial::new(num_rounds_inner).evaluate(&r_inner_batched);
-
-        // memory contents is z, so we compute eval_Z from eval_W and eval_X
-        let eval_val_col = {
-          // r_inner_batched was padded, so we now remove the padding
+      #[cfg(not(feature = "logup-no-gkr"))]
+      let mem_final = {
+        // mem_col = z at r_inner_batched, reconstructed from eval_W and public IO.
+        let eval_mem_col_at_r_inner = {
           let (factor, r_inner_batched_unpad) = {
             let l = vk.S_comm.N.log_2() - (2 * vk.num_vars).log_2();
-
             let mut factor = E::Scalar::ONE;
             for r_p in r_inner_batched.iter().take(l) {
               factor *= E::Scalar::ONE - r_p
             }
-
-            let r_inner_batched_unpad = r_inner_batched[l..].to_vec();
-
-            (factor, r_inner_batched_unpad)
+            (factor, r_inner_batched[l..].to_vec())
           };
-
           let eval_X = {
-            // public IO is (u, X)
             let X = vec![U.u]
               .into_iter()
               .chain(U.X.iter().cloned())
               .collect::<Vec<E::Scalar>>();
-
-            // evaluate the sparse polynomial at r_inner_batched_unpad[1..]
             let poly_X = SparsePolynomial::new(r_inner_batched_unpad.len() - 1, X);
             poly_X.evaluate(&r_inner_batched_unpad[1..])
           };
-
           self.eval_W + factor * r_inner_batched_unpad[0] * eval_X
         };
-        let eval_t = eval_addr_col + gamma * eval_val_col;
-        eval_t + r
+        let rerand_col_evals = [
+          self.eval_L_row,
+          self.eval_L_col,
+          self.eval_row,
+          self.eval_col,
+          self.eval_ts_row,
+          self.eval_ts_col,
+          eval_mem_col_at_r_inner,
+        ];
+        mem_check_logup_gkr::verify_final_claim::<E>(
+          &coeffs,
+          &gkr_eval_point,
+          &r_inner_batched,
+          &rerand_col_evals,
+        )?
       };
 
-      let eval_w_plus_r_col = {
-        let eval_addr_col = self.eval_col;
-        let eval_val_col = self.eval_L_col;
-        let eval_w = eval_addr_col + gamma * eval_val_col;
-        eval_w + r
-      };
-
-      // Memory claims (coeffs 0-5)
-      let claim_mem_final_expected: E::Scalar = coeffs[0]
-        * (self.eval_t_plus_r_inv_row - self.eval_w_plus_r_inv_row)
-        + coeffs[1] * (self.eval_t_plus_r_inv_col - self.eval_w_plus_r_inv_col)
-        + coeffs[2]
-          * (rand_eq_bound_r_inner_batched
-            * (self.eval_t_plus_r_inv_row * eval_t_plus_r_row - self.eval_ts_row))
-        + coeffs[3]
-          * (rand_eq_bound_r_inner_batched
-            * (self.eval_w_plus_r_inv_row * eval_w_plus_r_row - E::Scalar::ONE))
-        + coeffs[4]
-          * (rand_eq_bound_r_inner_batched
-            * (self.eval_t_plus_r_inv_col * eval_t_plus_r_col - self.eval_ts_col))
-        + coeffs[5]
-          * (rand_eq_bound_r_inner_batched
-            * (self.eval_w_plus_r_inv_col * eval_w_plus_r_col - E::Scalar::ONE));
-
-      // Inner batched ABC claim (coeff 6): L_row * L_col * (val_A + c·val_B + c²·val_C)
-      let claim_inner_batched_ABC_final = coeffs[6]
+      // Inner batched ABC claim: L_row * L_col * (val_A + c·val_B + c²·val_C)
+      let claim_inner_batched_ABC_final = coeffs[abc_idx]
         * self.eval_L_row
         * self.eval_L_col
         * (self.eval_val_A + c * self.eval_val_B + c * c * self.eval_val_C);
 
-      // Inner batched E claim (coeff 7): eq(r_outer_full, r_inner_batched) * E(r_inner_batched)
-      let claim_inner_batched_E_final = coeffs[7] * eq_r_outer_at_r_inner_batched * self.eval_E;
+      // Inner batched E claim: eq(r_outer_full, r_inner_batched) * E(r_inner_batched)
+      let claim_inner_batched_E_final = coeffs[e_idx] * eq_r_outer_at_r_inner_batched * self.eval_E;
 
-      // Witness claim (coeff 8)
-      let claim_witness_final = coeffs[8] * taus_masked_bound_r_inner_batched * self.eval_W;
+      // Witness claim
+      let claim_witness_final = coeffs[wit_idx] * taus_masked_bound_r_inner_batched * self.eval_W;
 
-      claim_mem_final_expected
-        + claim_inner_batched_ABC_final
-        + claim_inner_batched_E_final
-        + claim_witness_final
+      mem_final + claim_inner_batched_ABC_final + claim_inner_batched_E_final + claim_witness_final
     };
 
     if claim_sc_inner_batched_expected != claim_sc_inner_batched_final {
       return Err(NovaError::InvalidSumcheckProof);
     }
 
-    // Verify polynomial openings — all at r_inner_batched
-    let eval_vec = vec![
+    // Verify polynomial openings — all at r_inner_batched. Shared columns first,
+    // the inverse-oracle columns (inverse-logup only) appended at the end. Must
+    // match the prover's column ordering exactly.
+    #[cfg_attr(not(feature = "logup-no-gkr"), allow(unused_mut))]
+    let mut eval_vec = vec![
       self.eval_W,
       self.eval_E,
       self.eval_L_row,
@@ -1610,16 +1369,13 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
       self.eval_val_A,
       self.eval_val_B,
       self.eval_val_C,
-      self.eval_t_plus_r_inv_row,
       self.eval_row,
-      self.eval_w_plus_r_inv_row,
       self.eval_ts_row,
-      self.eval_t_plus_r_inv_col,
       self.eval_col,
-      self.eval_w_plus_r_inv_col,
       self.eval_ts_col,
     ];
-    let comm_vec = [
+    #[cfg_attr(not(feature = "logup-no-gkr"), allow(unused_mut))]
+    let mut comm_vec = vec![
       U.comm_W,
       U.comm_E,
       self.comm_L_row,
@@ -1627,15 +1383,27 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
       vk.S_comm.comm_val_A,
       vk.S_comm.comm_val_B,
       vk.S_comm.comm_val_C,
-      self.comm_t_plus_r_inv_row,
       vk.S_comm.comm_row,
-      self.comm_w_plus_r_inv_row,
       vk.S_comm.comm_ts_row,
-      self.comm_t_plus_r_inv_col,
       vk.S_comm.comm_col,
-      self.comm_w_plus_r_inv_col,
       vk.S_comm.comm_ts_col,
     ];
+    #[cfg(feature = "logup-no-gkr")]
+    {
+      eval_vec.extend([
+        self.mem_check.eval_t_plus_r_inv_row,
+        self.mem_check.eval_w_plus_r_inv_row,
+        self.mem_check.eval_t_plus_r_inv_col,
+        self.mem_check.eval_w_plus_r_inv_col,
+      ]);
+      comm_vec.extend([
+        self.mem_check.comm_t_plus_r_inv_row,
+        self.mem_check.comm_w_plus_r_inv_row,
+        self.mem_check.comm_t_plus_r_inv_col,
+        self.mem_check.comm_w_plus_r_inv_col,
+      ]);
+    }
+
     transcript.absorb(b"e", &eval_vec.as_slice()); // comm_vec is already in the transcript
     let c = transcript.squeeze(b"c")?;
     let u: PolyEvalInstance<E> =

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -1,4 +1,5 @@
 use crate::{
+  constants::PARALLEL_THRESHOLD,
   errors::NovaError,
   spartan::{
     polys::{
@@ -10,6 +11,7 @@ use crate::{
   traits::{Engine, TranscriptEngineTrait},
 };
 use ff::{Field, PrimeField};
+use itertools::Itertools as _;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -29,6 +31,21 @@ pub trait SumcheckEngine<E: Engine>: Send + Sync {
   /// For degree-3 (cubic) claims: [p(0), cubic_coeff, p(-1)]
   /// For degree-2 (quadratic) claims: [p(0), 0, p(-1)]
   fn evaluation_points(&mut self) -> Vec<Vec<E::Scalar>>;
+
+  /// Optional hook: once the batched prover's linear-combination coefficients
+  /// are known (squeezed inside `prove_helper`), an instance may collapse its
+  /// several equally-shaped claims into a single random linear combination so it
+  /// scans/binds one polynomial per round instead of many. `coeffs` are exactly
+  /// this instance's slice of the batch coefficients (same order as
+  /// [`Self::initial_claims`]). The default is a no-op.
+  ///
+  /// Correctness contract: after fusing, [`Self::evaluation_points`] must still
+  /// return one triple per original claim so positional `Σ coeffs[i]·evals[i]`
+  /// in the batched prover is unchanged. Fusing instances therefore return the
+  /// combined triple in slot 0 (whose coefficient is 1 when it leads the batch)
+  /// and zeros elsewhere, which is byte-identical to computing each triple
+  /// separately and summing.
+  fn fuse_with_coeffs(&mut self, _coeffs: &[E::Scalar]) {}
 
   /// bounds a variable in the constituent polynomials
   fn bound(&mut self, r: &E::Scalar);
@@ -442,6 +459,85 @@ impl<E: Engine> SumcheckProof<E> {
       )
   }
 
+  /// Computes cubic evaluation points while replacing every polynomial's high
+  /// half with its top-variable delta.
+  ///
+  /// The caller must bind all three polynomials with
+  /// `MultilinearPolynomial::bind_poly_var_top_with_cached_delta` before reading
+  /// their high halves again.
+  ///
+  /// Returns `(eval_0, cubic_coeff, eval_inf)`, the same layout as
+  /// [`Self::compute_eval_points_cubic`].
+  #[inline]
+  pub fn compute_eval_points_cubic_with_cached_deltas(
+    poly_A: &mut MultilinearPolynomial<E::Scalar>,
+    poly_B: &mut MultilinearPolynomial<E::Scalar>,
+    poly_C: &mut MultilinearPolynomial<E::Scalar>,
+  ) -> (E::Scalar, E::Scalar, E::Scalar) {
+    let len = poly_A.len() / 2;
+    assert_eq!(poly_B.len(), poly_A.len());
+    assert_eq!(poly_C.len(), poly_A.len());
+
+    let (a_low, a_delta) = poly_A.Z.split_at_mut(len);
+    let (b_low, b_delta) = poly_B.Z.split_at_mut(len);
+    let (c_low, c_delta) = poly_C.Z.split_at_mut(len);
+
+    let eval = |a_low: &E::Scalar,
+                a_delta: &mut E::Scalar,
+                b_low: &E::Scalar,
+                b_delta: &mut E::Scalar,
+                c_low: &E::Scalar,
+                c_delta: &mut E::Scalar| {
+      *a_delta -= a_low;
+      *b_delta -= b_low;
+      *c_delta -= c_low;
+
+      (
+        *a_low * *b_low * *c_low,
+        *a_delta * *b_delta * *c_delta,
+        (*a_low - *a_delta) * (*b_low - *b_delta) * (*c_low - *c_delta),
+      )
+    };
+
+    if len < PARALLEL_THRESHOLD {
+      zip_with!(
+        (
+          a_low.iter(),
+          a_delta.iter_mut(),
+          b_low.iter(),
+          b_delta.iter_mut(),
+          c_low.iter(),
+          c_delta.iter_mut()
+        ),
+        |a_low, a_delta, b_low, b_delta, c_low, c_delta| eval(
+          a_low, a_delta, b_low, b_delta, c_low, c_delta
+        )
+      )
+      .fold(
+        (E::Scalar::ZERO, E::Scalar::ZERO, E::Scalar::ZERO),
+        |acc, item| (acc.0 + item.0, acc.1 + item.1, acc.2 + item.2),
+      )
+    } else {
+      zip_with!(
+        (
+          a_low.par_iter(),
+          a_delta.par_iter_mut(),
+          b_low.par_iter(),
+          b_delta.par_iter_mut(),
+          c_low.par_iter(),
+          c_delta.par_iter_mut()
+        ),
+        |a_low, a_delta, b_low, b_delta, c_low, c_delta| eval(
+          a_low, a_delta, b_low, b_delta, c_low, c_delta
+        )
+      )
+      .reduce(
+        || (E::Scalar::ZERO, E::Scalar::ZERO, E::Scalar::ZERO),
+        |a, b| (a.0 + b.0, a.1 + b.1, a.2 + b.2),
+      )
+    }
+  }
+
   /// Prove poly_A * poly_B - poly_C
   pub fn prove_cubic_with_three_inputs(
     claim: &E::Scalar,
@@ -585,8 +681,11 @@ pub mod eq_sumcheck {
   //!
   //! The claim-derived evaluation points (computing only 2 N-scaling sums per round
   //! instead of 3) follow BDDT (eprint 2025/1117, Section 6.2).
-  use crate::{spartan::polys::multilinear::MultilinearPolynomial, traits::Engine};
-  use ff::Field;
+  use crate::{
+    constants::PARALLEL_THRESHOLD, spartan::polys::multilinear::MultilinearPolynomial,
+    traits::Engine,
+  };
+  use ff::{Field, PrimeField};
   use rayon::{iter::ZipEq, prelude::*, slice::Iter};
 
   /// Instance for optimized equality polynomial sumcheck.
@@ -601,6 +700,146 @@ pub mod eq_sumcheck {
     poly_eq_left: Vec<Vec<E::Scalar>>,
     poly_eq_right: Vec<Vec<E::Scalar>>,
     eq_tau_0_a_inf: Vec<(E::Scalar, E::Scalar, E::Scalar)>,
+  }
+
+  struct LogupGateCell<'a, Scalar> {
+    nl_0: Scalar,
+    nl_delta: &'a mut Scalar,
+    nr_0: Scalar,
+    nr_delta: &'a mut Scalar,
+    dl_0: Scalar,
+    dl_delta: &'a mut Scalar,
+    dr_0: Scalar,
+    dr_delta: &'a mut Scalar,
+  }
+
+  impl<Scalar: PrimeField> LogupGateCell<'_, Scalar> {
+    fn cache_and_evaluate(self, weights: (Scalar, Scalar)) -> (Scalar, Scalar) {
+      *self.nl_delta -= self.nl_0;
+      *self.nr_delta -= self.nr_0;
+      *self.dl_delta -= self.dl_0;
+      *self.dr_delta -= self.dr_0;
+
+      let (w_num, w_den) = weights;
+      (
+        w_num * (self.nl_0 * self.dr_0 + self.nr_0 * self.dl_0) + w_den * (self.dl_0 * self.dr_0),
+        w_num * (*self.nl_delta * *self.dr_delta + *self.nr_delta * *self.dl_delta)
+          + w_den * (*self.dl_delta * *self.dr_delta),
+      )
+    }
+  }
+
+  struct LogupGateInstanceSlices<'a, Scalar> {
+    nl_low: &'a [Scalar],
+    nl_delta: &'a mut [Scalar],
+    nr_low: &'a [Scalar],
+    nr_delta: &'a mut [Scalar],
+    dl_low: &'a [Scalar],
+    dl_delta: &'a mut [Scalar],
+    dr_low: &'a [Scalar],
+    dr_delta: &'a mut [Scalar],
+  }
+
+  impl<'a, Scalar: PrimeField> LogupGateInstanceSlices<'a, Scalar> {
+    fn new(
+      nl: &'a mut MultilinearPolynomial<Scalar>,
+      nr: &'a mut MultilinearPolynomial<Scalar>,
+      dl: &'a mut MultilinearPolynomial<Scalar>,
+      dr: &'a mut MultilinearPolynomial<Scalar>,
+    ) -> Self {
+      let half = nl.Z.len() / 2;
+      let (nl_low, nl_delta) = nl.Z.split_at_mut(half);
+      let (nr_low, nr_delta) = nr.Z.split_at_mut(half);
+      let (dl_low, dl_delta) = dl.Z.split_at_mut(half);
+      let (dr_low, dr_delta) = dr.Z.split_at_mut(half);
+      Self {
+        nl_low,
+        nl_delta,
+        nr_low,
+        nr_delta,
+        dl_low,
+        dl_delta,
+        dr_low,
+        dr_delta,
+      }
+    }
+
+    fn par_iter_mut(&mut self) -> impl IndexedParallelIterator<Item = LogupGateCell<'_, Scalar>> {
+      zip_with!(
+        (
+          self.nl_low.par_iter(),
+          self.nl_delta.par_iter_mut(),
+          self.nr_low.par_iter(),
+          self.nr_delta.par_iter_mut(),
+          self.dl_low.par_iter(),
+          self.dl_delta.par_iter_mut(),
+          self.dr_low.par_iter(),
+          self.dr_delta.par_iter_mut()
+        ),
+        |nl_0, nl_delta, nr_0, nr_delta, dl_0, dl_delta, dr_0, dr_delta| LogupGateCell {
+          nl_0: *nl_0,
+          nl_delta,
+          nr_0: *nr_0,
+          nr_delta,
+          dl_0: *dl_0,
+          dl_delta,
+          dr_0: *dr_0,
+          dr_delta,
+        }
+      )
+    }
+  }
+
+  fn cache_four_logup_gate_deltas<Scalar, Factor>(
+    nl: &mut [MultilinearPolynomial<Scalar>],
+    nr: &mut [MultilinearPolynomial<Scalar>],
+    dl: &mut [MultilinearPolynomial<Scalar>],
+    dr: &mut [MultilinearPolynomial<Scalar>],
+    weights: &[(Scalar, Scalar)],
+    factor: &Factor,
+  ) -> (Scalar, Scalar)
+  where
+    Scalar: PrimeField,
+    Factor: Fn(usize) -> Scalar + Sync,
+  {
+    let mut instances: Vec<_> = nl
+      .iter_mut()
+      .zip(nr.iter_mut())
+      .zip(dl.iter_mut())
+      .zip(dr.iter_mut())
+      .map(|(((nl, nr), dl), dr)| LogupGateInstanceSlices::new(nl, nr, dl, dr))
+      .collect();
+    let [i0, i1, i2, i3] = instances.as_mut_slice() else {
+      unreachable!("the ppSNARK Logup-GKR gate has four sub-instances");
+    };
+    let [w0, w1, w2, w3] = weights else {
+      unreachable!("the ppSNARK Logup-GKR gate has four weight pairs");
+    };
+
+    zip_with!(
+      (
+        i0.par_iter_mut(),
+        i1.par_iter_mut(),
+        i2.par_iter_mut(),
+        i3.par_iter_mut()
+      ),
+      |c0, c1, c2, c3| {
+        let g0 = c0.cache_and_evaluate(*w0);
+        let g1 = c1.cache_and_evaluate(*w1);
+        let g2 = c2.cache_and_evaluate(*w2);
+        let g3 = c3.cache_and_evaluate(*w3);
+        (g0.0 + g1.0 + g2.0 + g3.0, g0.1 + g1.1 + g2.1 + g3.1)
+      }
+    )
+    .enumerate()
+    .map(|(id, gate)| {
+      let eq_factor = factor(id);
+      (gate.0 * eq_factor, gate.1 * eq_factor)
+    })
+    .reduce(
+      || (Scalar::ZERO, Scalar::ZERO),
+      |a, b| (a.0 + b.0, a.1 + b.1),
+    )
   }
 
   impl<E: Engine> EqSumCheckInstance<E> {
@@ -893,6 +1132,249 @@ pub mod eq_sumcheck {
       (s_0, s_leading, s_m1)
     }
 
+    /// Evaluates `eq(tau, X)` times a weighted sum of fractional-add gates
+    /// without modifying the input MLEs.
+    ///
+    /// Each instance contributes
+    /// `w_num * (nL * dR + nR * dL) + w_den * dL * dR`. The degree-2 inner
+    /// polynomial uses BDDT claim derivation from `t(0)` and `t(inf)`, falling
+    /// back to a third sum when `tau = 0`.
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub fn evaluation_points_logup_gate(
+      &self,
+      nl: &[MultilinearPolynomial<E::Scalar>],
+      nr: &[MultilinearPolynomial<E::Scalar>],
+      dl: &[MultilinearPolynomial<E::Scalar>],
+      dr: &[MultilinearPolynomial<E::Scalar>],
+      weights: &[(E::Scalar, E::Scalar)],
+      claim: E::Scalar,
+    ) -> (E::Scalar, E::Scalar, E::Scalar) {
+      let m = nl.len();
+      assert!(m > 0);
+      assert_eq!(m, nr.len());
+      assert_eq!(m, dl.len());
+      assert_eq!(m, dr.len());
+      assert_eq!(m, weights.len());
+      assert_eq!(nl[0].Z.len() % 2, 0);
+
+      let half_p = nl[0].Z.len() / 2;
+      let gate_0_inf = |id: usize| -> (E::Scalar, E::Scalar) {
+        let mut sum_0 = E::Scalar::ZERO;
+        let mut sum_inf = E::Scalar::ZERO;
+        for i in 0..m {
+          let (w_num, w_den) = weights[i];
+          let nl_0 = nl[i].Z[id];
+          let nr_0 = nr[i].Z[id];
+          let dl_0 = dl[i].Z[id];
+          let dr_0 = dr[i].Z[id];
+          let nl_s = nl[i].Z[id + half_p] - nl_0;
+          let nr_s = nr[i].Z[id + half_p] - nr_0;
+          let dl_s = dl[i].Z[id + half_p] - dl_0;
+          let dr_s = dr[i].Z[id + half_p] - dr_0;
+          sum_0 += w_num * (nl_0 * dr_0 + nr_0 * dl_0) + w_den * (dl_0 * dr_0);
+          sum_inf += w_num * (nl_s * dr_s + nr_s * dl_s) + w_den * (dl_s * dr_s);
+        }
+        (sum_0, sum_inf)
+      };
+
+      let (t_0, t_inf) = if self.round < self.first_half {
+        let (poly_eq_left, poly_eq_right, second_half, low_mask) = self.poly_eqs_first_half();
+        (0..half_p)
+          .into_par_iter()
+          .map(|id| {
+            let factor = poly_eq_left[id >> second_half] * poly_eq_right[id & low_mask];
+            let gate = gate_0_inf(id);
+            (gate.0 * factor, gate.1 * factor)
+          })
+          .reduce(
+            || (E::Scalar::ZERO, E::Scalar::ZERO),
+            |a, b| (a.0 + b.0, a.1 + b.1),
+          )
+      } else {
+        let poly_eq_right = self.poly_eq_right_last_half();
+        (0..half_p)
+          .into_par_iter()
+          .map(|id| {
+            let gate = gate_0_inf(id);
+            (gate.0 * poly_eq_right[id], gate.1 * poly_eq_right[id])
+          })
+          .reduce(
+            || (E::Scalar::ZERO, E::Scalar::ZERO),
+            |a, b| (a.0 + b.0, a.1 + b.1),
+          )
+      };
+
+      if let Some(result) = self.derive_from_claim_deg2(t_0, t_inf, claim) {
+        result
+      } else {
+        self.fallback_eval_inf_logup_gate(t_0, t_inf, nl, nr, dl, dr, weights)
+      }
+    }
+
+    /// Computes the Logup-GKR evaluation at `-1` when `tau = 0` prevents claim
+    /// derivation.
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    fn fallback_eval_inf_logup_gate(
+      &self,
+      t_0: E::Scalar,
+      t_inf: E::Scalar,
+      nl: &[MultilinearPolynomial<E::Scalar>],
+      nr: &[MultilinearPolynomial<E::Scalar>],
+      dl: &[MultilinearPolynomial<E::Scalar>],
+      dr: &[MultilinearPolynomial<E::Scalar>],
+      weights: &[(E::Scalar, E::Scalar)],
+    ) -> (E::Scalar, E::Scalar, E::Scalar) {
+      let p = self.eval_eq_left;
+      let (eq_0, eq_slope, eq_m1) = self.eq_tau_0_a_inf[self.round - 1];
+      let m = nl.len();
+      let half_p = nl[0].Z.len() / 2;
+      let s_0 = eq_0 * p * t_0;
+      let s_leading = eq_slope * p * t_inf;
+
+      let gate_m1 = |id: usize| -> E::Scalar {
+        let mut sum = E::Scalar::ZERO;
+        for i in 0..m {
+          let (w_num, w_den) = weights[i];
+          let nl_m1 = nl[i].Z[id].double() - nl[i].Z[id + half_p];
+          let nr_m1 = nr[i].Z[id].double() - nr[i].Z[id + half_p];
+          let dl_m1 = dl[i].Z[id].double() - dl[i].Z[id + half_p];
+          let dr_m1 = dr[i].Z[id].double() - dr[i].Z[id + half_p];
+          sum += w_num * (nl_m1 * dr_m1 + nr_m1 * dl_m1) + w_den * (dl_m1 * dr_m1);
+        }
+        sum
+      };
+
+      let t_m1 = if self.round < self.first_half {
+        let (poly_eq_left, poly_eq_right, second_half, low_mask) = self.poly_eqs_first_half();
+        (0..half_p)
+          .into_par_iter()
+          .map(|id| gate_m1(id) * poly_eq_left[id >> second_half] * poly_eq_right[id & low_mask])
+          .reduce(|| E::Scalar::ZERO, |a, b| a + b)
+      } else {
+        let poly_eq_right = self.poly_eq_right_last_half();
+        (0..half_p)
+          .into_par_iter()
+          .map(|id| gate_m1(id) * poly_eq_right[id])
+          .reduce(|| E::Scalar::ZERO, |a, b| a + b)
+      };
+
+      let s_m1 = eq_m1 * p * t_m1;
+      (s_0, s_leading, s_m1)
+    }
+
+    /// Evaluates ppSNARK's four Logup-GKR sub-instances and caches each
+    /// top-variable delta in its MLE's high half.
+    ///
+    /// The inner polynomial is degree 2 in `X` (product of two linear factors),
+    /// so BDDT claim derivation applies: only `t(0)` and `t(inf)` are summed over
+    /// `N`, and `s(-1)` is derived from the claim (2 N-scaling sums, not 3).
+    /// Falls back to a third sum when `tau=0` makes the derivation impossible.
+    /// Every input must subsequently be bound with
+    /// `MultilinearPolynomial::bind_poly_var_top_with_cached_delta`.
+    ///
+    /// # Panics
+    ///
+    /// Panics unless exactly four sub-instances are supplied, matching
+    /// ppSNARK's row/column table/access layout.
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub fn evaluation_points_logup_gate_and_cache_deltas(
+      &self,
+      nl: &mut [MultilinearPolynomial<E::Scalar>],
+      nr: &mut [MultilinearPolynomial<E::Scalar>],
+      dl: &mut [MultilinearPolynomial<E::Scalar>],
+      dr: &mut [MultilinearPolynomial<E::Scalar>],
+      weights: &[(E::Scalar, E::Scalar)],
+      claim: E::Scalar,
+    ) -> (E::Scalar, E::Scalar, E::Scalar) {
+      let m = nl.len();
+      assert!(m > 0);
+      assert_eq!(m, nr.len());
+      assert_eq!(m, dl.len());
+      assert_eq!(m, dr.len());
+      assert_eq!(m, weights.len());
+      assert_eq!(nl[0].Z.len() % 2, 0);
+      assert_eq!(
+        m, 4,
+        "cached Logup-GKR evaluation is specialized for ppSNARK's four sub-instances"
+      );
+
+      let (t_0, t_inf) = if self.round < self.first_half {
+        let (poly_eq_left, poly_eq_right, second_half, low_mask) = self.poly_eqs_first_half();
+        let factor = |id| poly_eq_left[id >> second_half] * poly_eq_right[id & low_mask];
+        cache_four_logup_gate_deltas(nl, nr, dl, dr, weights, &factor)
+      } else {
+        let poly_eq_right = self.poly_eq_right_last_half();
+        let factor = |id| poly_eq_right[id];
+        cache_four_logup_gate_deltas(nl, nr, dl, dr, weights, &factor)
+      };
+
+      if let Some(result) = self.derive_from_claim_deg2(t_0, t_inf, claim) {
+        result
+      } else {
+        self.fallback_eval_inf_logup_gate_with_cached_deltas(t_0, t_inf, nl, nr, dl, dr, weights)
+      }
+    }
+
+    /// Fallback for the Logup-GKR gate after the top-variable deltas have been
+    /// cached in every high half.
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    fn fallback_eval_inf_logup_gate_with_cached_deltas(
+      &self,
+      t_0: E::Scalar,
+      t_inf: E::Scalar,
+      nl: &[MultilinearPolynomial<E::Scalar>],
+      nr: &[MultilinearPolynomial<E::Scalar>],
+      dl: &[MultilinearPolynomial<E::Scalar>],
+      dr: &[MultilinearPolynomial<E::Scalar>],
+      weights: &[(E::Scalar, E::Scalar)],
+    ) -> (E::Scalar, E::Scalar, E::Scalar) {
+      let p = self.eval_eq_left;
+      let (eq_0, eq_slope, eq_m1) = self.eq_tau_0_a_inf[self.round - 1];
+      let m = nl.len();
+      let half_p = nl[0].Z.len() / 2;
+
+      let s_0 = eq_0 * p * t_0;
+      let s_leading = eq_slope * p * t_inf;
+
+      // m(-1) = low - (high - low) = low - cached_delta.
+      let gate_m1 = |id: usize| -> E::Scalar {
+        let mut sum = E::Scalar::ZERO;
+        for i in 0..m {
+          let (w_num, w_den) = weights[i];
+          let nl_m1 = nl[i].Z[id] - nl[i].Z[id + half_p];
+          let nr_m1 = nr[i].Z[id] - nr[i].Z[id + half_p];
+          let dl_m1 = dl[i].Z[id] - dl[i].Z[id + half_p];
+          let dr_m1 = dr[i].Z[id] - dr[i].Z[id + half_p];
+          sum += w_num * (nl_m1 * dr_m1 + nr_m1 * dl_m1) + w_den * (dl_m1 * dr_m1);
+        }
+        sum
+      };
+
+      let t_m1 = if self.round < self.first_half {
+        let (poly_eq_left, poly_eq_right, second_half, low_mask) = self.poly_eqs_first_half();
+        (0..half_p)
+          .into_par_iter()
+          .map(|id| {
+            let factor = poly_eq_left[id >> second_half] * poly_eq_right[id & low_mask];
+            gate_m1(id) * factor
+          })
+          .reduce(|| E::Scalar::ZERO, |a, b| a + b)
+      } else {
+        let poly_eq_right = self.poly_eq_right_last_half();
+        (0..half_p)
+          .into_par_iter()
+          .map(|id| gate_m1(id) * poly_eq_right[id])
+          .reduce(|| E::Scalar::ZERO, |a, b| a + b)
+      };
+
+      let s_m1 = eq_m1 * p * t_m1;
+      (s_0, s_leading, s_m1)
+    }
+
     /// Evaluate eq(tau,X) * (A*B - C) using 2 N-scaling sums instead of 3
     /// (BDDT, eprint 2025/1117 Section 6.2).
     /// Falls back to computing all 3 sums when tau=0 makes derivation impossible.
@@ -1079,6 +1561,76 @@ pub mod eq_sumcheck {
       }
     }
 
+    /// Evaluates `eq(tau, X) * A(X)` while caching `A(high) - A(low)` in
+    /// `A`'s high half for the following bind.
+    ///
+    /// The caller must use
+    /// `MultilinearPolynomial::bind_poly_var_top_with_cached_delta` for this round.
+    #[inline]
+    pub fn evaluation_points_quadratic_with_one_input_and_cached_delta(
+      &self,
+      poly_A: &mut MultilinearPolynomial<E::Scalar>,
+      claim: E::Scalar,
+    ) -> (E::Scalar, E::Scalar, E::Scalar) {
+      debug_assert_eq!(poly_A.len() % 2, 0);
+
+      let in_first_half = self.round < self.first_half;
+      let half_p = poly_A.Z.len() / 2;
+      let (low, delta) = poly_A.Z.split_at_mut(half_p);
+
+      let t_0 = if in_first_half {
+        let (poly_eq_left, poly_eq_right, second_half, low_mask) = self.poly_eqs_first_half();
+        let eval = |id: usize, low: &E::Scalar, delta: &mut E::Scalar| {
+          *delta -= low;
+          *low * poly_eq_left[id >> second_half] * poly_eq_right[id & low_mask]
+        };
+
+        if half_p < PARALLEL_THRESHOLD {
+          low
+            .iter()
+            .zip(delta.iter_mut())
+            .enumerate()
+            .map(|(id, (low, delta))| eval(id, low, delta))
+            .sum()
+        } else {
+          low
+            .par_iter()
+            .zip(delta.par_iter_mut())
+            .enumerate()
+            .map(|(id, (low, delta))| eval(id, low, delta))
+            .sum()
+        }
+      } else {
+        let poly_eq_right = self.poly_eq_right_last_half();
+        let eval = |id: usize, low: &E::Scalar, delta: &mut E::Scalar| {
+          *delta -= low;
+          *low * poly_eq_right[id]
+        };
+
+        if half_p < PARALLEL_THRESHOLD {
+          low
+            .iter()
+            .zip(delta.iter_mut())
+            .enumerate()
+            .map(|(id, (low, delta))| eval(id, low, delta))
+            .sum()
+        } else {
+          low
+            .par_iter()
+            .zip(delta.par_iter_mut())
+            .enumerate()
+            .map(|(id, (low, delta))| eval(id, low, delta))
+            .sum()
+        }
+      };
+
+      if let Some(result) = self.derive_from_claim_deg1(t_0, claim) {
+        result
+      } else {
+        self.fallback_eval_inf_one_input_with_cached_delta(t_0, poly_A)
+      }
+    }
+
     /// Fallback for three-input case: compute eval_inf via third N-scaling sum
     /// when claim-based derivation is impossible (tau=0).
     #[inline]
@@ -1214,6 +1766,44 @@ pub mod eq_sumcheck {
             let m1_a = a.0.double() - *a.1;
             m1_a * eq_r
           })
+          .reduce(|| E::Scalar::ZERO, |a, b| a + b)
+      };
+
+      let s_m1 = eq_m1 * p * t_m1;
+      (s_0, s_leading, s_m1)
+    }
+
+    /// Computes the one-input evaluation at `-1` from the cached delta when
+    /// `tau = 0` prevents claim derivation.
+    #[inline]
+    fn fallback_eval_inf_one_input_with_cached_delta(
+      &self,
+      t_0: E::Scalar,
+      poly_A: &MultilinearPolynomial<E::Scalar>,
+    ) -> (E::Scalar, E::Scalar, E::Scalar) {
+      let p = self.eval_eq_left;
+      let (eq_0, _eq_slope, eq_m1) = self.eq_tau_0_a_inf[self.round - 1];
+
+      let s_0 = eq_0 * p * t_0;
+      let s_leading = E::Scalar::ZERO;
+
+      let half_p = poly_A.Z.len() / 2;
+      let (low, delta) = poly_A.Z.split_at(half_p);
+
+      let t_m1 = if self.round < self.first_half {
+        let (poly_eq_left, poly_eq_right, second_half, low_mask) = self.poly_eqs_first_half();
+        (0..half_p)
+          .into_par_iter()
+          .map(|id| {
+            let factor = poly_eq_left[id >> second_half] * poly_eq_right[id & low_mask];
+            (low[id] - delta[id]) * factor
+          })
+          .reduce(|| E::Scalar::ZERO, |a, b| a + b)
+      } else {
+        let poly_eq_right = self.poly_eq_right_last_half();
+        (0..half_p)
+          .into_par_iter()
+          .map(|id| (low[id] - delta[id]) * poly_eq_right[id])
           .reduce(|| E::Scalar::ZERO, |a, b| a + b)
       };
 

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -714,7 +714,10 @@ pub mod eq_sumcheck {
   }
 
   impl<Scalar: PrimeField> LogupGateCell<'_, Scalar> {
-    fn cache_and_evaluate(self, weights: (Scalar, Scalar)) -> (Scalar, Scalar) {
+    fn cache_and_evaluate<const EVALUATE_T_0: bool>(
+      self,
+      weights: (Scalar, Scalar),
+    ) -> (Scalar, Scalar) {
       *self.nl_delta -= self.nl_0;
       *self.nr_delta -= self.nr_0;
       *self.dl_delta -= self.dl_0;
@@ -722,7 +725,11 @@ pub mod eq_sumcheck {
 
       let (w_num, w_den) = weights;
       (
-        w_num * (self.nl_0 * self.dr_0 + self.nr_0 * self.dl_0) + w_den * (self.dl_0 * self.dr_0),
+        if EVALUATE_T_0 {
+          w_num * (self.nl_0 * self.dr_0 + self.nr_0 * self.dl_0) + w_den * (self.dl_0 * self.dr_0)
+        } else {
+          Scalar::ZERO
+        },
         w_num * (*self.nl_delta * *self.dr_delta + *self.nr_delta * *self.dl_delta)
           + w_den * (*self.dl_delta * *self.dr_delta),
       )
@@ -790,7 +797,7 @@ pub mod eq_sumcheck {
     }
   }
 
-  fn cache_four_logup_gate_deltas<Scalar, Factor>(
+  fn cache_four_logup_gate_deltas<const EVALUATE_T_0: bool, Scalar, Factor>(
     nl: &mut [MultilinearPolynomial<Scalar>],
     nr: &mut [MultilinearPolynomial<Scalar>],
     dl: &mut [MultilinearPolynomial<Scalar>],
@@ -824,10 +831,10 @@ pub mod eq_sumcheck {
         i3.par_iter_mut()
       ),
       |c0, c1, c2, c3| {
-        let g0 = c0.cache_and_evaluate(*w0);
-        let g1 = c1.cache_and_evaluate(*w1);
-        let g2 = c2.cache_and_evaluate(*w2);
-        let g3 = c3.cache_and_evaluate(*w3);
+        let g0 = c0.cache_and_evaluate::<EVALUATE_T_0>(*w0);
+        let g1 = c1.cache_and_evaluate::<EVALUATE_T_0>(*w1);
+        let g2 = c2.cache_and_evaluate::<EVALUATE_T_0>(*w2);
+        let g3 = c3.cache_and_evaluate::<EVALUATE_T_0>(*w3);
         (g0.0 + g1.0 + g2.0 + g3.0, g0.1 + g1.1 + g2.1 + g3.1)
       }
     )
@@ -840,6 +847,32 @@ pub mod eq_sumcheck {
       || (Scalar::ZERO, Scalar::ZERO),
       |a, b| (a.0 + b.0, a.1 + b.1),
     )
+  }
+
+  /// Caches four Logup-GKR instances' deltas, optionally taking `t(0)` from the
+  /// caller instead of evaluating it over the low halves.
+  #[allow(clippy::too_many_arguments)]
+  fn cache_four_logup_gate_deltas_with_t_0<Scalar, Factor>(
+    nl: &mut [MultilinearPolynomial<Scalar>],
+    nr: &mut [MultilinearPolynomial<Scalar>],
+    dl: &mut [MultilinearPolynomial<Scalar>],
+    dr: &mut [MultilinearPolynomial<Scalar>],
+    weights: &[(Scalar, Scalar)],
+    t_0: Option<Scalar>,
+    factor: &Factor,
+  ) -> (Scalar, Scalar)
+  where
+    Scalar: PrimeField,
+    Factor: Fn(usize) -> Scalar + Sync,
+  {
+    match t_0 {
+      Some(t_0) => {
+        let (_, t_inf) =
+          cache_four_logup_gate_deltas::<false, _, _>(nl, nr, dl, dr, weights, factor);
+        (t_0, t_inf)
+      }
+      None => cache_four_logup_gate_deltas::<true, _, _>(nl, nr, dl, dr, weights, factor),
+    }
   }
 
   impl<E: Engine> EqSumCheckInstance<E> {
@@ -1267,17 +1300,18 @@ pub mod eq_sumcheck {
     /// Evaluates ppSNARK's four Logup-GKR sub-instances and caches each
     /// top-variable delta in its MLE's high half.
     ///
-    /// The inner polynomial is degree 2 in `X` (product of two linear factors),
-    /// so BDDT claim derivation applies: only `t(0)` and `t(inf)` are summed over
-    /// `N`, and `s(-1)` is derived from the claim (2 N-scaling sums, not 3).
-    /// Falls back to a third sum when `tau=0` makes the derivation impossible.
+    /// The scan evaluates `t(0)` and `t(inf)`. BDDT claim derivation obtains
+    /// `s(-1)`, falling back to a third sum when the equality factor at `X=1`
+    /// is noninvertible.
+    /// `claim` must be the current `s(0) + s(1)` claim. Returns
+    /// `(s(0), X^3 coefficient of s, s(-1))`.
     /// Every input must subsequently be bound with
     /// `MultilinearPolynomial::bind_poly_var_top_with_cached_delta`.
     ///
     /// # Panics
     ///
-    /// Panics unless exactly four sub-instances are supplied, matching
-    /// ppSNARK's row/column table/access layout.
+    /// Panics unless all argument slices contain four equally sized, nonconstant
+    /// MLEs matching the current equality-sumcheck round.
     #[inline]
     #[allow(clippy::too_many_arguments)]
     pub fn evaluation_points_logup_gate_and_cache_deltas(
@@ -1287,6 +1321,57 @@ pub mod eq_sumcheck {
       dl: &mut [MultilinearPolynomial<E::Scalar>],
       dr: &mut [MultilinearPolynomial<E::Scalar>],
       weights: &[(E::Scalar, E::Scalar)],
+      claim: E::Scalar,
+    ) -> (E::Scalar, E::Scalar, E::Scalar) {
+      self.evaluation_points_logup_gate_and_cache_deltas_inner(nl, nr, dl, dr, weights, None, claim)
+    }
+
+    /// Round-0 specialization that accepts the already-evaluated inner `t(0)`.
+    ///
+    /// `t_0` is the weighted inner gate sum at `X=0`, before multiplication by
+    /// the current equality factor. This method still caches every `high - low`
+    /// delta and returns `(s(0), X^3 coefficient of s, s(-1))`; callers must
+    /// subsequently bind with
+    /// `MultilinearPolynomial::bind_poly_var_top_with_cached_delta`.
+    ///
+    /// # Panics
+    ///
+    /// Panics unless called in round 0 with exactly four compatible
+    /// sub-instances.
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn evaluation_points_logup_gate_and_cache_deltas_with_t_0(
+      &self,
+      nl: &mut [MultilinearPolynomial<E::Scalar>],
+      nr: &mut [MultilinearPolynomial<E::Scalar>],
+      dl: &mut [MultilinearPolynomial<E::Scalar>],
+      dr: &mut [MultilinearPolynomial<E::Scalar>],
+      weights: &[(E::Scalar, E::Scalar)],
+      t_0: E::Scalar,
+      claim: E::Scalar,
+    ) -> (E::Scalar, E::Scalar, E::Scalar) {
+      assert_eq!(self.round, 1, "precomputed t(0) is only valid in round 0");
+      self.evaluation_points_logup_gate_and_cache_deltas_inner(
+        nl,
+        nr,
+        dl,
+        dr,
+        weights,
+        Some(t_0),
+        claim,
+      )
+    }
+
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
+    fn evaluation_points_logup_gate_and_cache_deltas_inner(
+      &self,
+      nl: &mut [MultilinearPolynomial<E::Scalar>],
+      nr: &mut [MultilinearPolynomial<E::Scalar>],
+      dl: &mut [MultilinearPolynomial<E::Scalar>],
+      dr: &mut [MultilinearPolynomial<E::Scalar>],
+      weights: &[(E::Scalar, E::Scalar)],
+      known_t_0: Option<E::Scalar>,
       claim: E::Scalar,
     ) -> (E::Scalar, E::Scalar, E::Scalar) {
       let m = nl.len();
@@ -1304,11 +1389,11 @@ pub mod eq_sumcheck {
       let (t_0, t_inf) = if self.round < self.first_half {
         let (poly_eq_left, poly_eq_right, second_half, low_mask) = self.poly_eqs_first_half();
         let factor = |id| poly_eq_left[id >> second_half] * poly_eq_right[id & low_mask];
-        cache_four_logup_gate_deltas(nl, nr, dl, dr, weights, &factor)
+        cache_four_logup_gate_deltas_with_t_0(nl, nr, dl, dr, weights, known_t_0, &factor)
       } else {
         let poly_eq_right = self.poly_eq_right_last_half();
         let factor = |id| poly_eq_right[id];
-        cache_four_logup_gate_deltas(nl, nr, dl, dr, weights, &factor)
+        cache_four_logup_gate_deltas_with_t_0(nl, nr, dl, dr, weights, known_t_0, &factor)
       };
 
       if let Some(result) = self.derive_from_claim_deg2(t_0, t_inf, claim) {
@@ -1318,8 +1403,8 @@ pub mod eq_sumcheck {
       }
     }
 
-    /// Fallback for the Logup-GKR gate after the top-variable deltas have been
-    /// cached in every high half.
+    /// Computes `s(-1)` from cached deltas when claim derivation cannot invert
+    /// the current equality factor.
     #[inline]
     #[allow(clippy::too_many_arguments)]
     fn fallback_eval_inf_logup_gate_with_cached_deltas(


### PR DESCRIPTION
## Summary

This PR improves preprocessing Spartan (ppSNARK), primarily by replacing its inverse-logup memory-check with a Logup-GKR argument. The new default avoids committing to four inverse-oracle polynomials and reduces the final batched PCS opening from 15 polynomials to 11.

The trade-off is proof size: Logup-GKR adds a field-only proof whose size is quadratic in `log N`. In return, the measured end-to-end prover is about **1.3x faster** at medium and large circuit sizes, corresponding to roughly **23-24% less wall time** in the current A/B benchmark.

The original inverse-logup implementation remains available behind the `logup-no-gkr` feature for compatibility, comparison, and deployments that prefer the smaller proof.

## Motivation

The previous ppSNARK memory-check proves, independently for the row and column memories,

```text
sum_i ts[i] / (T[i] + r) = sum_i 1 / (W[i] + r).
```

Its prover materializes four inverse-oracle vectors through two batch inversions, commits to all four vectors, proves four inverse-validity claims in addition to the two balance claims, and includes the four inverse polynomials in the final batched PCS opening. At large `N`, the four length-`N` commitments dominate the memory-check wall time.

Logup-GKR keeps the fractions in projective form and proves their reduction through fractional-add trees. It therefore removes the need to materialize or commit to the inverse polynomials.

## Protocol changes

### Logup-GKR memory-check

The new memory-check builds four equal-height input layers:

```text
row table:   ts_row / (T_row + r)
row access:       -1 / (W_row + r)
col table:   ts_col / (T_col + r)
col access:       -1 / (W_col + r)
```

Each layer is folded with the projective fractional-add gate

```text
(n_l, d_l) + (n_r, d_r)
  = (n_l * d_r + n_r * d_l, d_l * d_r).
```

The prover and verifier batch the four trees at every layer. The verifier then:

1. verifies the GKR layer reductions;
2. reconstructs the four input fractions from the claimed column evaluations at the shared `eval_point` and reconciles them with the GKR result;
3. checks that the row and column table/access roots each sum to zero; and
4. binds the claimed columns to the committed ppSNARK polynomials through the batched inner sumcheck and final PCS opening.

The GKR reduction adds `O(log N)` layer sumchecks, with a decreasing number of rounds per layer. It contributes `O(log^2 N)` field elements to the proof.

### Opening-point reduction

GKR finishes at its own `eval_point`, while the existing ppSNARK inner sumcheck finishes at `r_inner_batched`. A rerandomization sumcheck carries the seven columns needed by the host reconciliation from `eval_point` to `r_inner_batched`:

```text
L_row, L_col, row, col, ts_row, ts_col, mem_col.
```

This rerandomization claim is included in the existing batched inner sumcheck, so all committed polynomials are still opened once at `r_inner_batched`.

### What is removed and added

Removed from the default path:

- two batch inversions that produce four inverse-oracle vectors;
- four length-`N` inverse-oracle commitments;
- the old six-claim memory sumcheck, including four inverse-validity claims;
- four inverse polynomials and evaluations from the batched PCS input (`15 -> 11` polynomials).

Added to the default path:

- four projective fractional-sum trees;
- one batched GKR argument across the four trees, with `O(log N)` layer sumchecks;
- seven claimed column evaluations at the GKR `eval_point`;
- a rerandomization sumcheck that aligns the GKR final claim with `r_inner_batched`.

The evaluation engine still receives one RLC-batched length-`N` polynomial, so the IPA, HyperKZG, or Mercury evaluation argument itself does not become smaller. The `15 -> 11` reduction saves construction work before `EvaluationEngine::prove`; the main wall-time saving comes from removing the four inverse-oracle commitments.

## Feature gate

Logup-GKR is the default memory-check. The original inverse-logup protocol can be selected at compile time:

```bash
# Default: Logup-GKR
cargo test --release

# Legacy inverse-logup memory-check
cargo test --release --features logup-no-gkr
```

The two configurations have different ppSNARK proof layouts. A proof must be verified with the same feature configuration that produced it.

## Sumcheck optimizations

### Reuse cached multilinear deltas

For a multilinear polynomial split into low and high halves, both round evaluation and binding need the slope

```text
delta = high - low.
```

The evaluation pass now stores `delta` in the high half. After the transcript produces the round challenge, binding reuses it directly:

```text
low <- low + r * cached_delta.
```

This avoids recomputing the subtraction during the bind pass without changing the round polynomial, transcript, or proof. The optimization is applied to:

- the ppSNARK batched inner sumcheck's cubic ABC claim (`L_row * L_col * val`) and its `E` evaluation claim;
- the four-instance Logup-GKR fractional-add layer sumcheck; and
- the multi-column rerandomization implementation when it is used without coefficient fusion.

The default Logup-GKR path fuses the rerandomization columns as described below, so that path binds one combined polynomial instead of seven cached polynomials.

### Fuse the seven rerandomization columns

Once `prove_helper` samples the inner-batch coefficients, the seven rerandomization columns and claims are collapsed into one random linear combination. This reduces the rerandomization state from approximately `7N` field elements to `N` and changes each inner-sumcheck round from seven column scans/binds to one.

The fusion is linear in the same coefficients already used by the batched sumcheck. It preserves the transcript and proof bytes. In the focused A/B measurement, it reduced the inner-batch phase by approximately 25-33% at `2^18` and `2^20` constraints.

### Optimize GKR layer sumchecks

The GKR prover also:

- reuses `EqSumCheckInstance` instead of materializing and rebinding a full equality MLE;
- uses Gruen equality factoring so the equality-polynomial bind is constant time per round;
- uses BDDT claim derivation to compute two `N`-scaling sums instead of three in the common case;
- evaluates the four ppSNARK sub-instances in one parallel pass, hoisting the shared equality factor out of the instance loop;
- computes round data directly and parallelizes only above measured crossover thresholds; and
- uses Horner-style powers for per-instance `lambda` batching.

## Memory management

This PR shortens the lifetime of large prover buffers before later ppSNARK phases allocate their own length-`N` data:

Here, `m` is the constraint count used by the shortened outer sumcheck and `N` is the padded inner-domain size.

- release `poly_Az`, `poly_Bz`, `poly_uCz_E`, and `Cz` after the outer claims are computed (approximately `4m` field elements);
- release the padded relaxed witness after the length-`N` `E` and `W` vectors are materialized (approximately `2m` field elements);
- release the local padded R1CS shape, its lazy sparse-matrix caches, and the assignment `z` after `evaluation_oracles`;
- move, rather than clone, GKR child buffers into each layer sumcheck; and
- consume and drop every GKR tree layer immediately after proving it.

These lifetime changes do not affect the transcript or proof.

## Performance

The following numbers compare the current default Logup-GKR path with `--features logup-no-gkr` using `Bn256EngineKZG` + HyperKZG on an Apple M-series machine with 14 cores. Each row is the median of 10 sequential repetitions after one warm-up.

| Constraints | Logup-GKR | Inverse-logup | Wall-time reduction | Speedup |
|---:|---:|---:|---:|---:|
| `2^16` | 0.667 s | 0.875 s | 23.7% | 1.31x |
| `2^18` | 2.387 s | 3.145 s | 24.1% | 1.32x |
| `2^20` | 8.789 s | 11.405 s | 22.9% | 1.30x |

At `2^20`, the isolated memory-check phase improves from 3.649 s to 0.834 s, or approximately **4.4x**. This phase accounts for essentially the entire end-to-end difference; the two `L` commitments and the final HyperKZG opening are shared costs.

The same `2^20` run measured peak RSS at 9.09 GB for Logup-GKR and 10.92 GB for inverse-logup. RSS remains high because ppSNARK and HyperKZG retain several length-`N` buffers; this PR reduces it but does not claim to solve the full prover-memory problem.

## Proof-size trade-off

Logup-GKR deliberately exchanges proof size for prover time. Let `d = log2(N)`. For four GKR sub-instances, its memory-check-specific payload is approximately

```text
initial roots:                       8 scalars
per-layer split final claims:      16d scalars
compressed layer round polynomials: 3d(d - 1) / 2 scalars
rerandomization claims:              7 scalars
total:                 15 + 16d + 3d(d - 1) / 2 scalars.
```

At `N = 2^20`, this is 905 field elements, or about 28 KiB for 32-byte field elements, before container and serialization metadata. The inverse-logup memory-check instead carries four commitments and four field evaluations.

The shared evaluation argument has the same size in both modes because all PCS inputs are RLC-batched before the evaluation engine is invoked. Users for whom proof bytes, network transfer, or calldata dominate can retain inverse-logup through `logup-no-gkr`.

## Correctness and review notes

- The Logup-GKR core is specialized to ppSNARK's four equal-height row/column table/access instances. It asserts equal `num_vars` and does not add generic padding machinery.
- The verifier defines the transcript order and independently checks every root gate, layer sumcheck, fold-down claim, host reconciliation, and final balance claim.
- Every layer samples a fresh Fiat-Shamir `lambda`; per-instance batching uses distinct Horner powers.
- Performance-only changes preserve the transcript and proof output.
- The default proof format changes because the memory-check protocol changes; `logup-no-gkr` is the explicit legacy fallback.

## Validation

Validated during development under both memory-check configurations:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --all-targets --features logup-no-gkr -- -D warnings`
- Spartan unit tests, including adversarial Logup-GKR verifier tests
- `cargo test --release test_ivc_nontrivial_with_compression`
- `cargo test --release --features logup-no-gkr test_ivc_nontrivial_with_compression`
