### PR TITLE
Reject malformed witness lengths instead of panicking

### DIFF
--- a/src/frontend/gadgets/num.rs
+++ b/src/frontend/gadgets/num.rs
@@ -228,7 +228,7 @@ impl<Scalar: PrimeField> AllocatedNum<Scalar> {
             cs.namespace(|| format!("run ending at {i}")),
             &current_run,
           )?);
-          current_run.truncate(0);
+          current_run.clear();
         }
 
         // If `last_run` is true, `a` must be false, or it would

--- a/src/frontend/test_shape_cs.rs
+++ b/src/frontend/test_shape_cs.rs
@@ -141,7 +141,7 @@ where
     let mut s = String::new();
 
     for input in &self.inputs {
-      writeln!(s, "INPUT {}", &input).unwrap()
+      writeln!(s, "INPUT {}", input).unwrap()
     }
 
     let negone = -<E::Scalar>::ONE;
@@ -174,10 +174,10 @@ where
 
         match var.0.get_unchecked() {
           Index::Input(i) => {
-            write!(s, "`I{}`", &self.inputs[i]).unwrap();
+            write!(s, "`I{}`", self.inputs[i]).unwrap();
           }
           Index::Aux(i) => {
-            write!(s, "`A{}`", &self.aux[i]).unwrap();
+            write!(s, "`A{}`", self.aux[i]).unwrap();
           }
         }
       }

--- a/src/nova/mod.rs
+++ b/src/nova/mod.rs
@@ -1176,6 +1176,66 @@ mod tests {
     test_ivc_trivial_with::<Secp256k1Engine, Secq256k1Engine>();
   }
 
