### PR TITLE
Speed up SHA-256 constraint and witness synthesis

### DIFF
--- a/src/frontend/gadgets/multieq.rs
+++ b/src/frontend/gadgets/multieq.rs
@@ -8,6 +8,7 @@ use crate::frontend::{ConstraintSystem, LinearCombination, SynthesisError, Varia
 #[derive(Debug)]
 pub struct MultiEq<Scalar: PrimeField, CS: ConstraintSystem<Scalar>> {
   cs: CS,
+  witness_only: bool,
   ops: usize,
   bits_used: usize,
   lhs: LinearCombination<Scalar>,
@@ -17,8 +18,11 @@ pub struct MultiEq<Scalar: PrimeField, CS: ConstraintSystem<Scalar>> {
 impl<Scalar: PrimeField, CS: ConstraintSystem<Scalar>> MultiEq<Scalar, CS> {
   /// Creates a new `MultiEq` gadget with the given constraint system.
   pub fn new(cs: CS) -> Self {
+    let witness_only = cs.is_witness_generator();
+
     MultiEq {
       cs,
+      witness_only,
       ops: 0,
       bits_used: 0,
       lhs: LinearCombination::zero(),
@@ -26,10 +30,14 @@ impl<Scalar: PrimeField, CS: ConstraintSystem<Scalar>> MultiEq<Scalar, CS> {
     }
   }
 
+  pub(super) fn witness_only(&self) -> bool {
+    self.witness_only
+  }
+
   fn accumulate(&mut self) {
     let ops = self.ops;
-    let lhs = self.lhs.clone();
-    let rhs = self.rhs.clone();
+    let lhs = std::mem::take(&mut self.lhs);
+    let rhs = std::mem::take(&mut self.rhs);
     self.cs.enforce(
       || format!("multieq {ops}"),
       |_| lhs,
@@ -50,6 +58,11 @@ impl<Scalar: PrimeField, CS: ConstraintSystem<Scalar>> MultiEq<Scalar, CS> {
     lhs: &LinearCombination<Scalar>,
     rhs: &LinearCombination<Scalar>,
   ) {
+    // The wrapped witness generator discards constraints, so there is nothing to pack.
+    if self.witness_only {
+      return;
+    }
+
     // Check if we will exceed the capacity
     if (Scalar::CAPACITY as usize) <= (self.bits_used + num_bits) {
       self.accumulate();
@@ -58,8 +71,11 @@ impl<Scalar: PrimeField, CS: ConstraintSystem<Scalar>> MultiEq<Scalar, CS> {
     assert!((Scalar::CAPACITY as usize) > (self.bits_used + num_bits));
 
     let coeff = Scalar::from(2u64).pow_vartime([self.bits_used as u64]);
-    self.lhs = self.lhs.clone() + (coeff, lhs);
-    self.rhs = self.rhs.clone() + (coeff, rhs);
+    // Move the accumulators to avoid cloning them before adding each equality.
+    let lhs_acc = std::mem::take(&mut self.lhs);
+    let rhs_acc = std::mem::take(&mut self.rhs);
+    self.lhs = lhs_acc + (coeff, lhs);
+    self.rhs = rhs_acc + (coeff, rhs);
     self.bits_used += num_bits;
   }
 }

--- a/src/frontend/gadgets/uint32.rs
+++ b/src/frontend/gadgets/uint32.rs
@@ -3,12 +3,27 @@
 
 use ff::PrimeField;
 
-use crate::frontend::{ConstraintSystem, LinearCombination, SynthesisError};
+use crate::frontend::{ConstraintSystem, LinearCombination, SynthesisError, Variable};
 
 use super::{
   boolean::{AllocatedBit, Boolean},
   multieq::MultiEq,
 };
+
+/// Add `coeff * b` to `lc` without constructing an intermediate [`LinearCombination`].
+fn push_bool<Scalar: PrimeField>(
+  lc: LinearCombination<Scalar>,
+  one: Variable,
+  coeff: Scalar,
+  b: &Boolean,
+) -> LinearCombination<Scalar> {
+  match b {
+    Boolean::Constant(false) => lc,
+    Boolean::Constant(true) => lc + (coeff, one),
+    Boolean::Is(v) => lc + (coeff, v.get_variable()),
+    Boolean::Not(v) => lc + (coeff, one) - (coeff, v.get_variable()),
+  }
+}
 
 /// Represents an interpretation of 32 `Boolean` objects as an
 /// unsigned integer.
@@ -220,6 +235,10 @@ impl UInt32 {
     assert!(operands.len() >= 2); // Weird trivial cases that should never happen
     assert!(operands.len() <= 10);
 
+    // The wrapped witness generator discards constraints, so avoid constructing
+    // linear combinations that will not be used.
+    let witness_only = cs.get_root().witness_only();
+
     // Compute the maximum value of the sum so we allocate enough bits for
     // the result
     let mut max_value = (operands.len() as u64) * (u64::from(u32::MAX));
@@ -253,7 +272,9 @@ impl UInt32 {
       // the linear combination
       let mut coeff = Scalar::ONE;
       for bit in &op.bits {
-        lc = lc + &bit.lc(CS::one(), coeff);
+        if !witness_only {
+          lc = push_bool(lc, CS::one(), coeff, bit);
+        }
 
         all_constants &= bit.is_constant();
 
@@ -289,7 +310,9 @@ impl UInt32 {
       )?;
 
       // Add this bit to the result combination
-      result_lc = result_lc + (coeff, b.get_variable());
+      if !witness_only {
+        result_lc = result_lc + (coeff, b.get_variable());
+      }
 
       result_bits.push(b.into());
 


### PR DESCRIPTION
## What

This PR removes three sources of overhead in the frontend gadgets used by SHA-256. In the benchmark below, the fitted per-block proving cost shows a 4.2× reduction (without changing the generated constraints or witness).

### 1. Avoid cloning `MultiEq` accumulators

`MultiEq::enforce_equal` cloned its growing accumulators whenever an equality was packed:

```rust
self.lhs = self.lhs.clone() + (coeff, lhs);
self.rhs = self.rhs.clone() + (coeff, rhs);
```

Using `mem::take` preserves the result while eliminating repeated copying. The same unnecessary clones were removed from `MultiEq::accumulate`.

### 2. Skip unused work during witness generation

`WitnessCS::enforce` discards constraints, so constructing linear combinations during witness generation is unnecessary.

`MultiEq::enforce_equal` now returns early in witness-only mode, and `UInt32::addmany` skips constructing `lc` and `result_lc`. Variable allocation, ordering, and assignment computation are unchanged.

### 3. Avoid an intermediate `LinearCombination` per bit

`UInt32::addmany` previously constructed a temporary one-term `LinearCombination` through `Boolean::lc` for every bit. The new `push_bool` helper adds the equivalent term directly to the destination.

## Correctness

For constraint-generating systems, the same linear combinations are produced in the same order. For witness generators, the same variables are allocated in the same order with the same assignments; only linear combinations that would be discarded are omitted.

Validation:

```text
cargo fmt --all -- --check
cargo clippy --lib --tests -- -D warnings
cargo test
cargo test --release --features experimental neutron   
```

## Benchmarks

```text
cargo bench --features test-utils --bench sha256
```

Configuration:

- Apple M4 Pro, 12 cores (8 performance, 4 efficiency)
- 48 GB memory
- macOS 26.5.2 (arm64)
- Rust 1.97.0, Cargo 1.97.0
- BN254/Grumpkin with KZG
- Criterion sample size: 10
- Target: `Prove`

| Bytes | Blocks | Before | After | Speedup |
|------:|-------:|-------:|------:|--------:|
| 64    | 2      | 28.93 ms | 22.74 ms | 1.27× |
| 128   | 3      | 33.54 ms | 23.55 ms | 1.42× |
| 256   | 5      | 41.88 ms | 25.98 ms | 1.61× |
| 512   | 9      | 58.66 ms | 29.04 ms | 2.02× |
| 1024  | 17     | 94.12 ms | 38.27 ms | 2.46× |

Criterion reported a statistically significant improvement at every size (`p < 0.05`). The speedup grows with the number of SHA-256 blocks.

A linear fit gives:

```text
before: 20.24 ms fixed + 4.331 ms/block
after:  20.51 ms fixed + 1.028 ms/block
```

This is consistent with unchanged fixed overhead and an approximately **4.2× reduction in per-block cost**.