### PR TITLE
Add a cryptographic randomness engine to Engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-snark"
-version = "0.74.0"
+version = "0.75.0"
 authors = ["Srinath Setty <srinath@microsoft.com>"]
 edition = "2021"
 description = "High-speed recursive arguments from folding schemes"

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -157,11 +157,14 @@ impl Engine for VestaEngine {
 
 #[cfg(test)]
 mod tests {
+  use super::PallasEngine;
   use crate::provider::{
     bn256_grumpkin::bn256, pasta::pallas, secp_secq::secp256k1, traits::DlogGroup,
   };
+  use crate::traits::Engine;
   use digest::{ExtendableOutput, Update};
   use halo2curves::{group::Curve, CurveExt};
+  use rand_core::{RngCore, SeedableRng};
   use sha3::Shake256;
   use std::io::Read;
 
@@ -207,5 +210,22 @@ mod tests {
   #[test]
   fn test_secp256k1_from_label() {
     impl_cycle_pair_test!(secp256k1);
+  }
+
+  #[test]
+  fn test_engine_randomness_is_seed_reproducible() {
+    let mut rng_1 = <PallasEngine as Engine>::RE::from_seed([7_u8; 32]);
+    let mut rng_2 = <PallasEngine as Engine>::RE::from_seed([7_u8; 32]);
+    let mut rng_3 = <PallasEngine as Engine>::RE::from_seed([8_u8; 32]);
+    let mut bytes_1 = [0_u8; 64];
+    let mut bytes_2 = [0_u8; 64];
+    let mut bytes_3 = [0_u8; 64];
+
+    rng_1.fill_bytes(&mut bytes_1);
+    rng_2.fill_bytes(&mut bytes_2);
+    rng_3.fill_bytes(&mut bytes_3);
+
+    assert_eq!(bytes_1, bytes_2);
+    assert_ne!(bytes_1, bytes_3);
   }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 #[cfg(feature = "io")]
 pub use ptau::{check_sanity_of_ptau_file, read_ptau, write_ptau};
+use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
 
 /// An implementation of Nova traits with HyperKZG over the BN256 curve
@@ -48,6 +49,7 @@ pub struct GrumpkinEngine;
 pub struct Bn256EngineIPA;
 
 impl Engine for Bn256EngineKZG {
+  type RE = ChaCha20Rng;
   type Base = bn256::Base;
   type Scalar = bn256::Scalar;
   type GE = bn256::Point;
@@ -60,6 +62,7 @@ impl Engine for Bn256EngineKZG {
 }
 
 impl Engine for Bn256EngineIPA {
+  type RE = ChaCha20Rng;
   type Base = bn256::Base;
   type Scalar = bn256::Scalar;
   type GE = bn256::Point;
@@ -72,6 +75,7 @@ impl Engine for Bn256EngineIPA {
 }
 
 impl Engine for GrumpkinEngine {
+  type RE = ChaCha20Rng;
   type Base = grumpkin::Base;
   type Scalar = grumpkin::Scalar;
   type GE = grumpkin::Point;
@@ -92,6 +96,7 @@ pub struct Secp256k1Engine;
 pub struct Secq256k1Engine;
 
 impl Engine for Secp256k1Engine {
+  type RE = ChaCha20Rng;
   type Base = secp256k1::Base;
   type Scalar = secp256k1::Scalar;
   type GE = secp256k1::Point;
@@ -104,6 +109,7 @@ impl Engine for Secp256k1Engine {
 }
 
 impl Engine for Secq256k1Engine {
+  type RE = ChaCha20Rng;
   type Base = secq256k1::Base;
   type Scalar = secq256k1::Scalar;
   type GE = secq256k1::Point;
@@ -124,6 +130,7 @@ pub struct PallasEngine;
 pub struct VestaEngine;
 
 impl Engine for PallasEngine {
+  type RE = ChaCha20Rng;
   type Base = pallas::Base;
   type Scalar = pallas::Scalar;
   type GE = pallas::Point;
@@ -136,6 +143,7 @@ impl Engine for PallasEngine {
 }
 
 impl Engine for VestaEngine {
+  type RE = ChaCha20Rng;
   type Base = vesta::Base;
   type Scalar = vesta::Scalar;
   type GE = vesta::Point;

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -79,6 +79,8 @@ pub struct R1CSWitnessBlind<E: Engine>(E::Scalar);
 impl<E: Engine> R1CSWitnessBlind<E> {
   /// Samples a fresh witness commitment blinding factor.
   pub fn random() -> Self {
+    // Seed the configured engine from system entropy so all Nova randomness
+    // follows the same engine policy, including caller-seeded protocols.
     Self(E::Scalar::random(&mut E::RE::from_entropy()))
   }
 

--- a/src/r1cs/mod.rs
+++ b/src/r1cs/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 use core::cmp::max;
 use ff::Field;
 use once_cell::sync::OnceCell;
-use rand_core::OsRng;
+use rand_core::{OsRng, SeedableRng};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -79,7 +79,7 @@ pub struct R1CSWitnessBlind<E: Engine>(E::Scalar);
 impl<E: Engine> R1CSWitnessBlind<E> {
   /// Samples a fresh witness commitment blinding factor.
   pub fn random() -> Self {
-    Self(E::Scalar::random(&mut OsRng))
+    Self(E::Scalar::random(&mut E::RE::from_entropy()))
   }
 
   /// Wraps a protocol-derived blinding factor.

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -6,6 +6,7 @@ use crate::{
 use core::fmt::Debug;
 use ff::{PrimeField, PrimeFieldBits};
 use num_bigint::BigInt;
+use rand_core::{CryptoRng, RngCore, SeedableRng};
 use serde::{Deserialize, Serialize};
 
 /// Selects the internal width of the random oracle.
@@ -47,6 +48,12 @@ pub trait Group: Clone + Copy + Debug + Send + Sync + Sized + Eq + PartialEq {
 
 /// A collection of engines that are required by the library
 pub trait Engine: Clone + Copy + Debug + Send + Sync + Sized + Eq + PartialEq {
+  /// A cryptographically secure, deterministic randomness engine.
+  ///
+  /// Protocol callers seed this engine from fresh entropy for new proofs or
+  /// from recorded, domain-separated entropy for deterministic replay.
+  type RE: RngCore + CryptoRng + SeedableRng<Seed = [u8; 32]> + Send;
+
   /// A type representing an element of the base field of the group
   type Base: PrimeFieldBits
     + TranscriptReprTrait<Self::GE>


### PR DESCRIPTION
## Summary
- add `Engine::RE` as a cryptographically secure, 32-byte-seeded randomness engine
- configure all built-in engines with `ChaCha20Rng`
- use the configured engine for fresh R1CS witness commitment blinds
- release the breaking trait update as `nova-snark` 0.75.0

## Why
Randomness is a cryptographic engine choice alongside the transcript and commitment engines. An associated type lets generic protocols initialize a secure deterministic stream without hard-coding a concrete RNG, while ordinary witness construction continues to seed from fresh system entropy.

## Scope
This PR applies the configured engine to fresh R1CS witness commitment blinds. Existing protocol-specific random sampling paths remain unchanged and can migrate separately when they need caller-seeded control.

## API
```rust
pub trait Engine {
  type RE: RngCore + CryptoRng + SeedableRng<Seed = [u8; 32]> + Send;
  // ...
}
```

## Validation
- all-target compilation with `experimental`
- strict Clippy with `experimental`
- deterministic `Engine::RE` seed-reproducibility test