### PR TITLE
Release nova-snark 0.75.0 with serde_with 3.21.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,19 @@ jobs:
           command: build
           args: --examples --benches --verbose
 
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check minimum supported Rust version
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.88.0
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --lib
+
   build-wasm:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,14 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Check minimum supported Rust version
+      - name: Check MSRV for non-GPU features
         uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.88.0
+          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --lib
+          args: --lib --features "io,evm,experimental,test-utils"
 
   build-wasm:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/Microsoft/Nova"
 license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
-rust-version = "1.79.0"
+rust-version = "1.88.0"
 
 [dependencies]
 ff = { version = "0.13.0", features = ["derive"] }
@@ -24,7 +24,7 @@ num-bigint = { version = "0.4.6", features = ["serde", "rand"] }
 num-traits = "0.2.19"
 num-integer = "0.1.46"
 serde = { version = "1.0.217", features = ["derive"] }
-serde_with = "3.8.3"
+serde_with = "=3.21.0"
 bincode = { version = "2", features = ["serde", "std"] }
 bitvec = "1.0"
 blitzar = { version = "5.0.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nova-snark"
-version = "0.74.0"
+version = "0.75.0"
 authors = ["Srinath Setty <srinath@microsoft.com>"]
 edition = "2021"
 description = "High-speed recursive arguments from folding schemes"

--- a/src/frontend/gadgets/poseidon/circuit2.rs
+++ b/src/frontend/gadgets/poseidon/circuit2.rs
@@ -414,8 +414,7 @@ where
   }
 
   fn initial_elements<CS: ConstraintSystem<Scalar>>() -> Vec<Elt<Scalar>> {
-    std::iter::repeat(Elt::num_from_fr::<CS>(Scalar::ZERO))
-      .take(A::to_usize() + 1)
+    std::iter::repeat_n(Elt::num_from_fr::<CS>(Scalar::ZERO), A::to_usize() + 1)
       .collect()
   }
 

--- a/src/frontend/gadgets/poseidon/circuit2.rs
+++ b/src/frontend/gadgets/poseidon/circuit2.rs
@@ -414,8 +414,7 @@ where
   }
 
   fn initial_elements<CS: ConstraintSystem<Scalar>>() -> Vec<Elt<Scalar>> {
-    std::iter::repeat_n(Elt::num_from_fr::<CS>(Scalar::ZERO), A::to_usize() + 1)
-      .collect()
+    std::iter::repeat_n(Elt::num_from_fr::<CS>(Scalar::ZERO), A::to_usize() + 1).collect()
   }
 
   pub fn reset_offsets(&mut self) {

--- a/src/frontend/gadgets/sha256.rs
+++ b/src/frontend/gadgets/sha256.rs
@@ -33,21 +33,21 @@ where
   Scalar: PrimeField,
   CS: ConstraintSystem<Scalar>,
 {
-  assert!(input.len() % 8 == 0);
+  assert!(input.len().is_multiple_of(8));
 
   let mut padded = input.to_vec();
   let plen = padded.len() as u64;
   // append a single '1' bit
   padded.push(Boolean::constant(true));
   // append K '0' bits, where K is the minimum number >= 0 such that L + 1 + K + 64 is a multiple of 512
-  while (padded.len() + 64) % 512 != 0 {
+  while !(padded.len() + 64).is_multiple_of(512) {
     padded.push(Boolean::constant(false));
   }
   // append L as a 64-bit big-endian integer, making the total post-processed length a multiple of 512 bits
   for b in (0..64).rev().map(|i| (plen >> i) & 1 == 1) {
     padded.push(Boolean::constant(b));
   }
-  assert!(padded.len() % 512 == 0);
+  assert!(padded.len().is_multiple_of(512));
 
   let mut cur = get_sha256_iv();
   for (i, block) in padded.chunks(512).enumerate() {

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -46,7 +46,7 @@ where
       Ok(coords.map_or(E::Base::ZERO, |c| c.1))
     })?;
     let is_infinity = AllocatedNum::alloc(cs.namespace(|| "is_infinity"), || {
-      Ok(if coords.map_or(true, |c| c.2) {
+      Ok(if coords.is_none_or(|c| c.2) {
         E::Base::ONE
       } else {
         E::Base::ZERO
@@ -942,7 +942,7 @@ impl<E: Engine> AllocatedNonnativePoint<E> {
     )?;
 
     let is_infinity = AllocatedNum::alloc(cs.namespace(|| "is_infinity"), || {
-      Ok(if coords.map_or(true, |c| c.2) {
+      Ok(if coords.is_none_or(|c| c.2) {
         E::Scalar::ONE
       } else {
         E::Scalar::ZERO


### PR DESCRIPTION
## Summary
- release `nova-snark` 0.75.0
- pin `serde_with` to exactly 3.21.0
- raise the declared MSRV to Rust 1.88, required by `serde_with` 3.21.0
- make the MSRV job activate Rust 1.88 and check all supported non-GPU features
- fix formatting required by current rustfmt