+  /// A `RecursiveSNARK` whose witness vectors do not match the shape must be
+  /// rejected, not abort the process.
+  ///
+  /// `RecursiveSNARK` derives `Deserialize` with no validation of its internal
+  /// vector lengths, so a verifier that accepts one from an untrusted source —
+  /// which is what a succinct proof is for — can be handed any shape at all.
+  /// `verify`'s pre-checks cover `i`, `z0` and the `X` lengths, and the
+  /// output-hash check does not cover `W` or `E`, so a proof with one witness
+  /// element added or removed reaches the satisfiability check with a length
+  /// that used to be asserted rather than returned.
+  fn test_ivc_malformed_witness_is_rejected_with<E1, E2>()
+  where
+    E1: Engine<Base = <E2 as Engine>::Scalar>,
+    E2: Engine<Base = <E1 as Engine>::Scalar>,
+  {
+    let test_circuit = TrivialCircuit::<<E1 as Engine>::Scalar>::default();
+    let pp = PublicParams::<E1, E2, TrivialCircuit<<E1 as Engine>::Scalar>>::setup(
+      &test_circuit,
+      &*default_ck_hint(),
+      &*default_ck_hint(),
+    )
+    .unwrap();
+    let z0 = [<E1 as Engine>::Scalar::ZERO];
+
+    let mut recursive_snark = RecursiveSNARK::new(&pp, &test_circuit, &z0).unwrap();
+    recursive_snark.prove_step(&pp, &test_circuit).unwrap();
+    assert!(recursive_snark.verify(&pp, 1, &z0).is_ok());
+
+    // One element too many in the primary running witness.
+    let mut grown = recursive_snark.clone();
+    grown.r_W_primary.W.push(<E1 as Engine>::Scalar::ZERO);
+    assert!(matches!(
+      grown.verify(&pp, 1, &z0),
+      Err(NovaError::InvalidWitnessLength)
+    ));
+
+    // One element too few in the primary error vector.
+    let mut shrunk = recursive_snark.clone();
+    shrunk.r_W_primary.E.pop();
+    assert!(matches!(
+      shrunk.verify(&pp, 1, &z0),
+      Err(NovaError::InvalidWitnessLength)
+    ));
+
+    // And on the secondary curve, whose incoming witness goes through
+    // `is_sat` rather than `is_sat_relaxed`.
+    let mut secondary = recursive_snark.clone();
+    secondary.l_w_secondary.W.push(<E2 as Engine>::Scalar::ZERO);
+    assert!(matches!(
+      secondary.verify(&pp, 1, &z0),
+      Err(NovaError::InvalidWitnessLength)
+    ));
+  }
+
+  #[test]
+  fn test_ivc_malformed_witness_is_rejected() {
+    test_ivc_malformed_witness_is_rejected_with::<PallasEngine, VestaEngine>();
+    test_ivc_malformed_witness_is_rejected_with::<Bn256EngineKZG, GrumpkinEngine>();
+  }
+
   fn test_ivc_nontrivial_with<E1, E2>()
   where
     E1: Engine<Base = <E2 as Engine>::Scalar>,

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -450,9 +450,21 @@ impl<E: Engine> R1CSShape<E> {
     U: &RelaxedR1CSInstance<E>,
     W: &RelaxedR1CSWitness<E>,
   ) -> Result<(), NovaError> {
-    assert_eq!(W.W.len(), self.num_vars);
-    assert_eq!(W.E.len(), self.num_cons);
-    assert_eq!(U.X.len(), self.num_io);
+    // A `RelaxedR1CSWitness` can arrive from `Deserialize` with any lengths at
+    // all, so these are checks on untrusted input rather than internal
+    // invariants: assert here and a verifier that accepts a proof from a peer
+    // aborts instead of rejecting it.
+    //
+    // `W` and `X` are also covered one call deeper, since `multiply_vec`
+    // returns `InvalidWitnessLength` when `z` does not match the shape.
+    // `E` is not: it is not part of `z`, and a short one is an out-of-bounds
+    // index in the satisfiability loop below.
+    if W.W.len() != self.num_vars || W.E.len() != self.num_cons {
+      return Err(NovaError::InvalidWitnessLength);
+    }
+    if U.X.len() != self.num_io {
+      return Err(NovaError::InvalidInputLength);
+    }
 
     // verify if Az * Bz = u*Cz + E
     let res_eq = {
@@ -496,8 +508,14 @@ impl<E: Engine> R1CSShape<E> {
     U: &R1CSInstance<E>,
     W: &R1CSWitness<E>,
   ) -> Result<(), NovaError> {
-    assert_eq!(W.W.len(), self.num_vars);
-    assert_eq!(U.X.len(), self.num_io);
+    // Same reasoning as `is_sat_relaxed`: attacker-supplied lengths, not
+    // internal invariants.
+    if W.W.len() != self.num_vars {
+      return Err(NovaError::InvalidWitnessLength);
+    }
+    if U.X.len() != self.num_io {
+      return Err(NovaError::InvalidInputLength);
+    }
 
     // verify if Az * Bz = u*Cz
     let res_eq = {


### PR DESCRIPTION
Towards #399, for the case that is reachable from untrusted input.

`RecursiveSNARK` derives `Deserialize` with no validation of its internal
vector lengths, and `verify` reaches `assert_eq!` inside `is_sat_relaxed` /
`is_sat` rather than returning `Err`:

```
src/r1cs/mod.rs:453   assert_eq!(W.W.len(), self.num_vars);
src/r1cs/mod.rs:454   assert_eq!(W.E.len(), self.num_cons);
src/r1cs/mod.rs:455   assert_eq!(U.X.len(), self.num_io);
src/r1cs/mod.rs:499   assert_eq!(W.W.len(), self.num_vars);
src/r1cs/mod.rs:500   assert_eq!(U.X.len(), self.num_io);
```

`verify`'s existing pre-checks cover `i`, `z0` and the `X` lengths of the
*instances*, and the output-hash check does not cover `W` or `E`, so a proof
with one witness element added or removed passes everything and then aborts
the process. For a verifier that accepts proofs from an untrusted peer — which
is what a succinct proof is for — that is a remote crash rather than a rejected
proof, and `catch_unwind` is the only thing a downstream user can do about it
(and it does nothing under `panic = "abort"`).

## The change

Both functions already return `Result<(), NovaError>`, and `NovaError` already
carries `InvalidWitnessLength` and `InvalidInputLength`. No signature changes.

Two of the five checks are strictly defence in depth: `multiply_vec` one call
deeper *already* returns `NovaError::InvalidWitnessLength` when
`z.len() != num_io + num_vars + 1`, so a bad `W.W` or `U.X` is caught either
way — the assert merely fires first, and as a panic. Making them explicit keeps
the error precise and local.

The `W.E` check is load-bearing. `E` is not part of `z`, so nothing downstream
validates it: the satisfiability loop indexes `W.E[i]` over `0..num_cons`, and
a short `E` is an out-of-bounds panic. A long one reaches
`assert!(ck.ck.len() >= v.len())` in `pedersen::commit`.

The remaining `assert_eq!(Az.len(), self.num_cons)` and friends are invariants
of `multiply_vec` given the checks above, not properties of caller input, so
they are left alone.

## Test

`test_ivc_malformed_witness_is_rejected`, over Pallas/Vesta and Bn256/Grumpkin,
covers the three reachable shapes: one element too many in the primary running
witness, one too few in the primary error vector, and the secondary incoming
witness (which goes through `is_sat` rather than `is_sat_relaxed`). Against
`main` it aborts the test process at `src/r1cs/mod.rs:453`
(`left: 9811, right: 9810`); with this change each case returns
`Err(NovaError::InvalidWitnessLength)`.

`cargo test --lib`, `cargo clippy --all-targets -- -D warnings` and
`cargo fmt --check` are clean, with and without `--features experimental`.

## Not in this PR

`pedersen::commit`'s `assert!(ck.ck.len() >= v.len())` is unreachable from
`verify` once the shape checks above are in place, but it is a panic on a
public API that returns `Commitment` rather than `Result`. Fixing it properly
means changing a widely used signature, which seemed worth keeping separate
from a change this small.

`neutron::relation::Structure::is_sat` has the same hole and no asserts at all
— its tensor-form `E` is split at `left` and indexed over `0..right`, so a
short one is an out-of-bounds index. Filed separately rather than fixed here:
the length check is easy, but the existing `test_sat` constructs `E` at a
different length than `nifs.rs` asserts, so the intended invariant is a
question for you rather than something I should guess at inside an
`experimental` module.

Found while hardening a downstream verifier that accepts recursive proofs from
mutually untrusting parties.
